### PR TITLE
Make 'clay import' work again

### DIFF
--- a/payas-cli/src/commands/import.rs
+++ b/payas-cli/src/commands/import.rs
@@ -16,11 +16,12 @@ pub struct ImportCommand {
 impl Command for ImportCommand {
     fn run(&self, _system_start_time: Option<SystemTime>) -> Result<()> {
         let database = Database::from_env(Some(1))?; // TODO: error handling here
-        database.get_client()?;
+        let mut client = database.get_client()?;
 
         let mut issues = Vec::new();
 
-        let mut schema = SchemaSpec::from_db(&database)?;
+        let mut schema = SchemaSpec::from_db(&mut client)?;
+
         let mut model = schema.value.to_model();
 
         issues.append(&mut schema.issues);

--- a/payas-sql/src/sql/database.rs
+++ b/payas-sql/src/sql/database.rs
@@ -1,11 +1,11 @@
 use anyhow::{bail, Context, Result};
 use once_cell::sync::OnceCell;
-use std::env;
+use std::{env, ops::DerefMut};
 
 use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
-use postgres::Config;
+use postgres::{Client, Config};
 use postgres_openssl::MakeTlsConnector;
-use r2d2::{Pool, PooledConnection};
+use r2d2::Pool;
 use r2d2_postgres::PostgresConnectionManager;
 
 const URL_PARAM: &str = "CLAY_DATABASE_URL";
@@ -82,9 +82,7 @@ impl<'a> Database {
         Ok(db)
     }
 
-    pub fn get_client(
-        &self,
-    ) -> Result<PooledConnection<PostgresConnectionManager<MakeTlsConnector>>> {
+    pub fn get_client(&self) -> Result<impl DerefMut<Target = Client>> {
         Ok(self.get_pool()?.get()?)
     }
 

--- a/payas-sql/tests/common.rs
+++ b/payas-sql/tests/common.rs
@@ -81,7 +81,7 @@ pub fn create_physical_table(db: &Database, table_name: &str, query: &str) -> Ph
     client.query(query, &[]).unwrap();
 
     // get definition back from database
-    let table_spec = TableSpec::from_db(db, table_name).unwrap();
+    let table_spec = TableSpec::from_db(&mut client, table_name).unwrap();
 
     if !table_spec.issues.is_empty() {
         for issue in table_spec.issues.iter() {


### PR DESCRIPTION
We had set the pool size for import purpose to be 1, but we were passing `Database` to various methods such as `ColumnSpec::from_db`, each of which needed a connection (while another connection was still in use), so the pool size of 1 wasn't sufficient.

So make all those methods take a `Client`. However, `Database.get_client()` return type was too specific and type used in the return type aren't available in payas-cli, so generalize the return type of `get_client()`.