### PR TITLE
Make watch mode not exit on syntax errors

### DIFF
--- a/payas-parser/src/builder/resolved_builder.rs
+++ b/payas-parser/src/builder/resolved_builder.rs
@@ -1158,7 +1158,7 @@ mod tests {
     }
 
     fn create_resolved_system(src: &str) -> ResolvedSystem {
-        let (parsed, codemap) = parser::parse_str(src);
+        let (parsed, codemap) = parser::parse_str(src).unwrap();
         let types = typechecker::build(parsed, codemap).unwrap();
 
         build(types).unwrap()

--- a/payas-parser/src/builder/system_builder.rs
+++ b/payas-parser/src/builder/system_builder.rs
@@ -276,7 +276,7 @@ mod tests {
     }
 
     fn create_system(src: &str) -> ModelSystem {
-        let (parsed, codemap) = parser::parse_str(src);
+        let (parsed, codemap) = parser::parse_str(src).unwrap();
         build(parsed, codemap).unwrap()
     }
 }

--- a/payas-parser/src/parser/mod.rs
+++ b/payas-parser/src/parser/mod.rs
@@ -30,25 +30,25 @@ pub fn parse_file<P: AsRef<Path>>(path: P) -> Result<(AstSystem<Untyped>, CodeMa
             &codemap,
             file_span,
             path.as_ref(),
-        ),
+        )?,
         codemap,
     ))
 }
 
-pub fn parse_str(str: &str) -> (AstSystem<Untyped>, CodeMap) {
+pub fn parse_str(str: &str) -> Result<(AstSystem<Untyped>, CodeMap)> {
     let mut codemap = CodeMap::new();
     let file_span = codemap
         .add_file("input.payas".to_string(), str.to_string())
         .span;
     let parsed = parse(str).unwrap();
-    (
+    Ok((
         convert_root(
             parsed.root_node(),
             str.as_bytes(),
             &codemap,
             file_span,
             Path::new("input.payas"),
-        ),
+        )?,
         codemap,
-    )
+    ))
 }

--- a/payas-parser/src/typechecker/mod.rs
+++ b/payas-parser/src/typechecker/mod.rs
@@ -387,7 +387,7 @@ pub mod test_support {
     use crate::parser::*;
 
     pub fn build(src: &str) -> Result<MappedArena<Type>> {
-        let (parsed, codemap) = parse_str(src);
+        let (parsed, codemap) = parse_str(src)?;
         super::build(parsed, codemap)
     }
 


### PR DESCRIPTION
Due to a panic!() in converter.rs, clay would exit on syntax errors
instead of staying in the watch mode. This commit uses Result to
return an error instead of panic!().