### PR TITLE
Print a clearer error message when the port is already in use

### DIFF
--- a/payas-server-actix/src/main.rs
+++ b/payas-server-actix/src/main.rs
@@ -21,7 +21,7 @@ async fn main() -> std::io::Result<()> {
     let subscriber_name = claypot_file.trim_end_matches(".claypot");
     telemetry::init(subscriber_name);
 
-    let operations_executor = web::Data::new(create_operations_executor(&claypot_file));
+    let operations_executor = web::Data::new(create_operations_executor(&claypot_file).unwrap());
     let request_context_processor = web::Data::new(ActixRequestContextProducer::new());
 
     let server_port = env::var("CLAY_SERVER_PORT")


### PR DESCRIPTION
Earlier, we used to issue error such as:
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 48, kind: AddrInUse, message: "Address already in use" }', payas-server-actix/src/main.rs:50:6
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Now we give a clearer error in this case (and avoid the default error message produced by `Result::unwrap()`):
```
Error: Port 9876 is already in use. Check if there is another process running at that port
```