### PR TITLE
Remove .cargo/config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["-A", "dead_code"]


### PR DESCRIPTION
This only contained a setting to allow dead_code which was causing
the issue described in #335. Setting RUST_FLAGS overrides the
settings in this file.

We usually want unused code to be flagged so this is better removed.