### PR TITLE
Ignore autocreated claytip.d.ts

### DIFF
--- a/integration-tests/.gitignore
+++ b/integration-tests/.gitignore
@@ -1,0 +1,3 @@
+# Ignore autocreated claytip.d.ts.
+# We need such an arrangement until we have claytip.d.ts  distributed over some repository that can be imported into users source code
+claytip.d.ts


### PR DESCRIPTION
We need such an arrangement until we have claytip.d.ts  distributed over some repository that can be imported into users source code