### PR TITLE
Align clay-server command better with 'clay server'.

### DIFF
--- a/payas-server/src/lib.rs
+++ b/payas-server/src/lib.rs
@@ -168,14 +168,12 @@ enum ServerLoopEvent {
 }
 
 pub fn start_prod_mode(
-    model_file: impl AsRef<Path> + Clone,
+    claypot_file: impl AsRef<Path> + Clone,
     system_start_time: Option<SystemTime>,
 ) -> Result<()> {
     let mut actix_system = System::new("claytip");
 
-    let claypot_file_name = format!("{}pot", &model_file.as_ref().to_str().unwrap());
-
-    match File::open(&claypot_file_name) {
+    match File::open(&claypot_file) {
         Ok(file) => {
             let claypot_file_buffer = BufReader::new(file);
             let in_file = BufReader::new(claypot_file_buffer);
@@ -187,7 +185,7 @@ pub fn start_prod_mode(
             Ok(())
         }
         Err(_) => {
-            let message = format!("File {} doesn't exist. You need build it with the 'clay build <model-file-name>' command", claypot_file_name);
+            let message = format!("File {} doesn't exist. You need build it with the 'clay build <model-file-name>' command", claypot_file.as_ref().to_str().unwrap());
             println!("{}", message);
             Err(anyhow::anyhow!(message))
         }

--- a/payas-server/src/main.rs
+++ b/payas-server/src/main.rs
@@ -1,11 +1,33 @@
-use std::{env, time::SystemTime};
+use std::{env, process::exit, time::SystemTime};
 
 use payas_server::start_prod_mode;
 
 fn main() {
     let system_start_time = SystemTime::now();
 
-    let model_file = env::args().nth(1).expect("Usage: clay-server <model-file>");
+    let mut args = env::args().skip(1);
 
-    start_prod_mode(&model_file, Some(system_start_time)).unwrap();
+    if args.len() == 0 {
+        // $ clay-server
+        start_prod_mode("index.claypot", Some(system_start_time)).unwrap();
+    } else if args.len() == 1 {
+        let file_name = args.next().unwrap();
+
+        let claypot_file = if file_name.ends_with(".claypot") {
+            // $ clay-server concerts.claypot
+            file_name
+        } else if file_name.ends_with(".clay") {
+            // $ clay-server concerts.clay
+            format!("{}pot", file_name)
+        } else {
+            println!("The input file {} doesn't appear to be a claypot. You need build one with the 'clay build <model-file-name>' command.", file_name);
+            exit(1);
+        };
+
+        start_prod_mode(&claypot_file, Some(system_start_time)).unwrap()
+    } else {
+        // $ clay-server <model-file-name> extra-arguments...
+        println!("Usage: clay-server <claypot-file>");
+        exit(1);
+    }
 }


### PR DESCRIPTION
- Assume no-args to mean supplying index.claypot
- Accept both .clay and .claypot extensions (and adjust to make it a .claypot file).