### PR TITLE
Fix executeQuery definition in claytip.d.ts

### DIFF
--- a/payas-parser/src/builder/service_skeleton_generator.rs
+++ b/payas-parser/src/builder/service_skeleton_generator.rs
@@ -12,7 +12,7 @@ use crate::{
 // Then, we will have this imported in each generated service code (currently, it suffices to just have it in the same directory as the service code).
 static CLAYTIP_D_TS: &str = r#"
 interface Claytip {
-  executeQuery(query: string, variable?: { [key: string]: any }): Promise<void>;
+  executeQuery(query: string, variable?: { [key: string]: any }): Promise<any>;
 }
 
 interface Operation {


### PR DESCRIPTION
We had it return Promise<void>, when the correct return type is
Promise<any>.

Fixes #355