### PR TITLE
Defer reference constraint to after creating tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1362,6 +1362,7 @@ dependencies = [
 name = "payas-cli"
 version = "0.1.0"
 dependencies = [
+ "id-arena",
  "payas-model",
  "payas-parser",
  "payas-sql",

--- a/payas-cli/Cargo.toml
+++ b/payas-cli/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Ramnivas Laddad <ramnivas@payalabs.com>"]
 edition = "2018"
 
 [dependencies]
+id-arena = "2.2.1"
 payas-sql = { path = "../payas-sql" }
 payas-parser = { path = "../payas-parser" }
 payas-model = { path = "../payas-model" }

--- a/payas-cli/src/main.rs
+++ b/payas-cli/src/main.rs
@@ -1,48 +1,15 @@
 use std::env;
 
-use payas_model::sql::{column::PhysicalColumn, PhysicalTable};
 use payas_parser::{builder::system_builder, parser};
+
+mod schema;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
     let ast_system = parser::parse_file(&args[1]);
     let system = system_builder::build(ast_system);
 
-    let tables = system.tables;
+    let schema_stmt = schema::schema_stmt(system.tables);
 
-    let table_stmts = tables
-        .iter()
-        .map(|table| create_table(table.1))
-        .collect::<Vec<_>>()
-        .join("\n\n");
-
-    println!("{}", table_stmts);
-}
-
-fn create_table(table: &PhysicalTable) -> String {
-    let column_stmts = table
-        .columns
-        .iter()
-        .map(create_column)
-        .collect::<Vec<_>>()
-        .join(",\n\t");
-
-    format!("CREATE TABLE {} (\n\t{}\n);", table.name, column_stmts)
-}
-
-fn create_column(column: &PhysicalColumn) -> String {
-    let pk_str = if column.is_pk { " PRIMARY KEY" } else { "" };
-
-    let references_str = match column.references {
-        Some(ref references) => format!(" REFERENCES {}", references.table_name),
-        None => "".to_string(),
-    };
-
-    format!(
-        "{} {}{}{}",
-        column.column_name,
-        column.typ.db_type(column.is_autoincrement),
-        pk_str,
-        references_str
-    )
+    println!("{}", schema_stmt);
 }

--- a/payas-cli/src/schema.rs
+++ b/payas-cli/src/schema.rs
@@ -1,0 +1,121 @@
+use id_arena::Arena;
+use payas_model::sql::{column::PhysicalColumn, PhysicalTable};
+
+struct SchemaSpec {
+    table_specs: Vec<TableSpec>,
+}
+struct TableSpec {
+    name: String,
+    column_specs: Vec<ColumnSpec>,
+}
+
+struct ColumnSpec {
+    name: String,
+    db_type: String,
+    is_pk: bool,
+    foreign_constraint: Option<ForeignConstraint>,
+}
+struct ForeignConstraint {
+    self_column: String,
+    foreign_table: String,
+}
+
+pub fn schema_stmt(tables: Arena<PhysicalTable>) -> String {
+    SchemaSpec::from_tables(tables).stmt()
+}
+
+impl SchemaSpec {
+    fn stmt(&self) -> String {
+        let table_stmts = self
+            .table_specs
+            .iter()
+            .map(|t| (t.stmt()))
+            .collect::<Vec<String>>()
+            .join("\n\n");
+
+        let foreign_constraint_stmts = self
+            .table_specs
+            .iter()
+            .map(|t| (t.foreign_constraint_stmt()))
+            .collect::<Vec<String>>()
+            .join("\n\n");
+
+        format!("{}\n\n{}", table_stmts, foreign_constraint_stmts)
+    }
+
+    fn from_tables(tables: Arena<PhysicalTable>) -> SchemaSpec {
+        let table_specs: Vec<_> = tables
+            .iter()
+            .map(|table| TableSpec::from_table(table.1))
+            .collect();
+
+        SchemaSpec { table_specs }
+    }
+}
+
+impl TableSpec {
+    fn stmt(&self) -> String {
+        let columns: Vec<_> = self.column_specs.iter().map(|c| c.stmt()).collect();
+
+        let column_stmts = columns.join(",\n\t");
+        format!("CREATE TABLE {} (\n\t{}\n);", self.name, column_stmts)
+    }
+
+    fn foreign_constraint_stmt(&self) -> String {
+        let stmts: Vec<_> = self
+            .column_specs
+            .iter()
+            .flat_map(|c| c.foreign_constraint_stmt())
+            .map(|stmt| format!("ALTER TABLE {} ADD CONSTRAINT {};", self.name, stmt))
+            .collect();
+
+        stmts.join(";\n\t")
+    }
+
+    fn from_table(table: &PhysicalTable) -> TableSpec {
+        let column_specs: Vec<_> = table.columns.iter().map(ColumnSpec::from_column).collect();
+
+        TableSpec {
+            name: table.name.clone(),
+            column_specs,
+        }
+    }
+}
+
+impl ColumnSpec {
+    fn stmt(&self) -> String {
+        let pk_str = if self.is_pk { " PRIMARY KEY" } else { "" };
+
+        format!("{} {}{}", self.name, self.db_type, pk_str)
+    }
+
+    fn foreign_constraint_stmt(&self) -> Option<String> {
+        self.foreign_constraint.as_ref().map(|c| c.stmt())
+    }
+
+    fn from_column(column: &PhysicalColumn) -> ColumnSpec {
+        let foreign_constraint = column
+            .references
+            .as_ref()
+            .map(|references| ForeignConstraint {
+                self_column: column.column_name.clone(),
+                foreign_table: references.table_name.clone(),
+            });
+
+        ColumnSpec {
+            name: column.column_name.clone(),
+            db_type: column.typ.db_type(column.is_autoincrement).to_string(),
+            is_pk: column.is_pk,
+            foreign_constraint,
+        }
+    }
+}
+
+impl ForeignConstraint {
+    fn stmt(&self) -> String {
+        format!(
+            "{}_fk FOREIGN KEY ({}) REFERENCES {}",
+            self.foreign_table, self.self_column, self.foreign_table
+        )
+    }
+}


### PR DESCRIPTION
Depending on how we order table creation, we may end up referencing table that is yet to be created. So instead of adding foreign key constraints through REFERENCES, we now add ALTER TABLE ADD CONSTAINTS to the same effect.

Fixes #39