### PR TITLE
Hash the path to the test file and use it as the database name for tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,6 +1432,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,6 +1797,7 @@ dependencies = [
  "async-graphql-parser",
  "isahc",
  "jsonwebtoken",
+ "md5",
  "postgres",
  "postgres-openssl",
  "rand 0.8.3",

--- a/payas-test/Cargo.toml
+++ b/payas-test/Cargo.toml
@@ -18,3 +18,4 @@ postgres = { version = "0.19.0", features = ["with-chrono-0_4"] }
 postgres-openssl = "0.5.0"
 rand = "0.8"
 async-graphql-parser = "2.6.5"
+md5 = "0.7"

--- a/payas-test/src/claytest/loader.rs
+++ b/payas-test/src/claytest/loader.rs
@@ -127,7 +127,7 @@ fn load_testfiles_from_dir_(
         }
     };
 
-    let prefix = model_path.file_name().unwrap().to_str().unwrap();
+    let prefix = model_path.to_str().unwrap();
 
     // Parse init files and populate init_ops
     let mut init_ops = init_ops.to_owned();
@@ -144,7 +144,7 @@ fn load_testfiles_from_dir_(
         let mut testfile = parse_testfile(testfile_path)?;
 
         // annotate testfile with our prefix and our init operations collection
-        testfile.name = format!("{}/{}", prefix, testfile.name);
+        testfile.name = format!("{} : {}", prefix, testfile.name);
         testfile.unique_dbname = to_postgres(&format!("{}/{}", prefix, testfile.unique_dbname));
         testfile.model_path = Some(model_path.to_str().unwrap().to_string());
         testfile.init_operations = init_ops.clone();
@@ -228,24 +228,7 @@ fn from_json(json: String) -> Result<serde_json::Value> {
     serde_json::from_str(&json).context("Failed to parse JSON")
 }
 
-// Generate a PostgreSQL-friendly name from a `str`.
+// Generate a unique, PostgreSQL-friendly name from a `str`.
 fn to_postgres(name: &str) -> String {
-    let mut index: usize = 0;
-
-    name.chars()
-        .map(|c| {
-            let nextchar = if !(c.is_ascii_alphanumeric() || c == '_') {
-                // only alphanumeric and underscores
-                'X'
-            } else if index == 0 && c.is_ascii_digit() {
-                // names in SQL cannot begin with a digit
-                'Z'
-            } else {
-                c
-            };
-
-            index += 1;
-            nextchar
-        })
-        .collect()
+    format!("{:x}", md5::compute(name))
 }


### PR DESCRIPTION
Fixes #135. We switch to a hash of the entire test file path when generating unique database names. This fixes collisions by using the entire path to the test file and also avoid problems with paths that are longer than the max allowed PostgreSQL database name length.