### PR TITLE
Namespace default unique constraint name under model

### DIFF
--- a/payas-cli/src/commands/schema/migration_helper.rs
+++ b/payas-cli/src/commands/schema/migration_helper.rs
@@ -328,7 +328,7 @@ mod tests {
                     false,
                 ),
                 (
-                    r#"ALTER TABLE "memberships" ADD CONSTRAINT "unique_constraint_user" UNIQUE ("user_id");"#,
+                    r#"ALTER TABLE "memberships" ADD CONSTRAINT "unique_constraint_membership_user" UNIQUE ("user_id");"#,
                     false,
                 ),
             ],
@@ -338,7 +338,7 @@ mod tests {
                     false,
                 ),
                 (
-                    r#"ALTER TABLE "memberships" ADD CONSTRAINT "unique_constraint_user" UNIQUE (user_id);"#,
+                    r#"ALTER TABLE "memberships" ADD CONSTRAINT "unique_constraint_membership_user" UNIQUE (user_id);"#,
                     false,
                 ),
                 (
@@ -349,7 +349,7 @@ mod tests {
             vec![
                 (r#"ALTER TABLE "memberships" DROP COLUMN "user_id";"#, true),
                 (
-                    r#"ALTER TABLE "memberships" DROP CONSTRAINT "unique_constraint_user";"#,
+                    r#"ALTER TABLE "memberships" DROP CONSTRAINT "unique_constraint_membership_user";"#,
                     false,
                 ),
             ],

--- a/payas-parser/src/builder/resolved_builder.rs
+++ b/payas-parser/src/builder/resolved_builder.rs
@@ -1120,7 +1120,9 @@ fn compute_column_info(
                 .unwrap_or_else(|| field_name.to_snake_case())
         };
 
-        let unique_constraint_computed_name = format!("unique_constraint_{}", field.name);
+        let unique_constraint_computed_name =
+            format!("unique_constraint_{}_{}", enclosing_type.name, field.name)
+                .to_ascii_lowercase();
         let unique_constraints = field
             .annotations
             .get("unique")


### PR DESCRIPTION
Previously, when two fields had the same name (but were in different tables), the generated constraint names for both collided.