### PR TITLE
Simplify the API of the payas-parser module to one method

### DIFF
--- a/payas-cli/src/commands/build.rs
+++ b/payas-cli/src/commands/build.rs
@@ -7,7 +7,6 @@ use std::{fs::File, io::BufWriter};
 use std::{path::PathBuf, time::SystemTime};
 
 use bincode::serialize_into;
-use payas_parser::{builder, parser};
 
 use super::Command;
 
@@ -40,8 +39,7 @@ impl Command for BuildCommand {
 }
 
 fn build(model: &Path, system_start_time: Option<SystemTime>, _restart: bool) -> Result<()> {
-    let (ast_system, codemap) = parser::parse_file(&model)?;
-    let system = builder::build(ast_system, codemap)?;
+    let system = payas_parser::build_system(&model)?;
 
     let claypot_file_name = format!("{}pot", &model.to_str().unwrap());
 

--- a/payas-cli/src/commands/schema.rs
+++ b/payas-cli/src/commands/schema.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use payas_model::spec::FromModel;
 use std::{path::PathBuf, time::SystemTime};
 
-use payas_parser::{builder, parser};
 use payas_sql::spec::SchemaSpec;
 
 use super::Command;
@@ -16,8 +15,7 @@ pub struct CreateCommand {
 
 impl Command for CreateCommand {
     fn run(&self, _system_start_time: Option<SystemTime>) -> Result<()> {
-        let (ast_system, codemap) = parser::parse_file(&self.model)?;
-        let system = builder::build(ast_system, codemap)?;
+        let system = payas_parser::build_system(&self.model)?;
 
         println!("{}", SchemaSpec::from_model(system.tables).to_sql());
         Ok(())

--- a/payas-parser/src/lib.rs
+++ b/payas-parser/src/lib.rs
@@ -1,5 +1,16 @@
-pub mod ast;
-pub mod builder;
-pub mod parser;
-pub mod typechecker;
+use std::path::Path;
+
+use payas_model::model::system::ModelSystem;
+
+mod ast;
+mod builder;
+mod parser;
+mod typechecker;
 mod util;
+use anyhow::Result;
+
+/// Build a model system from a clay file
+pub fn build_system(model_file: impl AsRef<Path>) -> Result<ModelSystem> {
+    let (ast_system, codemap) = parser::parse_file(&model_file)?;
+    builder::build(ast_system, codemap)
+}

--- a/payas-server/src/lib.rs
+++ b/payas-server/src/lib.rs
@@ -21,7 +21,6 @@ use async_stream::try_stream;
 
 use introspection::schema::Schema;
 use payas_model::{model::system::ModelSystem, sql::database::Database};
-use payas_parser::builder;
 use serde_json::Value;
 
 use std::time::{Duration, SystemTime};
@@ -33,8 +32,6 @@ mod introspection;
 pub mod model_watcher;
 mod watcher;
 
-pub use payas_parser::ast;
-pub use payas_parser::parser;
 pub use payas_sql::sql;
 
 use crate::authentication::{JwtAuthenticationError, JwtAuthenticator};
@@ -212,8 +209,7 @@ pub fn start_dev_mode(
         } else {
             system_start_time
         };
-        let (ast_system, codemap) = parser::parse_file(&model_file)?;
-        let system = builder::build(ast_system, codemap)?;
+        let system = payas_parser::build_system(&model_file)?;
 
         start_server(system, system_start_time, restart)
     };


### PR DESCRIPTION
And remove "pub" from all module in payas-parser/lib.rs so that the exposed `build_system` function is the only interface for clients to use and all ast/build/typechecker become internal details.