### PR TITLE
Remove unused code

### DIFF
--- a/payas-cli/src/commands/build.rs
+++ b/payas-cli/src/commands/build.rs
@@ -1,15 +1,12 @@
 use anyhow::Result;
 
 use std::path::Path;
-use std::time::Duration;
 use std::{fs::File, io::BufWriter};
 use std::{path::PathBuf, time::SystemTime};
 
 use bincode::serialize_into;
 
 use super::command::Command;
-
-const FILE_WATCHER_DELAY: Duration = Duration::from_millis(10);
 
 /// Build claytip server binary
 pub struct BuildCommand {

--- a/payas-deno/src/deno_module/mod.rs
+++ b/payas-deno/src/deno_module/mod.rs
@@ -5,8 +5,6 @@ use deno_core::JsRuntime;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
-use deno_core::v8::Global;
-use deno_core::v8::Script;
 use deno_runtime::deno_broadcast_channel::InMemoryBroadcastChannel;
 use deno_runtime::deno_web::BlobStore;
 use deno_runtime::permissions::Permissions;
@@ -35,12 +33,6 @@ fn get_error_class_name(e: &AnyError) -> &'static str {
 
 const JSERROR_PREFIX: &str = "Uncaught ClaytipError: ";
 
-// From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number
-const JS_MAX_SAFE_INTEGER: i64 = (1 << 53) - 1;
-const JS_MIN_SAFE_INTEGER: i64 = -JS_MAX_SAFE_INTEGER;
-const JS_MAX_VALUE: f64 = 1.797_693_134_862_315_7e308;
-const JS_MIN_VALUE: f64 = 5e-324;
-
 pub enum UserCode {
     LoadFromMemory { script: String, path: String },
     LoadFromFs(PathBuf),
@@ -62,10 +54,6 @@ pub struct DenoModuleSharedState {
     // TODO
     //  shared_array_buffer_store
     //  compiled_wasm_module_store
-}
-
-pub struct DenoScript {
-    pub script: Global<Script>,
 }
 
 /// A Deno-based runner for JavaScript.

--- a/payas-deno/tests/deno_module_tests.rs
+++ b/payas-deno/tests/deno_module_tests.rs
@@ -1,15 +1,10 @@
 use std::path::Path;
 
-use anyhow::Result;
 use deno_core::serde_json::json;
 use deno_core::{serde_json::Value, JsRuntime};
 use futures::future::join_all;
 use payas_deno::{Arg, DenoActor, DenoExecutor, DenoModule, DenoModuleSharedState, UserCode};
 use tokio::sync::mpsc::channel;
-
-fn no_op(_: String, _: Option<&serde_json::Map<String, Value>>) -> Result<serde_json::Value> {
-    panic!()
-}
 
 #[tokio::test]
 async fn test_direct_sync() {

--- a/payas-parser/src/ast/ast_types.rs
+++ b/payas-parser/src/ast/ast_types.rs
@@ -149,26 +149,10 @@ pub enum AstFieldType<T: NodeTypedness> {
 }
 
 impl<T: NodeTypedness> AstFieldType<T> {
-    pub fn span(&self) -> Span {
-        match self {
-            AstFieldType::Plain(_, _, _, span) => *span,
-            AstFieldType::Optional(inner) => inner.span(),
-        }
-    }
-}
-
-impl<T: NodeTypedness> AstFieldType<T> {
     pub fn name(&self) -> String {
         match self {
             AstFieldType::Optional(underlying) => underlying.name(),
             AstFieldType::Plain(base_type, _, _, _) => base_type.clone(),
-        }
-    }
-
-    pub fn optional(&self) -> Self {
-        match self {
-            AstFieldType::Optional(_) => self.clone(),
-            _ => AstFieldType::Optional(Box::new(self.clone())),
         }
     }
 }

--- a/payas-parser/src/typechecker/annotation_map.rs
+++ b/payas-parser/src/typechecker/annotation_map.rs
@@ -49,10 +49,6 @@ impl AnnotationMap {
         AnnotationMap { annotations, spans }
     }
 
-    pub fn add(&mut self, annotation: AstAnnotation<Typed>) {
-        self.annotations.insert(annotation.name.clone(), annotation);
-    }
-
     pub fn contains(&self, name: &str) -> bool {
         self.annotations.contains_key(name)
     }

--- a/payas-parser/src/typechecker/mod.rs
+++ b/payas-parser/src/typechecker/mod.rs
@@ -427,9 +427,9 @@ mod tests {
         context AuthContext {
             role: String @jwt
         }
-    
+
         model Doc {
-          is_public: Boolean 
+          is_public: Boolean
           content: String @access(AuthContext.role == "ROLE_ADMIN" || self.is_public)
         }
         "#;
@@ -443,7 +443,7 @@ mod tests {
         context AuthContext {
             roles: Array<String> @jwt
         }
-    
+
         model Doc {
           content: String @access("ROLE_ADMIN" in AuthContext.roles)
         }
@@ -458,11 +458,11 @@ mod tests {
         context AuthContext {
             role: String @jwt
         }
-    
+
         @access(AuthContext.role == "ROLE_ADMIN" || self.is_public)
         model Doc {
-          is_public: Boolean 
-          content: String 
+          is_public: Boolean
+          content: String
         }
         "#;
 
@@ -482,11 +482,11 @@ mod tests {
         let with_whitespace = r#"
 
         @table ( "venues" )
-        model    Venue   
+        model    Venue
         {
-            id:   Int   @column(  "idx"  )    
-            @pk 
-            
+            id:   Int   @column(  "idx"  )
+            @pk
+
             name:String
 
         }
@@ -509,6 +509,7 @@ mod tests {
         assert_err(src);
     }
 
+    #[test]
     fn duplicate_annotation() {
         let src = r#"
         @table("users")
@@ -520,6 +521,7 @@ mod tests {
         assert_err(src);
     }
 
+    #[test]
     fn invalid_annotation_parameter_type() {
         let expected_none = r#"
         model User {
@@ -544,6 +546,7 @@ mod tests {
         assert_err(expected_map);
     }
 
+    #[test]
     fn duplicate_annotation_mapped_param() {
         let src = r#"
         model User {
@@ -554,6 +557,7 @@ mod tests {
         assert_err(src);
     }
 
+    #[test]
     fn unknown_annotation_mapped_param() {
         let src = r#"
         model User {
@@ -564,6 +568,7 @@ mod tests {
         assert_err(src);
     }
 
+    #[test]
     fn invalid_annotation_target() {
         let model = r#"
         @pk

--- a/payas-server/src/introspection/definition/parameter_type.rs
+++ b/payas-server/src/introspection/definition/parameter_type.rs
@@ -16,7 +16,7 @@ use payas_model::model::{
     system::ModelSystem,
 };
 
-use super::{parameter::Parameter, provider::*};
+use super::provider::{InputValueProvider, TypeDefinitionProvider};
 
 pub trait ParameterType {
     fn name(&self) -> &String;
@@ -32,12 +32,6 @@ impl ParameterType for PredicateParameterType {
     fn name(&self) -> &String {
         &self.name
     }
-}
-
-pub enum ParameterTypeKind {
-    Primitive,
-    Composite { parameters: Vec<Box<dyn Parameter>> },
-    Enum { values: Vec<String> },
 }
 
 pub const PRIMITIVE_ORDERING_OPTIONS: [&str; 2] = ["ASC", "DESC"];

--- a/payas-server/src/lib.rs
+++ b/payas-server/src/lib.rs
@@ -130,11 +130,6 @@ pub async fn resolve(
     }
 }
 
-enum ServerLoopEvent {
-    FileChange,
-    SigInt,
-}
-
 /// Creates the data required by the actix endpoint.
 ///
 /// This should be added to the server as actix `app_data`.

--- a/payas-sql/src/sql/mod.rs
+++ b/payas-sql/src/sql/mod.rs
@@ -78,12 +78,6 @@ pub struct SQLValue {
     type_: Type,
 }
 
-impl SQLValue {
-    fn as_sql_param(&self) -> &dyn SQLParam {
-        self
-    }
-}
-
 impl Display for SQLValue {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         write!(fmt, "<SQLValue containing {}>", self.type_)

--- a/payas-sql/src/sql/transaction.rs
+++ b/payas-sql/src/sql/transaction.rs
@@ -177,8 +177,6 @@ impl<'a> ConcreteTransactionStep<'a> {
     }
 }
 
-type TransactionStepResult = Vec<SQLValue>;
-
 #[derive(Debug)]
 pub struct TemplateTransactionStep<'a> {
     pub operation: TemplateSQLOperation<'a>,


### PR DESCRIPTION
For some reason, setting lld as the linker using `RUSTFLAGS="-C link-arg=-fuse-ld=lld"` detects additional unused code. Also some tests were flagged up since they were missing the `#[test]` annotation.

This PR is intended for discussion of these. Perhaps some might still be needed and can be annotated as unused.