### PR TITLE
Remove the base directory prefix from test names

### DIFF
--- a/payas-test/src/claytest/loader.rs
+++ b/payas-test/src/claytest/loader.rs
@@ -93,10 +93,9 @@ pub struct InitFile {
 /// Load and parse testfiles from a given directory.
 pub fn load_testfiles_from_dir(
     root_directory: &Path,
-    directory: &Path,
     pattern: &Option<String>,
 ) -> Result<Vec<ParsedTestfile>> {
-    load_testfiles_from_dir_(root_directory, directory, None, &[], pattern)
+    load_testfiles_from_dir_(root_directory, root_directory, None, &[], pattern)
 }
 
 fn load_testfiles_from_dir_(

--- a/payas-test/src/lib.rs
+++ b/payas-test/src/lib.rs
@@ -31,13 +31,12 @@ pub fn run(root_directory: &Path, pattern: &Option<String>) -> Result<()> {
     let database_url =
         std::env::var("CLAY_TEST_DATABASE_URL").expect("CLAY_TEST_DATABASE_URL must be specified");
 
-    let testfiles = load_testfiles_from_dir(root_directory, Path::new(&root_directory), pattern)
-        .with_context(|| {
-            format!(
-                "While loading testfiles from directory {}",
-                root_directory_str
-            )
-        })?;
+    let testfiles = load_testfiles_from_dir(root_directory, pattern).with_context(|| {
+        format!(
+            "While loading testfiles from directory {}",
+            root_directory_str
+        )
+    })?;
 
     let number_of_tests = testfiles.len();
 


### PR DESCRIPTION
If you invoke `clay test integration-tests`, it no longer
prefixes the test name with the root directory (`integration-tests`
in this case).

Example output:
```
...

(many-to-many/indirect/default-names/create-nested)
 ::  OK

(services-with-auth/with-auth)
 ::  OK

(type-hints/can-build-schema-with-type-hints)
 ::  OK

(json-opaque/query-opaque-json-predicates)
 ::  OK

(date-and-time/query-datetime)
 ::  OK

* Test results: OK. 75 passed out of 75 total in 13 seconds (24 cpus)
```