### PR TITLE
Introduce ClaytipError and utils.js

### DIFF
--- a/integration-tests/services-basic/arithmetic.js
+++ b/integration-tests/services-basic/arithmetic.js
@@ -7,7 +7,7 @@ export function divide(x, y) {
     let remainder = x % y;
 
     if (y == 0) {
-        throw new Error("Division by zero is not allowed")
+        throw new ClaytipError("Division by zero is not allowed")
     }
 
     return {

--- a/payas-deno/src/deno_module.rs
+++ b/payas-deno/src/deno_module.rs
@@ -32,7 +32,7 @@ fn get_error_class_name(e: &AnyError) -> &'static str {
     deno_runtime::errors::get_error_class_name(e).unwrap_or("Error")
 }
 
-const JSERROR_PREFIX: &str = "Uncaught Error: ";
+const JSERROR_PREFIX: &str = "Uncaught ClaytipError: ";
 
 // From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number
 const JS_MAX_SAFE_INTEGER: i64 = (1 << 53) - 1;
@@ -139,6 +139,9 @@ impl DenoModule {
         worker.js_runtime.sync_ops_cache();
 
         worker.execute_main_module(&main_module).await?;
+        worker
+            .execute_script("", include_str!("./utils.js"))
+            .unwrap();
         worker.run_event_loop(false).await?;
 
         let shim_object_names = shims.iter().map(|(name, _)| name.to_string()).collect();

--- a/payas-deno/src/utils.js
+++ b/payas-deno/src/utils.js
@@ -1,0 +1,6 @@
+class ClaytipError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = "ClaytipError";
+    }
+}


### PR DESCRIPTION
This PR introduces `ClaytipError`, a specialized error class users can use to pass errors back to the user. This addresses the potential issue of libraries leaking error information through throwing generic `Error`s. We also introduce `utils.js`, allowing us to define utility functions and classes that exist in the global scope of users' Deno modules.