### PR TITLE
Emit a proper error instead of panics in typechecker

### DIFF
--- a/payas-parser/src/ast/ast_types.rs
+++ b/payas-parser/src/ast/ast_types.rs
@@ -69,6 +69,10 @@ pub struct AstService<T: NodeTypedness> {
     pub interceptors: Vec<AstInterceptor<T>>,
     pub annotations: T::Annotations,
     pub base_clayfile: PathBuf,
+    #[serde(skip_serializing)]
+    #[serde(skip_deserializing)]
+    #[serde(default = "default_span")]
+    pub span: Span,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/payas-parser/src/parser/converter.rs
+++ b/payas-parser/src/parser/converter.rs
@@ -184,6 +184,7 @@ fn convert_service(
             .map(|c| convert_annotation(c, source, source_span))
             .collect(),
         base_clayfile: filepath.into(),
+        span: span_from_node(source_span, node),
     }
 }
 

--- a/payas-parser/src/typechecker/service.rs
+++ b/payas-parser/src/typechecker/service.rs
@@ -27,6 +27,7 @@ impl TypecheckFrom<AstService<Untyped>> for AstService<Typed> {
             interceptors: typed(&untyped.interceptors),
             annotations: annotation_map,
             base_clayfile: untyped.base_clayfile.clone(),
+            span: untyped.span,
         }
     }
 


### PR DESCRIPTION
This takes care of two panics when a composite model is expected,
but a non-composite model is found and when a service is expected,
but some other type is found.