### PR TITLE
Share argument sequencing logic between interceptors and query execution

### DIFF
--- a/payas-model/src/model/interceptor.rs
+++ b/payas-model/src/model/interceptor.rs
@@ -1,21 +1,16 @@
 use serde::{Deserialize, Serialize};
 
-use super::{mapped_arena::SerializableSlabIndex, service::Script, GqlType, GqlTypeModifier};
+use super::{
+    mapped_arena::SerializableSlabIndex,
+    service::{Argument, Script},
+};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Interceptor {
     pub name: String,
     pub script: SerializableSlabIndex<Script>,
     pub interceptor_kind: InterceptorKind,
-    pub arguments: Vec<InterceptorArgument>,
-}
-
-// TODO: Could this be an enum, since we accept only a fixed set of arguments (such as `Operation`)
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct InterceptorArgument {
-    pub name: String,
-    pub type_id: SerializableSlabIndex<GqlType>,
-    pub modifier: GqlTypeModifier,
+    pub arguments: Vec<Argument>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/payas-parser/src/builder/service_builder.rs
+++ b/payas-parser/src/builder/service_builder.rs
@@ -1,7 +1,7 @@
 use payas_model::model::{
     access::Access,
     argument::ArgumentParameter,
-    interceptor::{Interceptor, InterceptorArgument, InterceptorKind},
+    interceptor::{Interceptor, InterceptorKind},
     mapped_arena::{MappedArena, SerializableSlabIndex},
     operation::{Interceptors, Mutation, MutationKind, OperationReturnType, Query, QueryKind},
     service::{Argument, Script, ServiceMethod, ServiceMethodType},
@@ -244,13 +244,14 @@ pub fn create_shallow_intercetor(
             arguments: resolved_interceptor
                 .arguments
                 .iter()
-                .map(|arg| InterceptorArgument {
+                .map(|arg| Argument {
                     name: arg.name.clone(),
                     type_id: building
                         .types
                         .get_id(arg.typ.get_underlying_typename())
                         .unwrap(),
                     modifier: arg.typ.get_modifier(),
+                    is_injected: true, // implicitly set is_injected for interceptors
                 })
                 .collect(),
         },


### PR DESCRIPTION
`Argument` and `InterceptorArgument` are similar concepts enough to merge into one, allowing us to share the argument sequencing logic between them (finally allowing usage of contexts in interceptors, for instance). 