### PR TITLE
Implement each command in a separate file

### DIFF
--- a/payas-cli/src/commands/build.rs
+++ b/payas-cli/src/commands/build.rs
@@ -8,7 +8,7 @@ use std::{path::PathBuf, time::SystemTime};
 
 use bincode::serialize_into;
 
-use super::Command;
+use super::command::Command;
 
 const FILE_WATCHER_DELAY: Duration = Duration::from_millis(10);
 

--- a/payas-cli/src/commands/command.rs
+++ b/payas-cli/src/commands/command.rs
@@ -1,0 +1,7 @@
+use std::time::SystemTime;
+
+use anyhow::Result;
+
+pub trait Command {
+    fn run(&self, system_start_time: Option<SystemTime>) -> Result<()>;
+}

--- a/payas-cli/src/commands/import.rs
+++ b/payas-cli/src/commands/import.rs
@@ -6,7 +6,7 @@ use payas_model::sql::database::Database;
 use payas_sql::spec::SchemaSpec;
 use std::{fs::File, io::Write, path::PathBuf, time::SystemTime};
 
-use super::Command;
+use super::command::Command;
 
 /// Create a claytip model file based on a database schema
 pub struct ImportCommand {

--- a/payas-cli/src/commands/migrate.rs
+++ b/payas-cli/src/commands/migrate.rs
@@ -1,0 +1,16 @@
+use std::{path::PathBuf, time::SystemTime};
+
+use super::command::Command;
+use anyhow::Result;
+
+/// Perform a database migration for a claytip model
+pub struct MigrateCommand {
+    pub model: PathBuf,
+    pub database: String,
+}
+
+impl Command for MigrateCommand {
+    fn run(&self, _system_start_time: Option<SystemTime>) -> Result<()> {
+        todo!("Implmement migrate command");
+    }
+}

--- a/payas-cli/src/commands/mod.rs
+++ b/payas-cli/src/commands/mod.rs
@@ -1,58 +1,10 @@
 //! Top level subcommands
 
-use anyhow::Result;
-use std::{path::PathBuf, time::SystemTime};
-
-pub mod build;
-pub mod import;
-pub mod schema;
-
-pub trait Command {
-    fn run(&self, system_start_time: Option<SystemTime>) -> Result<()>;
-}
-
-/// Perform a database migration for a claytip model
-pub struct MigrateCommand {
-    pub model: PathBuf,
-    pub database: String,
-}
-
-impl Command for MigrateCommand {
-    fn run(&self, _system_start_time: Option<SystemTime>) -> Result<()> {
-        todo!("Implmement migrate command");
-    }
-}
-
-/// Run local claytip server
-pub struct ServeCommand {
-    pub model: PathBuf,
-    pub watch: bool,
-}
-
-impl Command for ServeCommand {
-    fn run(&self, system_start_time: Option<SystemTime>) -> Result<()> {
-        payas_server::start_dev_mode(self.model.clone(), self.watch, system_start_time)
-    }
-}
-
-/// Perform integration tests
-pub struct TestCommand {
-    pub dir: PathBuf,
-}
-
-impl Command for TestCommand {
-    fn run(&self, _system_start_time: Option<SystemTime>) -> Result<()> {
-        payas_test::run(&self.dir)
-    }
-}
-
-/// Run local claytip server with a temporary database
-pub struct YoloCommand {
-    pub model: PathBuf,
-}
-
-impl Command for YoloCommand {
-    fn run(&self, _system_start_time: Option<SystemTime>) -> Result<()> {
-        todo!("Implmement yolo command");
-    }
-}
+pub(crate) mod build;
+pub(crate) mod command;
+pub(crate) mod import;
+pub(crate) mod migrate;
+pub(crate) mod schema;
+pub(crate) mod serve;
+pub(crate) mod test;
+pub(crate) mod yolo;

--- a/payas-cli/src/commands/schema.rs
+++ b/payas-cli/src/commands/schema.rs
@@ -6,7 +6,7 @@ use std::{path::PathBuf, time::SystemTime};
 
 use payas_sql::spec::SchemaSpec;
 
-use super::Command;
+use super::command::Command;
 
 /// Create a database schema from a claytip model
 pub struct CreateCommand {

--- a/payas-cli/src/commands/serve.rs
+++ b/payas-cli/src/commands/serve.rs
@@ -1,0 +1,16 @@
+use std::{path::PathBuf, time::SystemTime};
+
+use super::command::Command;
+use anyhow::Result;
+
+/// Run local claytip server
+pub struct ServeCommand {
+    pub model: PathBuf,
+    pub watch: bool,
+}
+
+impl Command for ServeCommand {
+    fn run(&self, system_start_time: Option<SystemTime>) -> Result<()> {
+        payas_server::start_dev_mode(self.model.clone(), self.watch, system_start_time)
+    }
+}

--- a/payas-cli/src/commands/test.rs
+++ b/payas-cli/src/commands/test.rs
@@ -1,0 +1,15 @@
+use std::{path::PathBuf, time::SystemTime};
+
+use super::command::Command;
+use anyhow::Result;
+
+/// Perform integration tests
+pub struct TestCommand {
+    pub dir: PathBuf,
+}
+
+impl Command for TestCommand {
+    fn run(&self, _system_start_time: Option<SystemTime>) -> Result<()> {
+        payas_test::run(&self.dir)
+    }
+}

--- a/payas-cli/src/commands/yolo.rs
+++ b/payas-cli/src/commands/yolo.rs
@@ -1,0 +1,15 @@
+use std::{path::PathBuf, time::SystemTime};
+
+use super::command::Command;
+use anyhow::Result;
+
+/// Run local claytip server with a temporary database
+pub struct YoloCommand {
+    pub model: PathBuf,
+}
+
+impl Command for YoloCommand {
+    fn run(&self, _system_start_time: Option<SystemTime>) -> Result<()> {
+        todo!("Implmement yolo command");
+    }
+}

--- a/payas-cli/src/main.rs
+++ b/payas-cli/src/main.rs
@@ -2,11 +2,12 @@ use std::{env, path::PathBuf, time::SystemTime};
 
 use anyhow::Result;
 use clap::{App, AppSettings, Arg, SubCommand};
-
-use crate::commands::{
-    build::BuildCommand, import, schema, Command, MigrateCommand, ServeCommand, TestCommand,
-    YoloCommand,
+use commands::{
+    command::Command, migrate::MigrateCommand, serve::ServeCommand, test::TestCommand,
+    yolo::YoloCommand,
 };
+
+use crate::commands::{build::BuildCommand, import, schema};
 
 mod commands;
 


### PR DESCRIPTION
This is a mechanical refactoring to put each command's code into a separate file. Earlier, we had an ad hoc organization where a few commands were in mod.rs and the rest in their own files. Now mod.rs contains only a few `pub mod` declarations.