### PR TITLE
Prefix test database names with `claytest`

### DIFF
--- a/payas-test/src/claytest/loader.rs
+++ b/payas-test/src/claytest/loader.rs
@@ -178,7 +178,7 @@ fn parse_testfile(path: &Path) -> Result<ParsedTestfile> {
 
     let mut result = ParsedTestfile {
         name: testfile_name.clone(),
-        unique_dbname: to_postgres(&format!("{}", testfile_name)),
+        unique_dbname: to_postgres(&testfile_name),
 
         ..ParsedTestfile::default()
     };


### PR DESCRIPTION
When generating databases for tests, we should prefix their names with something Clay-related (`claytest`).