### PR TITLE
Handle errors and expections from Deno service code

### DIFF
--- a/integration-tests/services-basic/arithmetic.clay
+++ b/integration-tests/services-basic/arithmetic.clay
@@ -28,4 +28,5 @@ service MathService {
 
     export query shimQuery(@inject claytip: Claytip): Int 
     export mutation testMutation(@inject claytip: Claytip): Float 
+    export mutation illegalFunction(): String
 }

--- a/integration-tests/services-basic/arithmetic.js
+++ b/integration-tests/services-basic/arithmetic.js
@@ -6,6 +6,10 @@ export function divide(x, y) {
     let quotient = Math.floor(x / y);
     let remainder = x % y;
 
+    if (y == 0) {
+        throw new Error("Division by zero is not allowed")
+    }
+
     return {
         "quotient": quotient,
         "remainder": remainder
@@ -36,6 +40,11 @@ export function shimQuery(claytip) {
 
 export function testMutation(claytip) {
     return 3.14
+}
+
+export function illegalFunction() {
+    const x = undefined;
+    return x[0]
 }
 
 export function log(env, message) {

--- a/integration-tests/services-basic/errors.claytest
+++ b/integration-tests/services-basic/errors.claytest
@@ -1,0 +1,12 @@
+operation: |
+    mutation Foo {
+      result: illegalFunction
+    }
+response: |
+    {
+      "errors": [
+        {
+          "message": "Internal server error"
+        }
+      ]
+    } 

--- a/integration-tests/services-basic/exceptions.claytest
+++ b/integration-tests/services-basic/exceptions.claytest
@@ -1,0 +1,15 @@
+operation: |
+    query Foo {
+      divide(x: 10, y: 0) {
+        quotient
+        remainder
+      }
+    }
+response: |
+    {
+      "errors": [
+        {
+          "message": "Division by zero is not allowed"
+        }
+      ]
+    } 


### PR DESCRIPTION
This PR ensures that we handle errors and exceptions from Deno code gracefully. We make sure to not expose internal details by returning `Internal server error` for all errors and uncaught exceptions except when the user throws a message explicitly (e.g. `throw new Error("...");`). Integration tests were added to ensure correctness of this behavior.