### PR TITLE
Offer choices for database SSL configuration

### DIFF
--- a/payas-sql/src/sql/database.rs
+++ b/payas-sql/src/sql/database.rs
@@ -115,7 +115,7 @@ impl<'a> Database {
             .map(|env_str| match env_str.parse::<bool>() {
                 Ok(b) => Ok(Some(b)),
                 Err(_) => Err(anyhow!(
-                    "Invalid {} value: {}. It must be set to true or false",
+                    "Invalid {} value: {}. It must be set to 'true' or 'false'",
                     SSL_NO_VERIFY_PARAM,
                     env_str,
                 )),
@@ -124,7 +124,7 @@ impl<'a> Database {
 
         if ssl_method.is_none() && ssl_no_verify == Some(false) {
             bail!(
-                "{} must be set to 'tls' or 'dtls' when {} is set to false",
+                "{} must be set to 'tls' or 'dtls' when {} is set to 'false'",
                 SSL_METHOD_PARAM,
                 SSL_NO_VERIFY_PARAM
             )


### PR DESCRIPTION
Earlier, we always set SSL method to `tls` and SSL verify to `None`,
but this is not enough for some databases (and an overkill for others
such as local database).

We now support two env variable to control these two aspects of SSL
configutation (defauling to no SSL).