### PR TITLE
Make "import" and "migrate" subcommands of "schema"

### DIFF
--- a/payas-cli/src/commands/migrate.rs
+++ b/payas-cli/src/commands/migrate.rs
@@ -11,6 +11,6 @@ pub struct MigrateCommand {
 
 impl Command for MigrateCommand {
     fn run(&self, _system_start_time: Option<SystemTime>) -> Result<()> {
-        todo!("Implmement migrate command");
+        todo!("Implement migrate command");
     }
 }

--- a/payas-cli/src/commands/schema.rs
+++ b/payas-cli/src/commands/schema.rs
@@ -30,6 +30,6 @@ pub struct VerifyCommand {
 
 impl Command for VerifyCommand {
     fn run(&self, _system_start_time: Option<SystemTime>) -> Result<()> {
-        todo!("Implmement verify command");
+        todo!("Implement verify command");
     }
 }

--- a/payas-cli/src/main.rs
+++ b/payas-cli/src/main.rs
@@ -31,41 +31,6 @@ fn main() -> Result<()> {
                 ),
         )
         .subcommand(
-            Command::new("migrate")
-                .about("Perform a database migration for a claytip model")
-                .arg(
-                    Arg::new("model")
-                        .help("Claytip model file")
-                        .required(true)
-                        .index(1),
-                )
-                .arg(
-                    Arg::new("database")
-                        .help("Database source (postgres, git)")
-                        .required(true)
-                        .index(2),
-                ),
-        )
-        .subcommand(
-            Command::new("model")
-                .about("Claytip model utilities")
-                .subcommand_required(true)
-                .arg_required_else_help(true)
-                .subcommand(
-                    Command::new("import")
-                        .about("Create claytip model file based on a database schema")
-                        .arg(
-                            Arg::new("output")
-                                .help("Claytip model output file")
-                                .short('o')
-                                .long("output")
-                                .takes_value(true)
-                                .value_name("output")
-                                .default_value(DEFAULT_MODEL_FILE),
-                        ),
-                ),
-        )
-        .subcommand(
             Command::new("schema")
                 .about("Database schema utilities")
                 .subcommand_required(true)
@@ -94,6 +59,35 @@ fn main() -> Result<()> {
                                 .help("Database schema source (postgres, git)")
                                 .required(true)
                                 .index(2),
+                        ),
+                )
+                .subcommand(
+                    Command::new("migrate")
+                        .about("Perform a database migration for a claytip model")
+                        .arg(
+                            Arg::new("model")
+                                .help("Claytip model file")
+                                .required(true)
+                                .index(1),
+                        )
+                        .arg(
+                            Arg::new("database")
+                                .help("Database source (postgres, git)")
+                                .required(true)
+                                .index(2),
+                        ),
+                )
+                .subcommand(
+                    Command::new("import")
+                        .about("Create claytip model file based on a database schema")
+                        .arg(
+                            Arg::new("output")
+                                .help("Claytip model output file")
+                                .short('o')
+                                .long("output")
+                                .takes_value(true)
+                                .value_name("output")
+                                .default_value(DEFAULT_MODEL_FILE),
                         ),
                 ),
         )
@@ -153,16 +147,6 @@ fn main() -> Result<()> {
         Some(("build", matches)) => Box::new(BuildCommand {
             model: get_path(matches, "model"),
         }),
-        Some(("migrate", matches)) => Box::new(MigrateCommand {
-            model: get_path(matches, "model"),
-            database: matches.get_one::<String>("database").unwrap().to_owned(),
-        }),
-        Some(("model", matches)) => match matches.subcommand() {
-            Some(("import", matches)) => Box::new(import::ImportCommand {
-                output: get_path(matches, "output"),
-            }),
-            _ => panic!("Unhandled command name"),
-        },
         Some(("schema", matches)) => match matches.subcommand() {
             Some(("create", matches)) => Box::new(schema::CreateCommand {
                 model: get_path(matches, "model"),
@@ -171,9 +155,15 @@ fn main() -> Result<()> {
                 model: get_path(matches, "model"),
                 database: matches.get_one::<String>("database").unwrap().to_owned(),
             }),
+            Some(("import", matches)) => Box::new(import::ImportCommand {
+                output: get_path(matches, "output"),
+            }),
+            Some(("migrate", matches)) => Box::new(MigrateCommand {
+                model: get_path(matches, "model"),
+                database: matches.get_one::<String>("database").unwrap().to_owned(),
+            }),
             _ => panic!("Unhandled command name"),
         },
-
         Some(("serve", matches)) => Box::new(ServeCommand {
             model: get_path(matches, "model"),
             port: matches.get_one::<u32>("port").copied(),


### PR DESCRIPTION
This keeps all schema-related commands in one place.

Fixes #438