### PR TITLE
Support case-insensitive `ilike` predicate for strings

### DIFF
--- a/integration-tests/simple-model/predicates-string.claytest
+++ b/integration-tests/simple-model/predicates-string.claytest
@@ -11,12 +11,17 @@ operation: |
         like: logs(where: { text: { like: $like } }) {
             text
         }
+
+        ilike: logs(where: { text: { ilike: $ilike } }) {
+            text
+        }
     }
 variable: |
     {
         "prefix": "[NORMAL]",
         "suffix": "50%",
-        "like": "[ERROR] service stopped"
+        "like": "[ERROR] service stopped",
+        "ilike": "[error] service stopped"
     }
 response: |
     {
@@ -38,6 +43,11 @@ response: |
     			{
     				"text": "[ERROR] service stopped"
     			}
-    		]
+    		],
+    		"ilike": [
+    			{
+    				"text": "[ERROR] service stopped"
+    			}
+    		]            
     	}
     }

--- a/payas-parser/src/builder/predicate_builder.rs
+++ b/payas-parser/src/builder/predicate_builder.rs
@@ -114,7 +114,7 @@ lazy_static! {
             Some(vec![
                 "eq", "neq",
                 "lt", "lte", "gt", "gte",
-                "like", "startsWith", "endsWith"
+                "like", "ilike", "startsWith", "endsWith"
             ])
         );
 


### PR DESCRIPTION
Fixes #217