### PR TITLE
Make 'cargo install --path payas-cli' work

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,7 @@
+# See https://github.com/rust-lang/cargo/issues/5034#issuecomment-1050225208
+# and the comment before that (if we were to restrict the target only to clippy, 
+# caches for clippy and normal build will clobber each other).
+[target.'cfg(all())']
+rustflags = [
+  "-Dclippy::wildcard_imports"
+]

--- a/payas-model/src/model/system.rs
+++ b/payas-model/src/model/system.rs
@@ -1,12 +1,15 @@
 use super::argument::ArgumentParameterType;
 use super::column_id::ColumnId;
 use super::mapped_arena::SerializableSlab;
-use super::order::*;
-use super::predicate::*;
+use super::order::OrderByParameterType;
+use super::predicate::PredicateParameterType;
 use super::service::Script;
 use super::service::ServiceMethod;
 use super::ContextType;
-use super::{mapped_arena::MappedArena, operation::*};
+use super::{
+    mapped_arena::MappedArena,
+    operation::{Mutation, Query},
+};
 
 use crate::sql::PhysicalTable;
 

--- a/payas-model/src/model/types.rs
+++ b/payas-model/src/model/types.rs
@@ -1,7 +1,7 @@
 use super::access::Access;
 use super::mapped_arena::{SerializableSlab, SerializableSlabIndex};
 use super::{column_id::ColumnId, relation::GqlRelation};
-use crate::model::operation::*;
+use crate::model::operation::Query;
 
 use crate::sql::PhysicalTable;
 

--- a/payas-parser/src/builder/order_by_type_builder.rs
+++ b/payas-parser/src/builder/order_by_type_builder.rs
@@ -1,10 +1,11 @@
 use payas_model::model::{
     column_id::ColumnId,
     mapped_arena::{MappedArena, SerializableSlabIndex},
+    order::OrderByParameter,
     order::{OrderByParameterType, OrderByParameterTypeKind},
+    relation::GqlRelation,
+    types::{GqlCompositeType, GqlField, GqlType, GqlTypeKind, GqlTypeModifier},
 };
-
-use payas_model::model::{order::*, relation::GqlRelation, types::*};
 
 use super::{
     resolved_builder::{ResolvedCompositeType, ResolvedCompositeTypeKind, ResolvedType},

--- a/payas-parser/src/builder/predicate_builder.rs
+++ b/payas-parser/src/builder/predicate_builder.rs
@@ -10,7 +10,9 @@ use super::{
     resolved_builder::{ResolvedCompositeType, ResolvedCompositeTypeKind, ResolvedType},
     system_builder::SystemContextBuilding,
 };
-use payas_model::model::predicate::*;
+use payas_model::model::predicate::{
+    PredicateParameter, PredicateParameterType, PredicateParameterTypeKind,
+};
 
 use lazy_static::lazy_static;
 

--- a/payas-parser/src/parser/converter.rs
+++ b/payas-parser/src/parser/converter.rs
@@ -5,7 +5,11 @@ use codemap::Span;
 use tree_sitter::{Node, Tree, TreeCursor};
 
 use super::{sitter_ffi, span_from_node};
-use crate::ast::ast_types::*;
+use crate::ast::ast_types::{
+    AstAnnotation, AstAnnotationParams, AstArgument, AstExpr, AstField, AstFieldDefault,
+    AstFieldDefaultKind, AstFieldType, AstInterceptor, AstMethod, AstModel, AstModelKind,
+    AstService, AstSystem, FieldSelection, Identifier, LogicalOp, RelationalOp, Untyped,
+};
 use crate::error::ParserError;
 
 pub fn parse(input: &str) -> Option<Tree> {

--- a/payas-parser/src/parser/mod.rs
+++ b/payas-parser/src/parser/mod.rs
@@ -4,12 +4,15 @@ use codemap::{CodeMap, Span};
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
 use tree_sitter::Node;
 
-use crate::{ast::ast_types::*, error::ParserError};
+use crate::{
+    ast::ast_types::{AstSystem, Untyped},
+    error::ParserError,
+};
 
 mod converter;
 mod sitter_ffi;
 
-use self::converter::*;
+use self::converter::{convert_root, parse};
 
 pub(crate) const DEFAULT_FN_AUTOINCREMENT: &str = "autoincrement";
 pub(crate) const DEFAULT_FN_CURRENT_TIME: &str = "now";

--- a/payas-parser/src/typechecker/mod.rs
+++ b/payas-parser/src/typechecker/mod.rs
@@ -374,7 +374,7 @@ pub fn build(ast_system: AstSystem<Untyped>) -> Result<MappedArena<Type>, Parser
 #[cfg(test)]
 pub mod test_support {
     use super::*;
-    use crate::parser::*;
+    use crate::parser::parse_str;
 
     pub fn build(src: &str) -> Result<MappedArena<Type>, ParserError> {
         let parsed = parse_str(src, "input.clay")?;
@@ -396,7 +396,7 @@ pub mod test_support {
 
 #[cfg(test)]
 mod tests {
-    use super::test_support::*;
+    use super::test_support::{build, parse_sorted};
 
     #[test]
     fn simple() {

--- a/payas-server/src/data/create_data_param_mapper.rs
+++ b/payas-server/src/data/create_data_param_mapper.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use anyhow::*;
+use anyhow::{anyhow, bail, Context, Result};
 use async_graphql_value::ConstValue;
 use maybe_owned::MaybeOwned;
 

--- a/payas-server/src/data/limit_offset_mapper.rs
+++ b/payas-server/src/data/limit_offset_mapper.rs
@@ -1,7 +1,7 @@
 use crate::execution::query_context::QueryContext;
 
 use super::operation_mapper::SQLMapper;
-use anyhow::*;
+use anyhow::{anyhow, Result};
 use async_graphql_value::ConstValue;
 use payas_model::{
     model::limit_offset::{LimitParameter, OffsetParameter},

--- a/payas-server/src/data/mod.rs
+++ b/payas-server/src/data/mod.rs
@@ -12,7 +12,7 @@ mod update_data_param_mapper;
 
 use predicate_mapper::PredicateParameterMapper;
 
-use anyhow::*;
+use anyhow::{Context, Result};
 use async_graphql_parser::Positioned;
 use async_graphql_value::{ConstValue, Name};
 

--- a/payas-server/src/data/mutation_resolver/mod.rs
+++ b/payas-server/src/data/mutation_resolver/mod.rs
@@ -7,9 +7,15 @@ use crate::{
     sql::{column::Column, predicate::Predicate, Cte, PhysicalTable, SQLOperation},
 };
 
-use anyhow::*;
+use anyhow::{anyhow, bail, Context, Result};
 use payas_model::{
-    model::{operation::*, predicate::PredicateParameter, types::*},
+    model::{
+        operation::{
+            CreateDataParameter, Interceptors, Mutation, MutationKind, Query, UpdateDataParameter,
+        },
+        predicate::PredicateParameter,
+        types::{GqlTypeKind, GqlTypeModifier},
+    },
     sql::{
         transaction::{ConcreteTransactionStep, TransactionScript, TransactionStep},
         Select,

--- a/payas-server/src/data/order_by_mapper.rs
+++ b/payas-server/src/data/order_by_mapper.rs
@@ -1,6 +1,6 @@
 use crate::execution::query_context::QueryContext;
 use crate::sql::order::{OrderBy, Ordering};
-use anyhow::*;
+use anyhow::{bail, Context, Result};
 use async_graphql_value::ConstValue;
 use payas_model::model::order::{OrderByParameter, OrderByParameterType, OrderByParameterTypeKind};
 use payas_model::sql::column::PhysicalColumn;

--- a/payas-server/src/data/predicate_mapper.rs
+++ b/payas-server/src/data/predicate_mapper.rs
@@ -4,12 +4,15 @@ use crate::{
     execution::query_context::QueryContext,
     sql::{column::Column, predicate::Predicate},
 };
-use anyhow::*;
+use anyhow::{bail, Result};
 use async_graphql_value::ConstValue;
 
 use maybe_owned::MaybeOwned;
 use payas_model::{
-    model::{predicate::*, system::ModelSystem},
+    model::{
+        predicate::{ColumnPath, ColumnPathLink, PredicateParameter, PredicateParameterTypeKind},
+        system::ModelSystem,
+    },
     sql::PhysicalTable,
 };
 

--- a/payas-server/src/data/query_resolver/mod.rs
+++ b/payas-server/src/data/query_resolver/mod.rs
@@ -3,10 +3,14 @@ use crate::sql::{column::Column, predicate::Predicate, SQLOperation, Select};
 
 use crate::sql::order::OrderBy;
 
-use anyhow::*;
+use anyhow::{anyhow, bail, Context, Result};
 use maybe_owned::MaybeOwned;
 use payas_model::model::system::ModelSystem;
-use payas_model::model::{operation::*, relation::*, types::*};
+use payas_model::model::{
+    operation::{DatabaseQueryParameter, Interceptors, Query, QueryKind},
+    relation::{GqlRelation, RelationCardinality},
+    types::{GqlTypeKind, GqlTypeModifier},
+};
 use payas_model::sql::transaction::{ConcreteTransactionStep, TransactionScript, TransactionStep};
 use payas_model::sql::{Limit, Offset, TableQuery};
 
@@ -130,7 +134,7 @@ impl<'a> QuerySQLOperations<'a> for Query {
             .iter()
             .flat_map(
                 |selection| match map_selection(self, &selection.node, query_context) {
-                    core::result::Result::Ok(s) => s.into_iter().map(Ok).collect(),
+                    Ok(s) => s.into_iter().map(Ok).collect(),
                     Err(err) => vec![Err(err)],
                 },
             )
@@ -303,7 +307,7 @@ fn map_selection<'a>(
                 .iter()
                 .flat_map(
                     |selection| match map_selection(query, &selection.node, query_context) {
-                        core::result::Result::Ok(s) => s.into_iter().map(Ok).collect(),
+                        Ok(s) => s.into_iter().map(Ok).collect(),
                         Err(err) => vec![Err(err)],
                     },
                 )

--- a/payas-server/src/data/update_data_param_mapper.rs
+++ b/payas-server/src/data/update_data_param_mapper.rs
@@ -1,4 +1,4 @@
-use anyhow::*;
+use anyhow::Result;
 use async_graphql_value::ConstValue;
 use maybe_owned::MaybeOwned;
 

--- a/payas-server/src/execution/executor.rs
+++ b/payas-server/src/execution/executor.rs
@@ -13,7 +13,7 @@ use payas_model::{
     model::{mapped_arena::SerializableSlab, system::ModelSystem, ContextSource, ContextType},
     sql::database::Database,
 };
-use query_context::*;
+use query_context::{QueryContext, QueryResponse};
 use serde_json::{Map, Value};
 use typed_arena::Arena;
 

--- a/payas-server/src/execution/query_context.rs
+++ b/payas-server/src/execution/query_context.rs
@@ -16,7 +16,7 @@ use payas_model::{
     model::{column_id::ColumnId, system::ModelSystem},
     sql::{
         array_util::{self, ArrayEntry},
-        column::*,
+        column::{Column, FloatBits, IntBits, PhysicalColumn, PhysicalColumnType},
         SQLBytes, SQLParam,
     },
 };
@@ -24,9 +24,18 @@ use pg_bigdecimal::{BigDecimal, PgNumeric};
 use serde_json::{Map, Value as JsonValue};
 use typed_arena::Arena;
 
-use super::{executor::Executor, resolver::*};
+use super::{
+    executor::Executor,
+    resolver::{FieldResolver, Resolver},
+};
 
-use crate::{data::data_resolver::DataResolver, error::ExecutionError, introspection::schema::*};
+use crate::{
+    data::data_resolver::DataResolver,
+    error::ExecutionError,
+    introspection::schema::{
+        MUTATION_ROOT_TYPENAME, QUERY_ROOT_TYPENAME, SUBSCRIPTION_ROOT_TYPENAME,
+    },
+};
 
 const NAIVE_DATE_FORMAT: &str = "%Y-%m-%d";
 const NAIVE_TIME_FORMAT: &str = "%H:%M:%S%.f";

--- a/payas-server/src/introspection/definition/operation.rs
+++ b/payas-server/src/introspection/definition/operation.rs
@@ -7,7 +7,7 @@ use payas_model::model::{
     },
     system::ModelSystem,
 };
-use util::*;
+use util::{default_positioned, default_positioned_name};
 
 use super::provider::{FieldDefinitionProvider, InputValueProvider};
 use crate::introspection::util;

--- a/payas-server/src/introspection/definition/parameter.rs
+++ b/payas-server/src/introspection/definition/parameter.rs
@@ -1,4 +1,4 @@
-use crate::introspection::util::*;
+use crate::introspection::util::default_positioned_name;
 use async_graphql_parser::types::InputValueDefinition;
 
 use crate::introspection::util;
@@ -7,7 +7,7 @@ use payas_model::model::{
     argument::ArgumentParameter,
     limit_offset::{LimitParameter, OffsetParameter},
     operation::{CreateDataParameter, UpdateDataParameter},
-    order::*,
+    order::OrderByParameter,
     predicate::PredicateParameter,
     types::GqlField,
     types::GqlTypeModifier,

--- a/payas-server/src/introspection/definition/parameter_type.rs
+++ b/payas-server/src/introspection/definition/parameter_type.rs
@@ -7,12 +7,15 @@ use async_graphql_parser::{
 };
 use async_graphql_value::Name;
 
-use crate::introspection::{definition::type_introspection::TypeDefinitionIntrospection, util::*};
+use crate::introspection::{
+    definition::type_introspection::TypeDefinitionIntrospection,
+    util::{default_positioned, default_positioned_name},
+};
 use payas_model::model::{
     argument::{ArgumentParameter, ArgumentParameterType},
     limit_offset::{LimitParameter, OffsetParameter},
-    order::*,
-    predicate::*,
+    order::{OrderByParameterType, OrderByParameterTypeKind},
+    predicate::{PredicateParameterType, PredicateParameterTypeKind},
     system::ModelSystem,
 };
 

--- a/payas-server/src/introspection/definition/type_definition.rs
+++ b/payas-server/src/introspection/definition/type_definition.rs
@@ -6,11 +6,11 @@ use payas_model::model::{
     operation::{DatabaseQueryParameter, QueryKind},
     relation::GqlRelation,
     system::ModelSystem,
-    types::{GqlField, GqlType, *},
+    types::{GqlCompositeType, GqlField, GqlFieldType, GqlType, GqlTypeKind, GqlTypeModifier},
 };
 
 use super::provider::{FieldDefinitionProvider, TypeDefinitionProvider};
-use crate::introspection::util::*;
+use crate::introspection::util::{default_positioned, default_positioned_name};
 
 impl TypeDefinitionProvider for GqlType {
     fn type_definition(&self, system: &ModelSystem) -> TypeDefinition {

--- a/payas-server/src/introspection/resolver/enum_value_resolver.rs
+++ b/payas-server/src/introspection/resolver/enum_value_resolver.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::execution::query_context::QueryContext;
-use crate::execution::resolver::*;
+use crate::execution::resolver::{FieldResolver, GraphQLExecutionError};
 use anyhow::{anyhow, Result};
 
 #[async_trait(?Send)]

--- a/payas-server/src/introspection/resolver/field_resolver.rs
+++ b/payas-server/src/introspection/resolver/field_resolver.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::execution::query_context::QueryContext;
-use crate::execution::resolver::*;
+use crate::execution::resolver::{FieldResolver, GraphQLExecutionError, Resolver};
 use anyhow::{anyhow, Result};
 
 #[async_trait(?Send)]

--- a/payas-server/src/introspection/resolver/input_value_resolver.rs
+++ b/payas-server/src/introspection/resolver/input_value_resolver.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::execution::query_context::QueryContext;
-use crate::execution::resolver::*;
+use crate::execution::resolver::{FieldResolver, GraphQLExecutionError, Resolver};
 use anyhow::{anyhow, Result};
 
 #[async_trait(?Send)]

--- a/payas-server/src/introspection/resolver/schema_resolver.rs
+++ b/payas-server/src/introspection/resolver/schema_resolver.rs
@@ -1,10 +1,12 @@
-use crate::introspection::schema::*;
+use crate::introspection::schema::{
+    Schema, MUTATION_ROOT_TYPENAME, QUERY_ROOT_TYPENAME, SUBSCRIPTION_ROOT_TYPENAME,
+};
 use async_graphql_parser::{types::Field, Positioned};
 use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::execution::query_context::QueryContext;
-use crate::execution::resolver::*;
+use crate::execution::resolver::{FieldResolver, GraphQLExecutionError, Resolver};
 use anyhow::{anyhow, Result};
 
 #[async_trait(?Send)]

--- a/payas-server/src/introspection/resolver/type_resolver.rs
+++ b/payas-server/src/introspection/resolver/type_resolver.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::execution::query_context::QueryContext;
-use crate::execution::resolver::*;
+use crate::execution::resolver::{FieldResolver, GraphQLExecutionError, Resolver};
 use crate::introspection::definition::type_introspection::TypeDefinitionIntrospection;
 use anyhow::{anyhow, Result};
 

--- a/payas-server/src/introspection/schema.rs
+++ b/payas-server/src/introspection/schema.rs
@@ -2,8 +2,11 @@ use async_graphql_parser::types::{ObjectType, TypeDefinition, TypeKind};
 
 use payas_model::model::system::ModelSystem;
 
-use super::definition::{provider::*, type_introspection::TypeDefinitionIntrospection};
-use crate::introspection::util::*;
+use super::definition::{
+    provider::{FieldDefinitionProvider, TypeDefinitionProvider},
+    type_introspection::TypeDefinitionIntrospection,
+};
+use crate::introspection::util::{default_positioned, default_positioned_name};
 #[derive(Debug, Clone)]
 pub struct Schema {
     pub type_definitions: Vec<TypeDefinition>,

--- a/payas-sql/src/sql/column.rs
+++ b/payas-sql/src/sql/column.rs
@@ -1,8 +1,8 @@
 use crate::spec::{ColumnSpec, SQLStatement};
 
 use super::{
-    select::*, transaction::TransactionStepId, Expression, ExpressionContext, ParameterBinding,
-    SQLParam,
+    select::Select, transaction::TransactionStepId, Expression, ExpressionContext,
+    ParameterBinding, SQLParam,
 };
 use anyhow::{bail, Result};
 use maybe_owned::MaybeOwned;

--- a/payas-test/src/claytest/runner.rs
+++ b/payas-test/src/claytest/runner.rs
@@ -17,7 +17,7 @@ use std::{
 
 use crate::claytest::dbutils::{createdb_psql, dropdb_psql, run_psql};
 use crate::claytest::loader::{ParsedTestfile, TestfileOperation};
-use crate::claytest::model::*;
+use crate::claytest::model::{TestOutput, TestResult, TestfileContext};
 
 use super::{
     assertion::{self, evaluate_using_deno},


### PR DESCRIPTION
This is a bit of puzzle, but without this change,
the `cargo install --path payas-cli` or
`cargo install --path payas-server` fail with a compiler error.

The change in [payas-server/src/data/predicate_mapper.rs](https://github.com/payalabs/payas/pull/370/files#diff-72f041851f2be7f8f5d20f2676462dac33aacbbd9ecc5baa4575f068d3d695f1) is also in the same spirit (if I had provided the full module path for Ok, that works too).