### PR TITLE
Revert "Use replace() instead of replaceAll()"

### DIFF
--- a/vscode-extension/build.js
+++ b/vscode-extension/build.js
@@ -31,7 +31,7 @@ function processTemplate() {
   let keys = Object.keys(replacements);
 
   for (const key of keys) {
-    content = content.replace(/{{${key}}}/g, replacements[key]);
+    content = content.replaceAll(`{{${key}}}`, replacements[key]);
   }
 
   fs.writeFileSync(`${out}/syntaxes/claytip.tmLanguage.json`, content);


### PR DESCRIPTION
This reverts commit e77baaa0611dde67d63a4a2b82bd9f17fbaae02c.

`replace()` replaces just the first occurrence, and thus leaves others in their unprocessed form.