### PR TITLE
Use <> instead of [] to specify type parameter in clay files

### DIFF
--- a/integration-tests/arrays/chess.clay
+++ b/integration-tests/arrays/chess.clay
@@ -2,6 +2,6 @@
 model ChessPiece {
   id: Int @pk @autoincrement
   name: String
-  position_history: Array[String]
-  neighbor_info: Array[Array[String]]
+  position_history: Array<String>
+  neighbor_info: Array<Array<String>>
 }

--- a/integration-tests/basic-model-no-auth/concerts.clay
+++ b/integration-tests/basic-model-no-auth/concerts.clay
@@ -11,7 +11,7 @@ model Concert {
 model Venue {
   id: Int @pk @autoincrement
   name: String
-  concerts: Set[Concert] @column("venueid")
+  concerts: Set<Concert> @column("venueid")
   published: Boolean
   latitude: Float @size(4)
 }

--- a/integration-tests/basic-model-with-auth/concerts-auth.clay
+++ b/integration-tests/basic-model-with-auth/concerts-auth.clay
@@ -16,6 +16,6 @@ model Concert {
 model Venue {
   id: Int @pk @autoincrement
   name: String
-  concerts: Set[Concert] @column("venueid")
+  concerts: Set<Concert> @column("venueid")
   published: Boolean
 }

--- a/integration-tests/interceptor/concert.clay
+++ b/integration-tests/interceptor/concert.clay
@@ -9,7 +9,7 @@ model Concert {
 model Venue {
   id: Int @pk @autoincrement
   name: String
-  concerts: Set[Concert] @column("venueid")
+  concerts: Set<Concert> @column("venueid")
   published: Boolean
   latitude: Float @size(4)
 }

--- a/integration-tests/many-to-many/indirect/custom-names/concert-artists.clay
+++ b/integration-tests/many-to-many/indirect/custom-names/concert-artists.clay
@@ -2,7 +2,7 @@
 model Concert {
   id: Int @pk @autoincrement
   title: String
-  concertArtists: Set[ConcertArtist]
+  concertArtists: Set<ConcertArtist>
   venue: Venue @column("venue_id")
 }
 
@@ -19,10 +19,10 @@ model ConcertArtist {
 model Artist {
   id: Int @pk @autoincrement
   name: String
-  aristsConcerts: Set[ConcertArtist]
+  aristsConcerts: Set<ConcertArtist>
 }
 
 model Venue {
   id: Int @pk @autoincrement
-  concerts: Set[Concert] @column("venue_id")
+  concerts: Set<Concert> @column("venue_id")
 }

--- a/integration-tests/many-to-many/indirect/default-names/concert-artists.clay
+++ b/integration-tests/many-to-many/indirect/default-names/concert-artists.clay
@@ -1,7 +1,7 @@
 model Concert {
   id: Int @pk @autoincrement
   title: String
-  concertArtists: Set[ConcertArtist]
+  concertArtists: Set<ConcertArtist>
 }
 
 model ConcertArtist {

--- a/integration-tests/model-with-errors/syntax-errors/concerts-syntax-errors.clay
+++ b/integration-tests/model-with-errors/syntax-errors/concerts-syntax-errors.clay
@@ -9,5 +9,5 @@ model Concert {
 model Venue {
   id: Int @pk @autoincrement @access(Foo)
   name: String
-  concerts: Concert] @column("venueid")
+  concerts: Concert> @column("venueid")
 }

--- a/integration-tests/model-with-errors/type-errors/concerts-type-errors.clay
+++ b/integration-tests/model-with-errors/type-errors/concerts-type-errors.clay
@@ -9,5 +9,5 @@ model Concert {
 model Venue {
   id: Int @pk @autoincrement @access(Foo)
   name: String @range(min=-10, max=10)
-  concerts: [Concert] @column("venueid")
+  concerts: <Concert> @column("venueid")
 }

--- a/payas-parser/grammar/grammar.js
+++ b/payas-parser/grammar/grammar.js
@@ -87,9 +87,9 @@ module.exports = grammar({
     ),
     type: $ => choice(
       $.optional_type,
-      seq($.term, optional(seq("[", commaSep(field("type_param", $.type)), "]")))
+      seq($.term, optional(seq("<", commaSep(field("type_param", $.type)), ">")))
     ),
-    array_type: $ => seq("[", field("inner", $.type), "]"),
+    array_type: $ => seq("<", field("inner", $.type), ">"),
     optional_type: $ => seq(field("inner", $.type), "?"),
     expression: $ => choice(
       $.parenthetical,

--- a/payas-parser/src/builder/resolved_builder.rs
+++ b/payas-parser/src/builder/resolved_builder.rs
@@ -1044,7 +1044,7 @@ mod tests {
         model Venue {
           id: Int @pk @autoincrement @column("custom_id")
           name: String @column("custom_name")
-          concerts: Set[Concert] @column("custom_venueid")
+          concerts: Set<Concert> @column("custom_venueid")
           capacity: Int @bits(16)
           latitude: Float @size(4)
         }       
@@ -1071,14 +1071,14 @@ mod tests {
           id: Int @pk @autoincrement 
           title: String 
           venue: Venue 
-          attending: Array[String]
-          seating: Array[Array[Boolean]]
+          attending: Array<String>
+          seating: Array<Array<Boolean>>
         }
 
         model Venue             {
           id: Int  @autoincrement @pk 
           name:String 
-          concerts: Set[Concert] 
+          concerts: Set<Concert> 
         }        
         "#;
 

--- a/payas-parser/src/parser/converter.rs
+++ b/payas-parser/src/parser/converter.rs
@@ -728,7 +728,7 @@ mod tests {
         model Venue {
           id: Int @pk @autoincrement
           name: String
-          concerts: Set[Concert /* here too! */] @column("venueid")
+          concerts: Set<Concert /* here too! */> @column("venueid")
         }
         "#,
         );
@@ -740,7 +740,7 @@ mod tests {
             r#"
         context AuthUser {
             id: Int @jwt("sub") 
-            roles: Array[String] @jwt
+            roles: Array<String> @jwt
          }
         "#,
         );


### PR DESCRIPTION
This makes the clay grammar closer to typescript.