### PR TITLE
Remove the "authors" field from Cargo.toml files

### DIFF
--- a/payas-cli/Cargo.toml
+++ b/payas-cli/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "payas-cli"
 version = "0.1.0"
-authors = ["Ramnivas Laddad <ramnivas@payalabs.com>"]
 edition = "2021"
 
 [[bin]]

--- a/payas-deno/Cargo.toml
+++ b/payas-deno/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "payas-deno"
 version = "0.1.0"
-authors = ["Ramnivas Laddad <ramnivas@payalabs.com>"]
 edition = "2021"
 
 [dependencies]

--- a/payas-model/Cargo.toml
+++ b/payas-model/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "payas-model"
 version = "0.1.0"
-authors = ["Ramnivas Laddad <ramnivas@payalabs.com>"]
 edition = "2021"
 
 [dependencies]

--- a/payas-parser/Cargo.toml
+++ b/payas-parser/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "payas-parser"
 version = "0.1.0"
-authors = ["Ramnivas Laddad <ramnivas@payalabs.com>"]
 edition = "2021"
 
 [dependencies]

--- a/payas-server/Cargo.toml
+++ b/payas-server/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "payas-server"
 version = "0.1.0"
-authors = ["Ramnivas Laddad <ramnivas@payalabs.com>"]
 edition = "2021"
 
 [dependencies]

--- a/payas-sql/Cargo.toml
+++ b/payas-sql/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "payas-sql"
 version = "0.1.0"
-authors = ["Ramnivas Laddad <ramnivas@payalabs.com>"]
 edition = "2021"
 
 [dependencies]

--- a/payas-test/Cargo.toml
+++ b/payas-test/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "payas-test"
 version = "0.1.0"
-authors = ["Andy Chun <andy.chun@payalabs.com>"]
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
That field doesn't convey anything meanigful and in any case, it displays incorrect information unless we maintain that field.

Also see, https://github.com/rust-lang/rfcs/pull/3052#issuecomment-768562315