### PR TITLE
Bump PostgreSQL connection limits in CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -66,6 +66,7 @@ steps:
 services:
   - name: database
     image: postgres:12-buster
+    command: ["postgres", "-c", "max_connections=1000"]
     environment:
       POSTGRES_USER: postgres
       POSTGRES_DB: test


### PR DESCRIPTION
Occasionally, integration tests fail in our CI due to the number of concurrent connections running up against the default limit.

```
...
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: db error: FATAL: sorry, too many clients already
...
```