### PR TITLE
Restructure creation of And/Or predicates

### DIFF
--- a/payas-server/src/data/access_solver.rs
+++ b/payas-server/src/data/access_solver.rs
@@ -155,10 +155,9 @@ fn reduce_logical_op<'a>(
                 (Predicate::True, Predicate::True) => Predicate::True,
                 (Predicate::True, right_predicate) => right_predicate,
                 (left_predicate, Predicate::True) => left_predicate,
-                (left_predicate, right_predicate) => Predicate::And(
-                    Box::new(left_predicate.into()),
-                    Box::new(right_predicate.into()),
-                ),
+                (left_predicate, right_predicate) => {
+                    Predicate::and(left_predicate, right_predicate)
+                }
             }
         }
         AccessLogicalOp::Or(left, right) => {
@@ -178,10 +177,9 @@ fn reduce_logical_op<'a>(
 
                 (Predicate::False, right_predicate) => right_predicate,
                 (left_predicate, Predicate::False) => left_predicate,
-                (left_predicate, right_predicate) => Predicate::And(
-                    Box::new(left_predicate.into()),
-                    Box::new(right_predicate.into()),
-                ),
+                (left_predicate, right_predicate) => {
+                    Predicate::and(left_predicate, right_predicate)
+                }
             }
         }
     }

--- a/payas-server/src/data/create_data_param_mapper.rs
+++ b/payas-server/src/data/create_data_param_mapper.rs
@@ -11,7 +11,9 @@ use payas_model::{
         column_id::ColumnId, relation::GqlRelation, system::ModelSystem, types::GqlTypeKind,
         GqlCompositeType, GqlField, GqlType,
     },
-    sql::{column::PhysicalColumn, Limit, Offset, PhysicalTable, SQLOperation, Select},
+    sql::{
+        column::PhysicalColumn, predicate::Predicate, Limit, Offset, PhysicalTable, SQLOperation,
+    },
 };
 
 use super::operation_mapper::SQLMapper;
@@ -259,15 +261,14 @@ fn map_foreign<'a>(
         parent_pk_physical_column: &'a PhysicalColumn,
         parent_index: Option<usize>,
     ) -> Column<'a> {
-        Column::SelectionTableWrapper(Box::new(Select {
-            underlying: parent_table,
-            columns: vec![Column::Physical(parent_pk_physical_column).into()],
-            predicate: None,
-            order_by: None,
-            offset: parent_index.map(|index| Offset(index as i64)),
-            limit: parent_index.map(|_| Limit(1)),
-            top_level_selection: false,
-        }))
+        Column::SelectionTableWrapper(Box::new(parent_table.select(
+            vec![Column::Physical(parent_pk_physical_column).into()],
+            Predicate::True,
+            None,
+            parent_index.map(|index| Offset(index as i64)),
+            parent_index.map(|_| Limit(1)),
+            false,
+        )))
     }
 
     // Find the column that the current entity refers to in the parent entity

--- a/payas-server/src/data/mod.rs
+++ b/payas-server/src/data/mod.rs
@@ -13,7 +13,6 @@ mod update_data_param_mapper;
 use anyhow::*;
 use async_graphql_parser::Positioned;
 use async_graphql_value::{ConstValue, Name};
-use maybe_owned::MaybeOwned;
 
 use crate::{execution::query_context::QueryContext, sql::predicate::Predicate};
 
@@ -37,9 +36,9 @@ fn find_arg<'a>(arguments: &'a Arguments, arg_name: &str) -> Option<&'a ConstVal
 fn compute_predicate<'a>(
     predicate_param: Option<&'a PredicateParameter>,
     arguments: &'a Arguments,
-    additional_predicate: MaybeOwned<'a, Predicate<'a>>,
+    additional_predicate: Predicate<'a>,
     query_context: &'a QueryContext<'a>,
-) -> Result<MaybeOwned<'a, Predicate<'a>>> {
+) -> Result<Predicate<'a>> {
     let predicate = predicate_param
         .as_ref()
         .and_then(|predicate_parameter| {
@@ -51,9 +50,7 @@ fn compute_predicate<'a>(
         .context("While mapping predicate parameters to SQL")?;
 
     let predicate = match predicate {
-        Some(predicate) => {
-            Predicate::And(Box::new(predicate.into()), Box::new(additional_predicate)).into()
-        }
+        Some(predicate) => Predicate::and(predicate, additional_predicate),
         None => additional_predicate,
     };
 

--- a/payas-server/src/data/mutation_resolver/mod.rs
+++ b/payas-server/src/data/mutation_resolver/mod.rs
@@ -135,7 +135,7 @@ fn delete_operation<'a>(
     let predicate = super::compute_predicate(
         Some(predicate_param),
         query_context.field_arguments(field),
-        access_predicate.into(),
+        access_predicate,
         query_context,
     )
     .with_context(|| {
@@ -147,7 +147,7 @@ fn delete_operation<'a>(
 
     let ops = vec![(
         table_name(mutation, query_context),
-        SQLOperation::Delete(table.delete(predicate, vec![Column::Star.into()])),
+        SQLOperation::Delete(table.delete(predicate.into(), vec![Column::Star.into()])),
     )];
 
     Ok(TransactionScript::Single(TransactionStep::Concrete(
@@ -178,7 +178,7 @@ fn update_operation<'a>(
     let predicate = super::compute_predicate(
         Some(predicate_param),
         field_arguments,
-        Predicate::True.into(),
+        Predicate::True,
         query_context,
     )
     .with_context(|| {
@@ -191,7 +191,13 @@ fn update_operation<'a>(
     let argument_value = super::find_arg(field_arguments, &data_param.name);
     argument_value
         .map(|argument_value| {
-            data_param.update_script(mutation, predicate, select, argument_value, query_context)
+            data_param.update_script(
+                mutation,
+                predicate.into(),
+                select,
+                argument_value,
+                query_context,
+            )
         })
         .unwrap()
 }

--- a/payas-server/src/data/predicate_mapper.rs
+++ b/payas-server/src/data/predicate_mapper.rs
@@ -41,7 +41,7 @@ impl<'a> SQLMapper<'a, Predicate<'a>> for PredicateParameter {
                         None => Predicate::True,
                     };
 
-                    Predicate::And(Box::new(acc.into()), Box::new(new_predicate.into()))
+                    Predicate::and(acc, new_predicate)
                 }))
             }
             PredicateParameterTypeKind::Composite(parameters, boolean_params) => {
@@ -94,8 +94,8 @@ impl<'a> SQLMapper<'a, Predicate<'a>> for PredicateParameter {
                                     };
 
                                     let predicate_connector = match boolean_predicate_name {
-                                        "and" => |a, b| Predicate::And(Box::new(a), Box::new(b)),
-                                        "or" => |a, b| Predicate::Or(Box::new(a), Box::new(b)),
+                                        "and" => |a, b| Predicate::and(a, b),
+                                        "or" => |a, b| Predicate::or(a, b),
                                         _ => todo!(),
                                     };
 
@@ -103,10 +103,7 @@ impl<'a> SQLMapper<'a, Predicate<'a>> for PredicateParameter {
 
                                     for argument in arguments.iter() {
                                         let mapped = self.map_to_sql(argument, query_context)?;
-                                        new_predicate = predicate_connector(
-                                            new_predicate.into(),
-                                            mapped.into(),
-                                        );
+                                        new_predicate = predicate_connector(new_predicate, mapped);
                                     }
 
                                     Ok(new_predicate)
@@ -139,10 +136,7 @@ impl<'a> SQLMapper<'a, Predicate<'a>> for PredicateParameter {
                                 None => Predicate::True,
                             };
 
-                            new_predicate = Predicate::And(
-                                Box::new(new_predicate.into()),
-                                Box::new(mapped.into()),
-                            )
+                            new_predicate = Predicate::and(new_predicate, mapped)
                         }
 
                         Ok(new_predicate)

--- a/payas-server/src/data/update_data_param_mapper.rs
+++ b/payas-server/src/data/update_data_param_mapper.rs
@@ -298,9 +298,9 @@ fn compute_nested_update_object_arg<'a>(
     let predicate = pk_columns
         .into_iter()
         .fold(Predicate::True, |acc, (pk_col, value)| {
-            Predicate::And(
-                Box::new(acc.into()),
-                Box::new(Predicate::Eq(Column::Physical(pk_col).into(), value.into()).into()),
+            Predicate::and(
+                acc,
+                Predicate::Eq(Column::Physical(pk_col).into(), value.into()),
             )
         });
     let table = &system.tables[field_model_type.table_id().unwrap()];
@@ -425,8 +425,7 @@ fn compute_nested_delete<'a>(
                 let mut predicate = Predicate::False;
                 for value in values {
                     let elem_predicate = compute_predicate(value, field_model_type, query_context);
-                    predicate =
-                        Predicate::Or(Box::new(predicate.into()), Box::new(elem_predicate.into()));
+                    predicate = Predicate::or(predicate, elem_predicate);
                 }
                 predicate
             }

--- a/payas-sql/src/sql/limit.rs
+++ b/payas-sql/src/sql/limit.rs
@@ -6,6 +6,6 @@ pub struct Limit(pub i64);
 impl Expression for Limit {
     fn binding(&self, expression_context: &mut ExpressionContext) -> ParameterBinding {
         let param_index = expression_context.next_param();
-        ParameterBinding::new(format! {"LIMIT ${}", param_index}, vec![&self.0])
+        ParameterBinding::new(format!("LIMIT ${}", param_index), vec![&self.0])
     }
 }

--- a/payas-sql/src/sql/order.rs
+++ b/payas-sql/src/sql/order.rs
@@ -20,7 +20,7 @@ impl<'a> Expression for OrderBy<'a> {
                     Ordering::Desc => "DESC",
                 };
                 (
-                    format!("{} {}", column_binding.stmt, order_stmt),
+                    format!("ORDER BY {} {}", column_binding.stmt, order_stmt),
                     column_binding.params,
                 )
             })

--- a/payas-sql/src/sql/physical_table.rs
+++ b/payas-sql/src/sql/physical_table.rs
@@ -39,19 +39,22 @@ impl PhysicalTable {
         self.columns.iter().find(|column| column.is_pk)
     }
 
-    pub fn select<'a>(
+    pub fn select<'a, P>(
         &'a self,
         columns: Vec<MaybeOwned<'a, Column<'a>>>,
-        predicate: Option<Predicate<'a>>,
+        predicate: P,
         order_by: Option<OrderBy<'a>>,
         offset: Option<Offset>,
         limit: Option<Limit>,
         top_level_selection: bool,
-    ) -> Select {
+    ) -> Select
+    where
+        P: Into<MaybeOwned<'a, Predicate<'a>>>,
+    {
         Select {
             underlying: self,
             columns,
-            predicate,
+            predicate: predicate.into(),
             order_by,
             offset,
             limit,


### PR DESCRIPTION
By introducing Predicate::and and Predicate::or we simplify predicate during the construction and avoid correct but redundant "true" and "false" in SQL expressions created.

Also fixed a bug where we didn't apply `limit`/`offset` when there is no `where`

Fixes #156