### PR TITLE
Improve reporting of corrupt claypot file

### DIFF
--- a/payas-server/src/lib.rs
+++ b/payas-server/src/lib.rs
@@ -196,10 +196,20 @@ pub fn start_prod_mode(
         Ok(file) => {
             let claypot_file_buffer = BufReader::new(file);
             let in_file = BufReader::new(claypot_file_buffer);
-            let system: ModelSystem = deserialize_from(in_file).unwrap();
-
-            let server = start_server(system, system_start_time, false)?;
-            actix_system.block_on(server)?;
+            match deserialize_from(in_file) {
+                Ok(system) => {
+                    let server = start_server(system, system_start_time, false)?;
+                    actix_system.block_on(server)?;
+                }
+                Err(e) => {
+                    println!(
+                        "Failed to read claypot file {:?}: {}",
+                        claypot_file.as_ref(),
+                        e
+                    );
+                    std::process::exit(1);
+                }
+            }
 
             Ok(())
         }


### PR DESCRIPTION
When running the integration tests, there's a race condition in
the production mode case where different tests can compile the same
claypot file in parallel resulting in a corrupt file. The server
then exits and the integration test fails after being unable to read
the server port from the server stdout.

This commit improves the detection of these cases by printing a
message to stdout if the server fails to deserialize the claypot
file and writing this as output in the test runner. The previous
message just reported failure to fill the buffer for the expected
output from the server, thus hiding the failure case.

Additional information may have been written to the server's stderr
when unwrapping the deserialization result but this wasn't being
read by the test runner so would be lost.