### PR TITLE
Fix array params to update mutations

### DIFF
--- a/integration-tests/basic-model-no-auth/concerts.clay
+++ b/integration-tests/basic-model-no-auth/concerts.clay
@@ -11,7 +11,7 @@ model Concert {
 model Venue {
   id: Int = autoincrement() @pk
   name: String
-  concerts: Set<Concert> @column("venueid")
+  concerts: Set<Concert>? @column("venueid")
   published: Boolean
   latitude: Float @size(4)
 }

--- a/integration-tests/basic-model-with-auth/concerts-auth.clay
+++ b/integration-tests/basic-model-with-auth/concerts-auth.clay
@@ -17,6 +17,6 @@ model Concert {
 model Venue {
   id: Int = autoincrement() @pk
   name: String
-  concerts: Set<Concert> @column("venueid")
+  concerts: Set<Concert>? @column("venueid")
   published: Boolean
 }

--- a/integration-tests/error-reporting/overly-nested-array-argument.claytest
+++ b/integration-tests/error-reporting/overly-nested-array-argument.claytest
@@ -1,0 +1,21 @@
+# An overly nested data argument
+operation: |
+    mutation {
+      createVenues(data: [[{name: "The Venue", published: true}]]) {
+        id
+      }
+    }
+response: |
+    {
+      "errors": [
+        {
+          "message": "Argument 'data' is not of a valid type. Expected 'VenueCreationInput', got '[VenueCreationInput]'",
+          "locations": [
+            {
+              "line": 2,
+              "column": 22
+            }
+          ]
+        }
+      ]
+    }

--- a/integration-tests/imports/mailing_list.clay
+++ b/integration-tests/imports/mailing_list.clay
@@ -3,5 +3,5 @@ import "users.clay"
 model MailingList {
     id: Int = autoincrement() @pk
     email_address: String
-    subscriptions: Set<UserSubscription> @column("subscribed_mailing_list") 
+    subscriptions: Set<UserSubscription>? @column("subscribed_mailing_list") 
 }

--- a/integration-tests/imports/users.clay
+++ b/integration-tests/imports/users.clay
@@ -3,7 +3,7 @@ import "mailing_list.clay"
 model User {
     id: Int = autoincrement() @pk
     username: String
-    subscribed_lists: Set<UserSubscription> @column("subscribed_user_id")
+    subscribed_lists: Set<UserSubscription>? @column("subscribed_user_id")
 }
 
 model UserSubscription {

--- a/integration-tests/interceptor/concert.clay
+++ b/integration-tests/interceptor/concert.clay
@@ -9,7 +9,7 @@ model Concert {
 model Venue {
   id: Int = autoincrement() @pk
   name: String
-  concerts: Set<Concert> @column("venueid")
+  concerts: Set<Concert>? @column("venueid")
   published: Boolean
   latitude: Float @size(4)
 }

--- a/integration-tests/many-to-many/indirect/custom-names/concert-artists.clay
+++ b/integration-tests/many-to-many/indirect/custom-names/concert-artists.clay
@@ -19,10 +19,10 @@ model ConcertArtist {
 model Artist {
   id: Int = autoincrement() @pk
   name: String
-  aristsConcerts: Set<ConcertArtist> @column("artist_id")
+  aristsConcerts: Set<ConcertArtist>? @column("artist_id") // An artist may yet to participate in a concert, hence optional
 }
 
 model Venue {
   id: Int = autoincrement() @pk
-  concerts: Set<Concert> @column("venue_id")
+  concerts: Set<Concert>? @column("venue_id")
 }

--- a/integration-tests/many-to-many/indirect/custom-names/introspection.claytest
+++ b/integration-tests/many-to-many/indirect/custom-names/introspection.claytest
@@ -24,6 +24,15 @@ operation: |
         name
         ofType {
           name
+          kind
+          ofType {
+            name
+            kind
+            ofType {
+              name
+              kind
+            }
+          }
         }
         kind
       }
@@ -40,9 +49,18 @@ response: |
             "type": {
               "name": null,
               "ofType": {
-                "name": "ConcertArtistCreationInputFromConcert"
+                "name": null,
+                "kind": "LIST",
+                "ofType": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "name": "ConcertArtistCreationInputFromConcert",
+                    "kind": "INPUT_OBJECT"
+                  }
+                }
               },
-              "kind": "LIST"
+              "kind": "NON_NULL"
             }
           },
           {
@@ -50,9 +68,18 @@ response: |
             "type": {
               "name": null,
               "ofType": {
-                "name": "ConcertArtistUpdateInputFromConcertNested"
+                "name": null,
+                "kind": "LIST",
+                "ofType": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "name": "ConcertArtistUpdateInputFromConcertNested",
+                    "kind": "INPUT_OBJECT"
+                  }
+                }
               },
-              "kind": "LIST"
+              "kind": "NON_NULL"
             }
           },
           {
@@ -60,9 +87,18 @@ response: |
             "type": {
               "name": null,
               "ofType": {
-                "name": "ConcertArtistReferenceInput"
+                "name": null,
+                "kind": "LIST",
+                "ofType": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "name": "ConcertArtistReferenceInput",
+                    "kind": "INPUT_OBJECT"
+                  }
+                }
               },
-              "kind": "LIST"
+              "kind": "NON_NULL"
             }
           }
         ]
@@ -75,7 +111,9 @@ response: |
             "type": {
               "name": null,
               "ofType": {
-                "name": "ArtistReferenceInput"
+                "name": "ArtistReferenceInput",
+                "kind": "INPUT_OBJECT",
+                "ofType": null
               },
               "kind": "NON_NULL"
             }
@@ -83,7 +121,6 @@ response: |
           {
             "name": "rank",
             "type": {
-              // fields with default values are never NOT_NULL
               "name": "Int",
               "ofType": null,
               "kind": "SCALAR"
@@ -94,7 +131,9 @@ response: |
             "type": {
               "name": null,
               "ofType": {
-                "name": "String"
+                "name": "String",
+                "kind": "SCALAR",
+                "ofType": null
               },
               "kind": "NON_NULL"
             }
@@ -107,9 +146,13 @@ response: |
           {
             "name": "id",
             "type": {
-              "name": "Int",
-              "ofType": null,
-              "kind": "SCALAR"
+              "name": null,
+              "ofType": {
+                "name": "Int",
+                "kind": "SCALAR",
+                "ofType": null
+              },
+              "kind": "NON_NULL"
             }
           },
           {
@@ -144,9 +187,13 @@ response: |
           {
             "name": "id",
             "type": {
-              "name": "Int",
-              "ofType": null,
-              "kind": "SCALAR"
+              "name": null,
+              "ofType": {
+                "name": "Int",
+                "kind": "SCALAR",
+                "ofType": null
+              },
+              "kind": "NON_NULL"
             }
           }
         ]

--- a/integration-tests/many-to-many/indirect/default-names/concert-artists.clay
+++ b/integration-tests/many-to-many/indirect/default-names/concert-artists.clay
@@ -15,5 +15,5 @@ model ConcertArtist {
 model Artist {
   id: Int = autoincrement() @pk
   name: String
-  concertArtists: Set<ConcertArtist>
+  concertArtists: Set<ConcertArtist>? // An artist may yet to participate in a concert, hence optional
 }

--- a/integration-tests/unique/users.clay
+++ b/integration-tests/unique/users.clay
@@ -11,5 +11,5 @@ model User {
   secondary_email_id: String? @unique("unique_email_secondary")
   email_domain: String @unique("unique_email_primary", "unique_email_secondary")
 
-  rsvps: Set<Rsvp>
+  rsvps: Set<Rsvp>?
 }

--- a/payas-parser/src/builder/update_mutation_builder.rs
+++ b/payas-parser/src/builder/update_mutation_builder.rs
@@ -210,14 +210,14 @@ impl DataParamBuilder<UpdateDataParameter> for UpdateMutationBuilder {
                         "create",
                         create_data_type_name(
                             field.typ.type_name(),
-                            &container_type.map(|t| t.name.as_str()),
+                            container_type.map(|t| t.name.as_str()),
                         ),
                     ),
                     (
                         "update",
                         update_data_type_name(
                             field.typ.type_name(),
-                            &container_type.map(|t| t.name.as_str()),
+                            container_type.map(|t| t.name.as_str()),
                         ) + "Nested",
                     ),
                     ("delete", field.typ.type_name().reference_type()),

--- a/payas-server-core/src/introspection/definition/operation.rs
+++ b/payas-server-core/src/introspection/definition/operation.rs
@@ -91,8 +91,8 @@ impl Operation for Mutation {
     }
 }
 
-// Field defintion for the query such as `venue(id: Int!): Venue`, combining such fields will form
-// the Query, Mutation, and Subscription object defintion
+// Field definition for the query such as `venue(id: Int!): Venue`, combining such fields will form
+// the Query, Mutation, and Subscription object definition
 impl<T: Operation> FieldDefinitionProvider for T {
     fn field_definition(&self, _system: &ModelSystem) -> FieldDefinition {
         let fields = self

--- a/payas-server-core/src/introspection/definition/parameter.rs
+++ b/payas-server-core/src/introspection/definition/parameter.rs
@@ -11,7 +11,6 @@ use payas_model::model::{
     predicate::PredicateParameter,
     types::GqlField,
     types::GqlTypeModifier,
-    GqlFieldType,
 };
 
 use super::provider::InputValueProvider;
@@ -110,30 +109,6 @@ impl Parameter for UpdateDataParameter {
     }
 }
 
-impl Parameter for GqlField {
-    fn name(&self) -> &str {
-        &self.name
-    }
-
-    fn type_name(&self) -> &str {
-        self.typ.type_name()
-    }
-
-    fn type_modifier(&self) -> &GqlTypeModifier {
-        match self.typ {
-            GqlFieldType::Optional(_) => &GqlTypeModifier::Optional,
-            GqlFieldType::Reference { .. } => {
-                if self.has_default_value {
-                    &GqlTypeModifier::Optional
-                } else {
-                    &GqlTypeModifier::NonNull
-                }
-            }
-            GqlFieldType::List(_) => &GqlTypeModifier::List,
-        }
-    }
-}
-
 impl Parameter for ArgumentParameter {
     fn name(&self) -> &str {
         &self.name
@@ -172,4 +147,21 @@ impl<T: Parameter> InputValueProvider for T {
 // TODO: Derive this from the one above
 impl InputValueProvider for &dyn Parameter {
     parameter_input_value_provider!();
+}
+
+// We need to a special case for the GqlField type, so that we can properly
+// created nested types such as Optional(List(List(String))). The blanket impl
+// above will not work for nested types like these.
+impl InputValueProvider for GqlField {
+    fn input_value(&self) -> InputValueDefinition {
+        let field_type = util::default_positioned(util::compute_type(&self.typ));
+
+        InputValueDefinition {
+            description: None,
+            name: default_positioned_name(&self.name),
+            ty: field_type,
+            default_value: None,
+            directives: vec![],
+        }
+    }
 }

--- a/payas-server-core/src/introspection/definition/type_definition.rs
+++ b/payas-server-core/src/introspection/definition/type_definition.rs
@@ -6,7 +6,7 @@ use payas_model::model::{
     operation::{DatabaseQueryParameter, QueryKind},
     relation::GqlRelation,
     system::ModelSystem,
-    types::{GqlCompositeType, GqlField, GqlFieldType, GqlType, GqlTypeKind, GqlTypeModifier},
+    types::{GqlCompositeType, GqlField, GqlType, GqlTypeKind},
 };
 
 use super::provider::{FieldDefinitionProvider, TypeDefinitionProvider};
@@ -57,13 +57,7 @@ impl TypeDefinitionProvider for GqlType {
 
 impl FieldDefinitionProvider for GqlField {
     fn field_definition(&self, system: &ModelSystem) -> FieldDefinition {
-        let type_modifier = match &self.typ {
-            GqlFieldType::Optional(_) => GqlTypeModifier::Optional,
-            GqlFieldType::Reference { .. } => GqlTypeModifier::NonNull,
-            GqlFieldType::List(_) => GqlTypeModifier::List,
-        };
-        let field_type =
-            util::default_positioned(util::value_type(self.typ.type_name(), &type_modifier));
+        let field_type = util::default_positioned(util::compute_type(&self.typ));
 
         let arguments = match self.relation {
             GqlRelation::Pk { .. }

--- a/payas-server-core/src/validation/arguments_validator.rs
+++ b/payas-server-core/src/validation/arguments_validator.rs
@@ -357,20 +357,19 @@ impl<'a> ArgumentValidator<'a> {
                 actual_type: format!("[{name}]"),
                 pos,
             }),
-            BaseType::List(_elem_type) => {
+            BaseType::List(elem_type) => {
                 // Peel off the list type to get the element type
-                let elem_argument_definition = argument_definition;
-                // See https://github.com/payalabs/payas/issues/401
-                // let elem_argument_definition = InputValueDefinition {
-                //     ty: Positioned::new(elem_type.as_ref().clone(), pos),
-                //     ..argument_definition.clone()
-                // };
+
+                let elem_argument_definition = InputValueDefinition {
+                    ty: Positioned::new(elem_type.as_ref().clone(), pos),
+                    ..argument_definition.clone()
+                };
 
                 let validated_elems = elems
                     .iter()
                     .flat_map(|elem| {
                         self.validate_argument(
-                            elem_argument_definition,
+                            &elem_argument_definition,
                             Some(&Positioned::new(elem.clone(), pos)),
                         )
                     })


### PR DESCRIPTION
Update mutations mark every argument as optional. The logic to create `InputValueDefinition` didn't account for underlying types such as Optional(List), marking them as plain type (i.e. without the array designation).

In this commit, we specialize `InputValueProvider for GqlField` to account for nested types. In the process, we found a few issues with the tests (such as `concerts` in Venue should have been marked optional); those tests have been fixed as well. Also noticed and fixed a few issues with building arguments for mutations (especially concerning optonality of a parameter).

An extension of the same logic also created an issue with multidimensional arrays (https://github.com/payalabs/payas/issues/401). That too got fixed with this PR.

Fixes #401