### PR TITLE
Add a rayon thread pool to the test runner in payas-test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2963,9 +2987,11 @@ dependencies = [
  "isahc",
  "jsonwebtoken",
  "md5",
+ "num_cpus",
  "postgres",
  "postgres-openssl",
  "rand 0.8.4",
+ "rayon",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3410,6 +3436,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a441a7a6c80ad6473bd4b74ec1c9a4c951794285bf941c2126f607c72e48211"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg 1.0.1",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
 ]
 
 [[package]]

--- a/payas-test/Cargo.toml
+++ b/payas-test/Cargo.toml
@@ -11,11 +11,13 @@ anyhow = "1.0"
 ansi_term = "0.12"
 jsonwebtoken = "7.2"
 isahc = { version = "1.4", features = ["json"] }
+num_cpus = "1.13.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8.17"
 serde_json = "1.0"
 postgres = { version = "0.19.0", features = ["with-chrono-0_4"] }
 postgres-openssl = "0.5.0"
 rand = "0.8"
+rayon = "1.5.1"
 async-graphql-parser = "2.6.5"
 md5 = "0.7"

--- a/payas-test/src/lib.rs
+++ b/payas-test/src/lib.rs
@@ -1,10 +1,14 @@
 mod claytest;
 
 use anyhow::{bail, Result};
-use claytest::loader::load_testfiles_from_dir;
+use claytest::loader::{load_testfiles_from_dir, ParsedTestfile};
 use claytest::runner::run_testfile;
+use rayon::ThreadPoolBuilder;
+use std::cmp::min;
 use std::path::Path;
+use std::sync::mpsc;
 
+/// Loads test files from the supplied directory and runs them using a thread pool.
 pub fn run(directory: &Path) -> Result<()> {
     println!(
         "{} {} {}",
@@ -14,33 +18,42 @@ pub fn run(directory: &Path) -> Result<()> {
         directory.to_str().unwrap(),
         ansi_term::Color::Blue.bold().paint("..."),
     );
+    let start_time = std::time::Instant::now();
+    let cpus = num_cpus::get();
 
-    // Load testfiles
+    let database_url = std::env::var("CLAY_TEST_DATABASE_URL").expect("CLAY_TEST_DATABASE_URL");
+
     let testfiles = load_testfiles_from_dir(Path::new(&directory)).unwrap();
-    let number_of_tests = testfiles.len() * 2; // *2 because we run each testfile twice: dev mode and qproduction mode
+    let number_of_tests = testfiles.len() * 2; // *2 because we run each testfile twice: dev mode and production mode
 
-    // Run testfiles in parallel
-    let mut test_results: Vec<_> = testfiles
-        .into_iter()
-        .flat_map(|t| {
-            let t_dev = t.clone();
-            vec![
-                std::thread::spawn(move || {
-                    run_testfile(
-                        &t_dev,
-                        std::env::var("CLAY_TEST_DATABASE_URL").unwrap(),
-                        true, // dev_mode
-                    )
-                }),
-                std::thread::spawn(move || {
-                    run_testfile(&t, std::env::var("CLAY_TEST_DATABASE_URL").unwrap(), false)
-                }),
-            ]
-        })
-        .collect::<Vec<_>>()
-        .into_iter()
-        .map(|j| j.join().unwrap())
-        .collect();
+    // Estimate an optimal pool size
+    let pool_size = min(number_of_tests, cpus * 2);
+    let pool = ThreadPoolBuilder::new()
+        .num_threads(pool_size)
+        .build()
+        .unwrap();
+
+    let (tx, rx) = mpsc::channel();
+
+    let run_test_in_pool = |file: ParsedTestfile, is_dev_mode: bool| {
+        let tx = tx.clone();
+        let url = database_url.clone();
+
+        pool.spawn(move || {
+            let result = run_testfile(&file, url, is_dev_mode);
+            tx.send(result).unwrap();
+        });
+    };
+
+    // Run testfiles in parallel using the thread pool in both production and dev modes
+    for file in testfiles.iter() {
+        run_test_in_pool(file.clone(), false);
+        run_test_in_pool(file.clone(), true);
+    }
+
+    drop(tx);
+
+    let mut test_results: Vec<_> = rx.into_iter().collect();
 
     test_results.sort_by(|a, b| {
         if a.is_ok() && b.is_err() {
@@ -57,6 +70,7 @@ pub fn run(directory: &Path) -> Result<()> {
             std::cmp::Ordering::Equal
         }
     });
+
     test_results.reverse();
 
     let mut number_of_succeeded_tests = 0;
@@ -84,13 +98,15 @@ pub fn run(directory: &Path) -> Result<()> {
     };
 
     println!(
-        "{} {} {} out of {} total",
+        "{} {} {} out of {} total in {} seconds ({} cpus)",
         ansi_term::Color::Blue.bold().paint("* Test results:"),
         status,
         ansi_term::Style::new()
             .bold()
             .paint(format!("{} passed", number_of_succeeded_tests)),
-        number_of_tests
+        number_of_tests,
+        start_time.elapsed().as_secs(),
+        cpus,
     );
 
     if success {


### PR DESCRIPTION
This limits the number of threads that are used when running integration
test files. A server is spawned for every test file, so it is currently
possible to run out of database connections if all the tests are being
run at once - postgres has a default maximum of 100 connections. Even
without this limitation it's probably more efficient to limit the number
of servers spawned, depending on the resources of the test machine.

The number of threads used is the minimum of the number of tests or
the 2*number of CPUs on the machine.

Also added reporting of time taken and number of CPUs when running the
tests.