### PR TITLE
Do not create new CodeMaps during model file imports

### DIFF
--- a/payas-parser/src/builder/resolved_builder.rs
+++ b/payas-parser/src/builder/resolved_builder.rs
@@ -1444,6 +1444,8 @@ fn field_cardinality(field_type: &AstFieldType<Typed>) -> Cardinality {
 
 #[cfg(test)]
 mod tests {
+    use codemap::CodeMap;
+
     use super::*;
     use crate::{parser, typechecker};
     use std::fs::File;
@@ -1700,7 +1702,8 @@ mod tests {
     }
 
     fn create_resolved_system(src: &str) -> Result<ResolvedSystem, ParserError> {
-        let parsed = parser::parse_str(src, "input.clay")?;
+        let mut codemap = CodeMap::new();
+        let parsed = parser::parse_str(src, &mut codemap, "input.clay")?;
         let types = typechecker::build(parsed)?;
         build(types)
     }

--- a/payas-parser/src/builder/system_builder.rs
+++ b/payas-parser/src/builder/system_builder.rs
@@ -140,6 +140,7 @@ pub struct SystemContextBuilding {
 
 #[cfg(test)]
 mod tests {
+    use codemap::CodeMap;
     use payas_model::model::mapped_arena::SerializableSlab;
     use payas_sql::{FloatBits, IntBits, PhysicalColumn, PhysicalColumnType};
 
@@ -360,7 +361,8 @@ mod tests {
     }
 
     fn create_system(src: &str) -> ModelSystem {
-        let parsed = parser::parse_str(src, "input.clay").unwrap();
+        let mut codemap = CodeMap::new();
+        let parsed = parser::parse_str(src, &mut codemap, "input.clay").unwrap();
         build(parsed).unwrap()
     }
 }

--- a/payas-parser/src/lib.rs
+++ b/payas-parser/src/lib.rs
@@ -20,11 +20,11 @@ pub fn build_system(model_file: impl AsRef<Path>) -> Result<ModelSystem, ParserE
         model_file.as_ref().to_str().unwrap().to_string(),
         file_content,
     );
-    let mut emitter = Emitter::stderr(ColorConfig::Always, Some(&codemap));
 
-    parser::parse_file(&model_file)
+    parser::parse_file(&model_file, &mut codemap)
         .and_then(builder::build)
         .map_err(|err| {
+            let mut emitter = Emitter::stderr(ColorConfig::Always, Some(&codemap));
             if let ParserError::Diagnosis(err) = err {
                 emitter.emit(&err);
                 ParserError::Generic("Failed to parse input file".to_string())
@@ -42,11 +42,12 @@ pub fn build_system_from_str(
 ) -> Result<ModelSystem, ParserError> {
     let mut codemap = CodeMap::new();
     codemap.add_file(file_name.clone(), model_str.to_string());
-    let mut emitter = Emitter::stderr(ColorConfig::Always, Some(&codemap));
 
-    parser::parse_str(model_str, &file_name)
+    parser::parse_str(model_str, &mut codemap, &file_name)
         .and_then(builder::build)
         .map_err(|err| {
+            let mut emitter = Emitter::stderr(ColorConfig::Always, Some(&codemap));
+
             if let ParserError::Diagnosis(err) = err {
                 emitter.emit(&err);
                 ParserError::Generic("Failed to parse input file".to_string())

--- a/payas-parser/src/typechecker/mod.rs
+++ b/payas-parser/src/typechecker/mod.rs
@@ -409,11 +409,14 @@ pub fn build(ast_system: AstSystem<Untyped>) -> Result<MappedArena<Type>, Parser
 
 #[cfg(test)]
 pub mod test_support {
+    use codemap::CodeMap;
+
     use super::*;
     use crate::parser::parse_str;
 
     pub fn build(src: &str) -> Result<MappedArena<Type>, ParserError> {
-        let parsed = parse_str(src, "input.clay")?;
+        let mut codemap = CodeMap::new();
+        let parsed = parse_str(src, &mut codemap, "input.clay")?;
         super::build(parsed)
     }
 


### PR DESCRIPTION
When importing `.clay` files, `codemap` will panic when it encounters an error during the parsing of imported files due to spans referring to different instances of `CodeMap`s. This PR makes all parsing use one canonical `CodeMap`. 