### PR TITLE
Ignore __typename while validating arguments

### DIFF
--- a/integration-tests/basic-model-no-auth/update-with-typename.claytest
+++ b/integration-tests/basic-model-no-auth/update-with-typename.claytest
@@ -1,0 +1,23 @@
+operation: |
+    mutation {
+      updateVenue(id: 1, data: {name: "V1-updated", published: false, __typename: "IGNORED"}) {
+        id
+        name
+        published
+        latitude
+        __typename
+      }
+    }
+response: |
+    {
+      "data": {
+        "updateVenue": {
+          "id": 1,
+          "name": "V1-updated",
+          "published": false,
+          "latitude": 37.7749,
+          "__typename": "Venue"
+        }
+      }
+    }
+    


### PR DESCRIPTION
A few typical usages of GraphQL operations involve taking an old value (typically has the `__typename` attribute while querying--often added by clients such as Apollo for caching purposes), update that value, and then send it as an argument for an update mutation. To support such cases this commit makes `argument_validator` not consider the `__typename` argument as a stray argument.