### PR TITLE
Fix a regression in passing headers from GraphiQL

### DIFF
--- a/graphiql/package-lock.json
+++ b/graphiql/package-lock.json
@@ -8,6 +8,7 @@
       "name": "payas-graphiql",
       "version": "0.1.0",
       "dependencies": {
+        "@graphiql/create-fetcher": "^0.1.0",
         "graphiql": "1.8.3",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
@@ -2118,6 +2119,69 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@graphiql/create-fetcher": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@graphiql/create-fetcher/-/create-fetcher-0.1.0.tgz",
+      "integrity": "sha512-qutJsyhvoCgRF82sBE6SlvWQBzSCyrO6qzCsYdLDzVR2J2L9JmuxqmkRp+V4Z5e/bDBNTOrpXe0FQ8gnylbhBg==",
+      "dependencies": {
+        "@graphiql/toolkit": "^0.1.0",
+        "@n1ru4l/push-pull-async-iterable-iterator": "^2.0.1",
+        "graphql-ws": "^4.1.0",
+        "meros": "^1.1.0-beta.2",
+        "subscriptions-transport-ws": "^0.9.18"
+      }
+    },
+    "node_modules/@graphiql/create-fetcher/node_modules/@graphiql/toolkit": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@graphiql/toolkit/-/toolkit-0.1.1.tgz",
+      "integrity": "sha512-cvsuaPkOA6/TZOdqEdvzqr7i+or2STTpSsteyDkrUXrwftRnH9ZfiUwnHPyf0AC2cKMwpP/Dny/UTS6CLC8ZNQ==",
+      "dependencies": {
+        "@n1ru4l/push-pull-async-iterable-iterator": "^2.0.1",
+        "graphql-ws": "^4.1.0",
+        "meros": "^1.1.2",
+        "subscriptions-transport-ws": "^0.9.18"
+      }
+    },
+    "node_modules/@graphiql/create-fetcher/node_modules/@n1ru4l/push-pull-async-iterable-iterator": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@n1ru4l/push-pull-async-iterable-iterator/-/push-pull-async-iterable-iterator-2.1.4.tgz",
+      "integrity": "sha512-qLIvoOUJ+zritv+BlzcBMePKNjKQzH9Rb2i9W98YXxf/M62Lye8qH0peyiU8yJ1tL0kfulWi31BoK10E6BKJeA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@graphiql/create-fetcher/node_modules/eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+    },
+    "node_modules/@graphiql/create-fetcher/node_modules/graphql-ws": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-4.9.0.tgz",
+      "integrity": "sha512-sHkK9+lUm20/BGawNEWNtVAeJzhZeBg21VmvmLoT5NdGVeZWv5PdIhkcayQIAgjSyyQ17WMKmbDijIPG2On+Ag==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=15"
+      }
+    },
+    "node_modules/@graphiql/create-fetcher/node_modules/subscriptions-transport-ws": {
+      "version": "0.9.19",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.19.tgz",
+      "integrity": "sha512-dxdemxFFB0ppCLg10FTtRqH/31FNRL1y1BQv8209MK5I4CwALb7iihQg+7p65lFcIl8MHatINWBLOqpgU4Kyyw==",
+      "deprecated": "The `subscriptions-transport-ws` package is no longer maintained. We recommend you use `graphql-ws` instead. For help migrating Apollo software to `graphql-ws`, see https://www.apollographql.com/docs/apollo-server/data/subscriptions/#switching-from-subscriptions-transport-ws    For general help using `graphql-ws`, see https://github.com/enisdenjo/graphql-ws/blob/master/README.md",
+      "dependencies": {
+        "backo2": "^1.0.2",
+        "eventemitter3": "^3.1.0",
+        "iterall": "^1.2.1",
+        "symbol-observable": "^1.0.4",
+        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.10.0"
       }
     },
     "node_modules/@graphiql/toolkit": {
@@ -8134,12 +8198,12 @@
       }
     },
     "node_modules/graphql": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.3.0.tgz",
-      "integrity": "sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
       "peer": true,
       "engines": {
-        "node": "^12.22.0 || ^14.16.0 || >=16.0.0"
+        "node": ">= 10.x"
       }
     },
     "node_modules/graphql-config": {
@@ -18178,6 +18242,59 @@
         }
       }
     },
+    "@graphiql/create-fetcher": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@graphiql/create-fetcher/-/create-fetcher-0.1.0.tgz",
+      "integrity": "sha512-qutJsyhvoCgRF82sBE6SlvWQBzSCyrO6qzCsYdLDzVR2J2L9JmuxqmkRp+V4Z5e/bDBNTOrpXe0FQ8gnylbhBg==",
+      "requires": {
+        "@graphiql/toolkit": "^0.1.0",
+        "@n1ru4l/push-pull-async-iterable-iterator": "^2.0.1",
+        "graphql-ws": "^4.1.0",
+        "meros": "^1.1.0-beta.2",
+        "subscriptions-transport-ws": "^0.9.18"
+      },
+      "dependencies": {
+        "@graphiql/toolkit": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/@graphiql/toolkit/-/toolkit-0.1.1.tgz",
+          "integrity": "sha512-cvsuaPkOA6/TZOdqEdvzqr7i+or2STTpSsteyDkrUXrwftRnH9ZfiUwnHPyf0AC2cKMwpP/Dny/UTS6CLC8ZNQ==",
+          "requires": {
+            "@n1ru4l/push-pull-async-iterable-iterator": "^2.0.1",
+            "graphql-ws": "^4.1.0",
+            "meros": "^1.1.2",
+            "subscriptions-transport-ws": "^0.9.18"
+          }
+        },
+        "@n1ru4l/push-pull-async-iterable-iterator": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/@n1ru4l/push-pull-async-iterable-iterator/-/push-pull-async-iterable-iterator-2.1.4.tgz",
+          "integrity": "sha512-qLIvoOUJ+zritv+BlzcBMePKNjKQzH9Rb2i9W98YXxf/M62Lye8qH0peyiU8yJ1tL0kfulWi31BoK10E6BKJeA=="
+        },
+        "eventemitter3": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+        },
+        "graphql-ws": {
+          "version": "4.9.0",
+          "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-4.9.0.tgz",
+          "integrity": "sha512-sHkK9+lUm20/BGawNEWNtVAeJzhZeBg21VmvmLoT5NdGVeZWv5PdIhkcayQIAgjSyyQ17WMKmbDijIPG2On+Ag==",
+          "requires": {}
+        },
+        "subscriptions-transport-ws": {
+          "version": "0.9.19",
+          "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.19.tgz",
+          "integrity": "sha512-dxdemxFFB0ppCLg10FTtRqH/31FNRL1y1BQv8209MK5I4CwALb7iihQg+7p65lFcIl8MHatINWBLOqpgU4Kyyw==",
+          "requires": {
+            "backo2": "^1.0.2",
+            "eventemitter3": "^3.1.0",
+            "iterall": "^1.2.1",
+            "symbol-observable": "^1.0.4",
+            "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
+          }
+        }
+      }
+    },
     "@graphiql/toolkit": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@graphiql/toolkit/-/toolkit-0.4.2.tgz",
@@ -22586,9 +22703,9 @@
       }
     },
     "graphql": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.3.0.tgz",
-      "integrity": "sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
       "peer": true
     },
     "graphql-config": {

--- a/graphiql/package.json
+++ b/graphiql/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@graphiql/create-fetcher": "^0.1.0",
     "graphiql": "1.8.3",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/graphiql/src/App.tsx
+++ b/graphiql/src/App.tsx
@@ -1,25 +1,18 @@
 import GraphiQL from 'graphiql';
+import { createGraphiQLFetcher } from '@graphiql/toolkit';
+
 import 'graphiql/graphiql.min.css';
 
 const Logo = () => <img src="/logo.svg" className="logo" alt='Claytip'/>;
 
+const fetcher = createGraphiQLFetcher({
+  url: window.location.origin
+});
+
 const App = () => (
+  
   <GraphiQL tabs 
-    fetcher={async graphQLParams => {
-      const data = await fetch(
-        window.location.origin,
-        {
-          method: 'POST',
-          headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(graphQLParams),
-          credentials: 'same-origin',
-        },
-      );
-      return data.json().catch(() => data.text());
-    }}
+    fetcher={fetcher}
     defaultVariableEditorOpen = {true}
     headerEditorEnabled = {true}
   >

--- a/payas-server-actix/src/request_context/jwt.rs
+++ b/payas-server-actix/src/request_context/jwt.rs
@@ -35,7 +35,7 @@ impl JwtAuthenticator {
         JwtAuthenticator { secret }
     }
 
-    // TODO: Expand to work with extenral authentication providers such as auth0 (that require JWK support)
+    // TODO: Expand to work with external authentication providers such as auth0 (that require JWK support)
     fn validate_jwt(&self, token: &str) -> Result<TokenData<Value>, jsonwebtoken::errors::Error> {
         decode::<Value>(
             token,


### PR DESCRIPTION
During the switch to our own GraphiQL app, we introduced a regression, due to which we did not pass any user-specified headers (such as "Authorization"). We fix it by using the recommended approach of using `createGraphiQLFetcher` from `@graphiql/toolkit`