### PR TITLE
Ensure that the imported path is a file

### DIFF
--- a/integration-tests/imports/mailing_list.clay
+++ b/integration-tests/imports/mailing_list.clay
@@ -1,4 +1,4 @@
-import "users.clay"
+import "users/users.clay"
 
 model MailingList {
     id: Int = autoincrement() @pk

--- a/integration-tests/imports/root.clay
+++ b/integration-tests/imports/root.clay
@@ -1,2 +1,2 @@
 import "mailing_list.clay"
-import "users.clay"
+import "users/users" // An example of imported file in a directory and importing without providing the "clay" extension.

--- a/integration-tests/imports/users/users.clay
+++ b/integration-tests/imports/users/users.clay
@@ -1,4 +1,4 @@
-import "mailing_list.clay"
+import "../mailing_list.clay"
 
 model User {
     id: Int = autoincrement() @pk

--- a/payas-parser/src/parser/converter.rs
+++ b/payas-parser/src/parser/converter.rs
@@ -82,16 +82,16 @@ pub fn convert_root(
                         }
 
                         match import_path.canonicalize() {
-                            Ok(path) => Ok(Some(path)),
-                            Err(_) => {
+                            Ok(path) if path.is_file() => Ok(Some(path)),
+                            _ => {
                                 // If no extension is given, try if a file with the same name but with ".clay" extension exists.
                                 if import_path.extension() == Some(OsStr::new("clay")) {
                                     Err(compute_diagnosis(import_path, source_span, first_child))
                                 } else {
                                     let with_extension = import_path.with_extension("clay");
                                     match with_extension.canonicalize() {
-                                        Ok(path) => Ok(Some(path)),
-                                        Err(_) => Err(compute_diagnosis(
+                                        Ok(path) if path.is_file() => Ok(Some(path)),
+                                        _ => Err(compute_diagnosis(
                                             with_extension,
                                             source_span,
                                             first_child,


### PR DESCRIPTION
Our check for existance of the imported file did not account for matching the directory name. In those cases, we didn't report the expected user. This change checks if the imported path is a file.

Also adjust import tests to check for imports from a directory.