### PR TITLE
Give a cleaner error when model file is not found during `yolo`

### DIFF
--- a/payas-cli/src/util/watcher.rs
+++ b/payas-cli/src/util/watcher.rs
@@ -23,10 +23,15 @@ pub fn start_watcher<F>(
 where
     F: Fn() -> Result<()>,
 {
-    let absolute_path = model_path.canonicalize()?;
-    let parent_dir = absolute_path
-        .parent()
-        .ok_or_else(|| anyhow!("Could not get parent directory"))?;
+    let absolute_path = model_path
+        .canonicalize()
+        .map_err(|e| anyhow!("Could not find {}: {}", model_path.to_string_lossy(), e))?;
+    let parent_dir = absolute_path.parent().ok_or_else(|| {
+        anyhow!(
+            "Could not get parent directory of {}",
+            model_path.to_string_lossy()
+        )
+    })?;
 
     println!("Watching: {:?}", &parent_dir);
     let (tx, rx) = channel();


### PR DESCRIPTION
```
$ clay yolo does-not-exist.clay
Starting PostgreSQL docker...
Cleaning up container...
Error: No such file or directory (os error 2)
```