### PR TITLE
Mark nested create/update/delete args optional

### DIFF
--- a/integration-tests/many-to-many/indirect/custom-names/introspection.claytest
+++ b/integration-tests/many-to-many/indirect/custom-names/introspection.claytest
@@ -50,17 +50,14 @@ response: |
               "name": null,
               "ofType": {
                 "name": null,
-                "kind": "LIST",
+                "kind": "NON_NULL",
                 "ofType": {
-                  "name": null,
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "name": "ConcertArtistCreationInputFromConcert",
-                    "kind": "INPUT_OBJECT"
-                  }
+                  "name": "ConcertArtistCreationInputFromConcert",
+                  "kind": "INPUT_OBJECT",
+                  "ofType": null
                 }
               },
-              "kind": "NON_NULL"
+              "kind": "LIST"
             }
           },
           {
@@ -69,17 +66,14 @@ response: |
               "name": null,
               "ofType": {
                 "name": null,
-                "kind": "LIST",
+                "kind": "NON_NULL",
                 "ofType": {
-                  "name": null,
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "name": "ConcertArtistUpdateInputFromConcertNested",
-                    "kind": "INPUT_OBJECT"
-                  }
+                  "name": "ConcertArtistUpdateInputFromConcertNested",
+                  "kind": "INPUT_OBJECT",
+                  "ofType": null
                 }
               },
-              "kind": "NON_NULL"
+              "kind": "LIST"
             }
           },
           {
@@ -88,17 +82,14 @@ response: |
               "name": null,
               "ofType": {
                 "name": null,
-                "kind": "LIST",
+                "kind": "NON_NULL",
                 "ofType": {
-                  "name": null,
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "name": "ConcertArtistReferenceInput",
-                    "kind": "INPUT_OBJECT"
-                  }
+                  "name": "ConcertArtistReferenceInput",
+                  "kind": "INPUT_OBJECT",
+                  "ofType": null
                 }
               },
-              "kind": "NON_NULL"
+              "kind": "LIST"
             }
           }
         ]

--- a/payas-parser/src/builder/update_mutation_builder.rs
+++ b/payas-parser/src/builder/update_mutation_builder.rs
@@ -232,7 +232,10 @@ impl DataParamBuilder<UpdateDataParameter> for UpdateMutationBuilder {
                         };
                         GqlField {
                             name: String::from(name),
-                            typ: GqlFieldType::List(Box::new(plain_field_type)),
+                            // The nested "create", "update", and "delete" fields are all optional that take multiple values.
+                            typ: GqlFieldType::Optional(Box::new(GqlFieldType::List(Box::new(
+                                plain_field_type,
+                            )))),
                             relation: field.relation.clone(),
                             has_default_value: field.has_default_value,
                         }


### PR DESCRIPTION
All arguments to an update mutation are optional, but we weren't marking the nested create/update/delete arguments as optional. This commit fixes that.