### PR TITLE
Remove the concept of ModelTypeModifier

### DIFF
--- a/payas-model/src/model/types.rs
+++ b/payas-model/src/model/types.rs
@@ -73,8 +73,43 @@ pub enum ModelTypeModifier {
 #[derive(Debug, Clone)]
 pub struct ModelField {
     pub name: String,
-    pub type_id: Id<ModelType>,
-    pub type_name: String,
-    pub type_modifier: ModelTypeModifier,
+    pub typ: ModelFieldType,
     pub relation: ModelRelation,
+}
+
+#[derive(Debug, Clone)]
+pub enum ModelFieldType {
+    Optional(Box<ModelFieldType>),
+    Plain {
+        type_id: Id<ModelType>,
+        type_name: String,
+    },
+    List(Box<ModelFieldType>),
+}
+
+impl ModelFieldType {
+    pub fn type_id(&self) -> &Id<ModelType> {
+        match self {
+            ModelFieldType::Optional(underlying) | ModelFieldType::List(underlying) => {
+                underlying.type_id()
+            }
+            ModelFieldType::Plain { type_id, .. } => type_id,
+        }
+    }
+
+    pub fn type_name(&self) -> &str {
+        match self {
+            ModelFieldType::Optional(underlying) | ModelFieldType::List(underlying) => {
+                underlying.type_name()
+            }
+            ModelFieldType::Plain { type_name, .. } => type_name,
+        }
+    }
+
+    pub fn optional(&self) -> Self {
+        match self {
+            ModelFieldType::Optional(_) => self.clone(),
+            _ => ModelFieldType::Optional(Box::new(self.clone())),
+        }
+    }
 }

--- a/payas-parser/src/builder/order_by_type_builder.rs
+++ b/payas-parser/src/builder/order_by_type_builder.rs
@@ -101,7 +101,7 @@ pub fn new_field_param(
     model_field: &ModelField,
     building: &SystemContextBuilding,
 ) -> OrderByParameter {
-    let field_model_type = &building.types[model_field.type_id];
+    let field_model_type = &building.types[model_field.typ.type_id().to_owned()];
 
     let column_id = match &model_field.relation {
         ModelRelation::Pk { column_id, .. } | ModelRelation::Scalar { column_id, .. } => {
@@ -140,5 +140,8 @@ fn order_by_param_type(
 }
 
 fn is_primitive(kind: &AstTypeKind) -> bool {
-    matches!(kind, AstTypeKind::Primitive)
+    match kind {
+        AstTypeKind::Composite { .. } => false,
+        _ => true,
+    }
 }

--- a/payas-parser/src/builder/predicate_builder.rs
+++ b/payas-parser/src/builder/predicate_builder.rs
@@ -98,7 +98,7 @@ fn create_composite_filter_type_kind(
     let parameters = fields
         .iter()
         .map(|field| {
-            let param_type_name = get_parameter_type_name(&field.type_name);
+            let param_type_name = get_parameter_type_name(&field.typ.type_name());
             PredicateParameter {
                 name: field.name.to_string(),
                 type_name: param_type_name.clone(),

--- a/payas-parser/src/builder/query_builder.rs
+++ b/payas-parser/src/builder/query_builder.rs
@@ -81,10 +81,10 @@ pub fn pk_predicate_param(
 
     PredicateParameter {
         name: pk_field.name.to_string(),
-        type_name: pk_field.type_name.to_string(),
+        type_name: pk_field.typ.type_name().to_string(),
         type_id: building
             .predicate_types
-            .get_id(&pk_field.type_name)
+            .get_id(&pk_field.typ.type_name())
             .unwrap(),
         type_modifier: ModelTypeModifier::NonNull,
         column_id: pk_field.relation.self_column(),

--- a/payas-server/src/introspection/definition/parameter.rs
+++ b/payas-server/src/introspection/definition/parameter.rs
@@ -5,23 +5,23 @@ use crate::introspection::util;
 
 use payas_model::model::{
     operation::MutationDataParameter, order::*, predicate::PredicateParameter, types::ModelField,
-    types::ModelTypeModifier,
+    types::ModelTypeModifier, ModelFieldType,
 };
 
 use super::provider::InputValueProvider;
 
 pub trait Parameter {
-    fn name(&self) -> &String;
-    fn type_name(&self) -> &String;
+    fn name(&self) -> &str;
+    fn type_name(&self) -> &str;
     fn type_modifier(&self) -> &ModelTypeModifier;
 }
 
 impl Parameter for OrderByParameter {
-    fn name(&self) -> &String {
+    fn name(&self) -> &str {
         &self.name
     }
 
-    fn type_name(&self) -> &String {
+    fn type_name(&self) -> &str {
         &self.type_name
     }
 
@@ -31,11 +31,11 @@ impl Parameter for OrderByParameter {
 }
 
 impl Parameter for PredicateParameter {
-    fn name(&self) -> &String {
+    fn name(&self) -> &str {
         &self.name
     }
 
-    fn type_name(&self) -> &String {
+    fn type_name(&self) -> &str {
         &self.type_name
     }
 
@@ -45,11 +45,11 @@ impl Parameter for PredicateParameter {
 }
 
 impl Parameter for MutationDataParameter {
-    fn name(&self) -> &String {
+    fn name(&self) -> &str {
         &self.name
     }
 
-    fn type_name(&self) -> &String {
+    fn type_name(&self) -> &str {
         &self.type_name
     }
 
@@ -59,16 +59,20 @@ impl Parameter for MutationDataParameter {
 }
 
 impl Parameter for ModelField {
-    fn name(&self) -> &String {
+    fn name(&self) -> &str {
         &self.name
     }
 
-    fn type_name(&self) -> &String {
-        &self.type_name
+    fn type_name(&self) -> &str {
+        self.typ.type_name()
     }
 
     fn type_modifier(&self) -> &ModelTypeModifier {
-        &self.type_modifier
+        match self.typ {
+            ModelFieldType::Optional(_) => &ModelTypeModifier::Optional,
+            ModelFieldType::Plain { .. } => &ModelTypeModifier::NonNull,
+            ModelFieldType::List(_) => &ModelTypeModifier::List,
+        }
     }
 }
 

--- a/payas-server/src/introspection/definition/type_definition.rs
+++ b/payas-server/src/introspection/definition/type_definition.rs
@@ -55,8 +55,13 @@ impl TypeDefinitionProvider for ModelType {
 
 impl FieldDefinitionProvider for ModelField {
     fn field_definition(&self, system: &ModelSystem) -> FieldDefinition {
+        let type_modifier = match &self.typ {
+            ModelFieldType::Optional(_) => ModelTypeModifier::Optional,
+            ModelFieldType::Plain { .. } => ModelTypeModifier::NonNull,
+            ModelFieldType::List(_) => ModelTypeModifier::List,
+        };
         let field_type =
-            util::default_positioned(util::value_type(&self.type_name, &self.type_modifier));
+            util::default_positioned(util::value_type(&self.typ.type_name(), &type_modifier));
 
         let arguments = match self.relation {
             ModelRelation::Pk { .. }


### PR DESCRIPTION
This removes ModelTypeModifier for AST and Model types, but still not
for PredicateParamater and OrderByParameter

Fixes #31