### PR TITLE
Fix bulk insert when the data is supplied through a variable

### DIFF
--- a/integration-tests/basic-model-no-auth/create-venue-with-variable.claytest
+++ b/integration-tests/basic-model-no-auth/create-venue-with-variable.claytest
@@ -1,0 +1,26 @@
+# Supply a single element even when an array is expected. GraphQL allows auto-coercing a single element to an array
+operation: |
+    mutation($data: [VenueCreationInput]){
+      createVenues(data: $data) {
+        id
+      }
+    }
+variable: |
+    {
+      "data": { 
+        "name": "V1", 
+        "published": true, 
+        "latitude": 1.0
+      }
+    }
+response: |
+    {
+      "data": {
+        "createVenues": [
+          {
+            "id": 3
+          }
+        ]
+      }
+    }
+    

--- a/integration-tests/basic-model-no-auth/create-venue.claytest
+++ b/integration-tests/basic-model-no-auth/create-venue.claytest
@@ -1,0 +1,17 @@
+operation: |
+    mutation {
+      createVenues(data: {name: "V1", published:true, latitude: 1.0}) {
+        id
+      }
+    }
+response: |
+    {
+      "data": {
+        "createVenues": [
+          {
+            "id": 3
+          }
+        ]
+      }
+    }
+    

--- a/integration-tests/basic-model-no-auth/create-venues-with-variable.claytest
+++ b/integration-tests/basic-model-no-auth/create-venues-with-variable.claytest
@@ -1,0 +1,35 @@
+operation: |
+    mutation($data: [VenueCreationInput]){
+      createVenues(data: $data) {
+        id
+      }
+    }
+variable: |
+    {
+      "data": [
+        { 
+          "name": "V1", 
+          "published": true, 
+          "latitude": 1.0
+        }, 
+        { 
+          "published": false, 
+          "name": "V2", 
+          "latitude": 2.0
+        }
+      ]
+    }
+response: |
+    {
+      "data": {
+        "createVenues": [
+          {
+            "id": 3
+          },
+          {
+            "id": 4
+          }
+        ]
+      }
+    }
+    

--- a/payas-server/src/data/create_data_param_mapper.rs
+++ b/payas-server/src/data/create_data_param_mapper.rs
@@ -76,6 +76,12 @@ impl<'a> SQLMapper<'a, InsertionInfo<'a>> for GqlType {
             .map(|table_id| &operation_context.get_system().tables[table_id])
             .unwrap();
 
+        // Before we can make the decision of mapping a single or multiple elements, we must resolve variable
+        let argument = match argument {
+            Value::Variable(name) => operation_context.resolve_variable(name.as_str()).unwrap(),
+            _ => argument,
+        };
+
         match argument {
             Value::List(elems) => {
                 let unaligned = elems


### PR DESCRIPTION
We weren't resolving variables before deciding if we need a bulk insert
or a single insert. Thus we used a single-insert case when data was
suuplied through a variable (due to a match fallback).