### PR TITLE
Rework how we resolve query variables

### DIFF
--- a/integration-tests/services-basic/query-service.claytest
+++ b/integration-tests/services-basic/query-service.claytest
@@ -1,6 +1,8 @@
 operation: |
     query Foo {
-      add(x: 1, y: 2)
+      addDirect: add(x: 1, y: 2)
+
+      addVariables: add(x: $x, y: $y)
     
       divide(x: 13, y: 2) {
         quotient
@@ -9,10 +11,16 @@ operation: |
     
       shimQuery
     }
+variable: |
+    {
+        "x": 5,
+        "y": 6
+    }
 response: |
     {
       "data": {
-        "add": 3,
+        "addDirect": 3,
+        "addVariables": 11,
         "divide": {
           "quotient": 6,
           "remainder": 1

--- a/payas-server/src/data/limit_offset_mapper.rs
+++ b/payas-server/src/data/limit_offset_mapper.rs
@@ -2,15 +2,15 @@ use crate::execution::query_context::QueryContext;
 
 use super::operation_mapper::SQLMapper;
 use anyhow::*;
-use async_graphql_value::Value;
+use async_graphql_value::ConstValue;
 use payas_model::{
     model::limit_offset::{LimitParameter, OffsetParameter},
     sql::{Limit, Offset},
 };
 
-fn cast_to_i64(argument: &Value) -> Result<i64> {
+fn cast_to_i64(argument: &ConstValue) -> Result<i64> {
     match argument {
-        Value::Number(n) => Ok(n
+        ConstValue::Number(n) => Ok(n
             .as_i64()
             .ok_or_else(|| anyhow!("Could not cast {} to i64", n))?),
         _ => Err(anyhow!("Not a number")),
@@ -20,7 +20,7 @@ fn cast_to_i64(argument: &Value) -> Result<i64> {
 impl<'a> SQLMapper<'a, Limit> for LimitParameter {
     fn map_to_sql(
         &self,
-        argument: &'a Value,
+        argument: &'a ConstValue,
         _query_context: &'a QueryContext<'a>,
     ) -> Result<Limit> {
         cast_to_i64(argument).map(Limit)
@@ -30,7 +30,7 @@ impl<'a> SQLMapper<'a, Limit> for LimitParameter {
 impl<'a> SQLMapper<'a, Offset> for OffsetParameter {
     fn map_to_sql(
         &self,
-        argument: &'a Value,
+        argument: &'a ConstValue,
         _query_context: &'a QueryContext<'a>,
     ) -> Result<Offset> {
         cast_to_i64(argument).map(Offset)

--- a/payas-server/src/data/mod.rs
+++ b/payas-server/src/data/mod.rs
@@ -12,7 +12,7 @@ mod update_data_param_mapper;
 
 use anyhow::*;
 use async_graphql_parser::Positioned;
-use async_graphql_value::{Name, Value};
+use async_graphql_value::{ConstValue, Name};
 use maybe_owned::MaybeOwned;
 
 use crate::{execution::query_context::QueryContext, sql::predicate::Predicate};
@@ -21,9 +21,9 @@ use payas_model::model::predicate::PredicateParameter;
 
 use self::operation_mapper::SQLMapper;
 
-type Arguments = [(Positioned<Name>, Positioned<Value>)];
+pub type Arguments = [(Positioned<Name>, Positioned<ConstValue>)];
 
-fn find_arg<'a>(arguments: &'a Arguments, arg_name: &str) -> Option<&'a Value> {
+fn find_arg<'a>(arguments: &'a Arguments, arg_name: &str) -> Option<&'a ConstValue> {
     arguments.iter().find_map(|argument| {
         let (argument_name, argument_value) = argument;
         if arg_name == argument_name.node {

--- a/payas-server/src/execution/executor.rs
+++ b/payas-server/src/execution/executor.rs
@@ -72,7 +72,7 @@ impl<'a> Executor<'a> {
                 variables,
                 executor: self,
                 request_context,
-                resolved_variables: Arena::new(),
+                field_arguments: Arena::new(),
             },
         )
     }


### PR DESCRIPTION
Earlier, we had a whack-a-mole approach to resolving variables and did miss a few places (services, limit, offset etc). Now we use `ConstValue` (which doesn't have the `Variable` variation) instead of `Value` (both from async-graphql-parser).