### PR TITLE
Cleanup of generic resolver code

### DIFF
--- a/payas-server-core/src/graphql/execution/system_context.rs
+++ b/payas-server-core/src/graphql/execution/system_context.rs
@@ -36,19 +36,19 @@ pub struct SystemContext {
 impl SystemContext {
     /// Resolve the provided top-level operation.
     ///
-    /// Goes through the FieldResolver for ValidatedOperation (thus through the generic support offered by Resolver) and
+    /// Goes through the FieldResolver for ValidatedOperation (and thus get free support for `resolve_fields`)
     /// so that we can support fragments in top-level queries in such as:
-
+    ///
     /// ```graphql
     /// {
     ///   ...query_info
     /// }
-
+    ///
     /// fragment query_info on Query {
     ///   __type(name: "Concert") {
     ///     name
     ///   }
-
+    ///
     ///   __schema {
     ///       types {
     ///       name

--- a/payas-server-core/src/graphql/introspection/resolver/field_resolver.rs
+++ b/payas-server-core/src/graphql/introspection/resolver/field_resolver.rs
@@ -2,10 +2,12 @@ use async_graphql_parser::types::FieldDefinition;
 use async_trait::async_trait;
 use serde_json::Value;
 
-use crate::graphql::execution::resolver::{FieldResolver, Resolver};
+use crate::graphql::execution::resolver::FieldResolver;
 use crate::graphql::execution_error::ExecutionError;
 use crate::graphql::request_context::RequestContext;
 use crate::graphql::{execution::system_context::SystemContext, validation::field::ValidatedField};
+
+use super::resolver_support::Resolver;
 
 #[async_trait]
 impl FieldResolver<Value> for FieldDefinition {

--- a/payas-server-core/src/graphql/introspection/resolver/input_value_resolver.rs
+++ b/payas-server-core/src/graphql/introspection/resolver/input_value_resolver.rs
@@ -2,10 +2,12 @@ use async_graphql_parser::types::InputValueDefinition;
 use async_trait::async_trait;
 use serde_json::Value;
 
-use crate::graphql::execution::resolver::{FieldResolver, Resolver};
+use crate::graphql::execution::resolver::FieldResolver;
 use crate::graphql::execution_error::ExecutionError;
 use crate::graphql::request_context::RequestContext;
 use crate::graphql::{execution::system_context::SystemContext, validation::field::ValidatedField};
+
+use super::resolver_support::Resolver;
 
 #[async_trait]
 impl FieldResolver<Value> for InputValueDefinition {

--- a/payas-server-core/src/graphql/introspection/resolver/mod.rs
+++ b/payas-server-core/src/graphql/introspection/resolver/mod.rs
@@ -2,6 +2,7 @@ mod directive_resolver;
 mod enum_value_resolver;
 mod field_resolver;
 mod input_value_resolver;
+mod resolver_support;
 pub mod root_resolver;
 mod schema_resolver;
 mod type_resolver;

--- a/payas-server-core/src/graphql/introspection/resolver/resolver_support.rs
+++ b/payas-server-core/src/graphql/introspection/resolver/resolver_support.rs
@@ -1,0 +1,101 @@
+use async_graphql_parser::Positioned;
+use async_trait::async_trait;
+use futures::StreamExt;
+use serde_json::Value;
+
+use crate::{
+    graphql::{
+        execution::resolver::FieldResolver, execution_error::ExecutionError,
+        validation::field::ValidatedField,
+    },
+    request_context::RequestContext,
+    SystemContext,
+};
+
+#[async_trait]
+pub(super) trait Resolver {
+    async fn resolve_value<'e>(
+        &self,
+        fields: &'e [ValidatedField],
+        system_context: &'e SystemContext,
+        request_context: &'e RequestContext<'e>,
+    ) -> Result<Value, ExecutionError>;
+}
+
+#[async_trait]
+impl<T> Resolver for Vec<T>
+where
+    T: Resolver + std::fmt::Debug + Send + Sync,
+{
+    async fn resolve_value<'e>(
+        &self,
+        fields: &'e [ValidatedField],
+        system_context: &'e SystemContext,
+        request_context: &'e RequestContext<'e>,
+    ) -> Result<Value, ExecutionError> {
+        let resolved: Vec<_> = futures::stream::iter(self.iter())
+            .then(|elem| elem.resolve_value(fields, system_context, request_context))
+            .collect()
+            .await;
+
+        let resolved: Result<Vec<Value>, ExecutionError> = resolved.into_iter().collect();
+
+        Ok(Value::Array(resolved?))
+    }
+}
+
+#[async_trait]
+impl<T> Resolver for T
+where
+    T: FieldResolver<Value> + std::fmt::Debug + Send + Sync,
+{
+    async fn resolve_value<'e>(
+        &self,
+        fields: &'e [ValidatedField],
+        system_context: &'e SystemContext,
+        request_context: &'e RequestContext<'e>,
+    ) -> Result<Value, ExecutionError> {
+        Ok(Value::Object(FromIterator::from_iter(
+            self.resolve_fields(fields, system_context, request_context)
+                .await?,
+        )))
+    }
+}
+
+#[async_trait]
+impl<T> Resolver for Positioned<T>
+where
+    T: Resolver + std::fmt::Debug + Send + Sync,
+{
+    async fn resolve_value<'e>(
+        &self,
+        fields: &'e [ValidatedField],
+        system_context: &'e SystemContext,
+        request_context: &'e RequestContext<'e>,
+    ) -> Result<Value, ExecutionError> {
+        self.node
+            .resolve_value(fields, system_context, request_context)
+            .await
+    }
+}
+
+#[async_trait]
+impl<T> Resolver for Option<&T>
+where
+    T: Resolver + std::fmt::Debug + Send + Sync,
+{
+    async fn resolve_value<'e>(
+        &self,
+        fields: &'e [ValidatedField],
+        system_context: &'e SystemContext,
+        request_context: &'e RequestContext<'e>,
+    ) -> Result<Value, ExecutionError> {
+        match self {
+            Some(elem) => {
+                elem.resolve_value(fields, system_context, request_context)
+                    .await
+            }
+            None => Ok(Value::Null),
+        }
+    }
+}

--- a/payas-server-core/src/graphql/introspection/resolver/root_resolver.rs
+++ b/payas-server-core/src/graphql/introspection/resolver/root_resolver.rs
@@ -1,6 +1,6 @@
 use crate::graphql::execution_error::ExecutionError;
 
-use crate::graphql::execution::resolver::{FieldResolver, Resolver};
+use crate::graphql::execution::resolver::FieldResolver;
 use crate::graphql::execution::system_context::SystemContext;
 use crate::graphql::introspection::definition::root_element::IntrospectionRootElement;
 use crate::graphql::introspection::schema::{
@@ -12,6 +12,8 @@ use async_graphql_parser::types::{BaseType, OperationType, Type};
 use async_graphql_value::{ConstValue, Name};
 use async_trait::async_trait;
 use serde_json::Value;
+
+use super::resolver_support::Resolver;
 
 #[async_trait]
 impl<'a> FieldResolver<Value> for IntrospectionRootElement<'a> {

--- a/payas-server-core/src/graphql/introspection/resolver/schema_resolver.rs
+++ b/payas-server-core/src/graphql/introspection/resolver/schema_resolver.rs
@@ -7,8 +7,10 @@ use crate::graphql::validation::field::ValidatedField;
 use async_trait::async_trait;
 use serde_json::Value;
 
-use crate::graphql::execution::resolver::{FieldResolver, Resolver};
+use crate::graphql::execution::resolver::FieldResolver;
 use crate::graphql::execution::system_context::SystemContext;
+
+use super::resolver_support::Resolver;
 
 #[async_trait]
 impl FieldResolver<Value> for Schema {

--- a/payas-server-core/src/graphql/introspection/resolver/type_resolver.rs
+++ b/payas-server-core/src/graphql/introspection/resolver/type_resolver.rs
@@ -2,11 +2,13 @@ use async_graphql_parser::types::{BaseType, Type, TypeDefinition};
 use async_trait::async_trait;
 use serde_json::Value;
 
-use crate::graphql::execution::resolver::{FieldResolver, Resolver};
+use crate::graphql::execution::resolver::FieldResolver;
 use crate::graphql::execution_error::ExecutionError;
 use crate::graphql::introspection::definition::type_introspection::TypeDefinitionIntrospection;
 use crate::graphql::request_context::RequestContext;
 use crate::graphql::{execution::system_context::SystemContext, validation::field::ValidatedField};
+
+use super::resolver_support::Resolver;
 
 #[derive(Debug)]
 struct BoxedType<'a> {


### PR DESCRIPTION
- Move `Resolver` and its blanket implementations to where they are
  needed: the introspection submodule.
- Remove the generic parameter from `Resolver` (and fix it to `Value`).