### PR TITLE
Improve the error message for missing input file

### DIFF
--- a/payas-cli/src/commands/build.rs
+++ b/payas-cli/src/commands/build.rs
@@ -40,7 +40,7 @@ impl Command for BuildCommand {
 }
 
 fn build(model: &Path, system_start_time: Option<SystemTime>, _restart: bool) -> Result<()> {
-    let (ast_system, codemap) = parser::parse_file(&model);
+    let (ast_system, codemap) = parser::parse_file(&model)?;
     let system = builder::build(ast_system, codemap)?;
 
     let claypot_file_name = format!("{}pot", &model.to_str().unwrap());

--- a/payas-cli/src/commands/schema.rs
+++ b/payas-cli/src/commands/schema.rs
@@ -16,7 +16,7 @@ pub struct CreateCommand {
 
 impl Command for CreateCommand {
     fn run(&self, _system_start_time: Option<SystemTime>) -> Result<()> {
-        let (ast_system, codemap) = parser::parse_file(&self.model);
+        let (ast_system, codemap) = parser::parse_file(&self.model)?;
         let system = builder::build(ast_system, codemap)?;
 
         println!("{}", SchemaSpec::from_model(system.tables).to_sql());

--- a/payas-cli/src/main.rs
+++ b/payas-cli/src/main.rs
@@ -1,5 +1,6 @@
-use std::{env, path::PathBuf, process, time::SystemTime};
+use std::{env, path::PathBuf, time::SystemTime};
 
+use anyhow::Result;
 use clap::{App, AppSettings, Arg, SubCommand};
 
 use crate::commands::{
@@ -11,7 +12,7 @@ mod commands;
 
 const DEFAULT_MODEL_FILE: &str = "index.clay";
 
-fn main() {
+fn main() -> Result<()> {
     let system_start_time = SystemTime::now();
 
     let matches = App::new("Claytip")
@@ -175,8 +176,5 @@ fn main() {
         _ => panic!("Unhandled command name"),
     };
 
-    if let Err(e) = command.run(Some(system_start_time)) {
-        eprintln!("error: {}", e);
-        process::exit(1);
-    }
+    command.run(Some(system_start_time))
 }

--- a/payas-server/src/lib.rs
+++ b/payas-server/src/lib.rs
@@ -173,6 +173,10 @@ pub fn start_prod_mode(
     claypot_file: impl AsRef<Path> + Clone,
     system_start_time: Option<SystemTime>,
 ) -> Result<()> {
+    if !Path::new(claypot_file.as_ref()).exists() {
+        anyhow::bail!("File '{}' not found", claypot_file.as_ref().display());
+    }
+
     let mut actix_system = System::new("claytip");
 
     match File::open(&claypot_file) {
@@ -208,7 +212,7 @@ pub fn start_dev_mode(
         } else {
             system_start_time
         };
-        let (ast_system, codemap) = parser::parse_file(&model_file);
+        let (ast_system, codemap) = parser::parse_file(&model_file)?;
         let system = builder::build(ast_system, codemap)?;
 
         start_server(system, system_start_time, restart)

--- a/payas-server/src/main.rs
+++ b/payas-server/src/main.rs
@@ -1,15 +1,16 @@
 use std::{env, process::exit, time::SystemTime};
 
+use anyhow::Result;
 use payas_server::start_prod_mode;
 
-fn main() {
+fn main() -> Result<()> {
     let system_start_time = SystemTime::now();
 
     let mut args = env::args().skip(1);
 
     if args.len() == 0 {
         // $ clay-server
-        start_prod_mode("index.claypot", Some(system_start_time)).unwrap();
+        start_prod_mode("index.claypot", Some(system_start_time))?;
     } else if args.len() == 1 {
         let file_name = args.next().unwrap();
 
@@ -24,10 +25,12 @@ fn main() {
             exit(1);
         };
 
-        start_prod_mode(&claypot_file, Some(system_start_time)).unwrap()
+        start_prod_mode(&claypot_file, Some(system_start_time))?
     } else {
         // $ clay-server <model-file-name> extra-arguments...
         println!("Usage: clay-server <claypot-file>");
         exit(1);
     }
+
+    Ok(())
 }


### PR DESCRIPTION
Without this, we get an opaque error such as:
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', /Users/ramnivas/open-source/payas/payas-parser/src/parser/mod.rs:13:58
```

After the change, we get a nicer message:
```
Error: File 'integration-tests/interceptor/concert.clayx' not found
```