### PR TITLE
Use underlying type of column reference for casting

### DIFF
--- a/payas-server-core/src/execution/operations_context.rs
+++ b/payas-server-core/src/execution/operations_context.rs
@@ -288,6 +288,10 @@ fn cast_string(string: &str, destination_type: &PhysicalColumnType) -> Result<Bo
 
         PhysicalColumnType::Array { typ } => cast_string(string, typ)?,
 
+        PhysicalColumnType::ColumnReference { ref_pk_type, .. } => {
+            cast_string(string, ref_pk_type)?
+        }
+
         _ => Box::new(string.to_owned()),
     };
 


### PR DESCRIPTION
Strings should be casted to the underlying type of column references.