### PR TITLE
Fix corrupt claypot files in integration-tests

### DIFF
--- a/payas-test/src/claytest/runner.rs
+++ b/payas-test/src/claytest/runner.rs
@@ -23,7 +23,7 @@ struct ClayPost {
     variables: serde_json::Value,
 }
 
-pub fn run_testfile(
+pub(crate) fn run_testfile(
     testfile: &ParsedTestfile,
     bootstrap_dburl: String,
     dev_mode: bool,
@@ -282,7 +282,7 @@ fn run_operation(
     }
 }
 
-pub fn build_clay_file(path: &str) -> Result<()> {
+pub(crate) fn build_claypot_file(path: &str) -> Result<()> {
     let build_child = cmd("clay").args(["build", path]).output()?;
 
     if !build_child.status.success() {

--- a/payas-test/src/lib.rs
+++ b/payas-test/src/lib.rs
@@ -2,7 +2,7 @@ mod claytest;
 
 use anyhow::{bail, Result};
 use claytest::loader::{load_testfiles_from_dir, ParsedTestfile};
-use claytest::runner::{build_clay_file, run_testfile};
+use claytest::runner::{build_claypot_file, run_testfile};
 use rayon::ThreadPoolBuilder;
 use std::cmp::min;
 use std::collections::HashMap;
@@ -68,7 +68,7 @@ pub fn run(directory: &Path) -> Result<()> {
         let tx = tx.clone();
         let url = database_url.clone();
 
-        pool.spawn(move || match build_clay_file(&model_path) {
+        pool.spawn(move || match build_claypot_file(&model_path) {
             Ok(()) => {
                 for file in testfiles.iter() {
                     let result = run_testfile(file, url.clone(), false);


### PR DESCRIPTION
Instead of building the claypot file for each production mode test,
which can cause the errors described in #301, we first create a
hashmap of the model paths to the test files which depend on them.

The map is later used to spawn threads which build the claypot file
and then run the tests which depend on it once the file has been
built.

This is potentially slower, since multiple tests are running in the
same thread but should at least partially be offset by the reduction
in duplicated `clay build` commands.