### PR TITLE
Support optional --port argument to clay

### DIFF
--- a/payas-cli/src/commands/serve.rs
+++ b/payas-cli/src/commands/serve.rs
@@ -11,6 +11,7 @@ use super::command::Command;
 /// Run local claytip server
 pub struct ServeCommand {
     pub model: PathBuf,
+    pub port: Option<u32>,
 }
 
 impl Command for ServeCommand {
@@ -36,10 +37,12 @@ impl Command for ServeCommand {
 
         let start_server = || {
             super::build::build(&self.model, None, false).and_then(|_| {
-                std::process::Command::new(&server_binary)
-                    .args(vec![&claypot_file_name])
-                    .spawn()
-                    .context("Failed to start clay-server")
+                let mut command = std::process::Command::new(&server_binary);
+                command.args(vec![&claypot_file_name]);
+                if let Some(port) = self.port {
+                    command.env("CLAY_SERVER_PORT", port.to_string());
+                }
+                command.spawn().context("Failed to start clay-server")
             })
         };
 

--- a/payas-cli/src/main.rs
+++ b/payas-cli/src/main.rs
@@ -98,12 +98,22 @@ fn main() -> Result<()> {
                 ),
         )
         .subcommand(
-            Command::new("serve").about("Run local claytip server").arg(
-                Arg::new("model")
-                    .help("Claytip model file")
-                    .default_value(DEFAULT_MODEL_FILE)
-                    .index(1),
-            ),
+            Command::new("serve")
+                .about("Run local claytip server")
+                .arg(
+                    Arg::new("model")
+                        .help("Claytip model file")
+                        .default_value(DEFAULT_MODEL_FILE)
+                        .index(1),
+                )
+                .arg(
+                    Arg::new("port")
+                        .help("Port to start the server")
+                        .short('p')
+                        .long("port")
+                        .takes_value(true)
+                        .value_name("port"),
+                ),
         )
         .subcommand(
             Command::new("test")
@@ -161,6 +171,16 @@ fn main() -> Result<()> {
 
         Some(("serve", matches)) => Box::new(ServeCommand {
             model: PathBuf::from(matches.value_of("model").unwrap()),
+            port: {
+                let port_str = matches.value_of("port");
+                port_str.map(|port_str| match port_str.parse() {
+                    Ok(port) => port,
+                    Err(_) => {
+                        eprintln!("Invalid port number '{port_str}'");
+                        std::process::exit(1);
+                    }
+                })
+            },
         }),
         Some(("test", matches)) => Box::new(TestCommand {
             dir: PathBuf::from(matches.value_of("dir").unwrap()),


### PR DESCRIPTION
This allows an easy way to run multiple clay instances on the same machine during development.

Note: In production (using 'clay-server') specifying the port through the CLAY_SERVER_PORT env remains the same.