### PR TITLE
Handle explicit errors thrown by async Deno functions

### DIFF
--- a/integration-tests/services-basic/arithmetic.clay
+++ b/integration-tests/services-basic/arithmetic.clay
@@ -25,6 +25,7 @@ service MathService {
 
     export query add(x: Int, y: Int): Int
     export query divide(x: Int, y: Int): DivisionResult
+    export query asyncDivide(x: Int, y: Int): DivisionResult
     export query currentUnixEpoch(): Int
 
     export query shimQuery(@inject claytip: Claytip): Int 

--- a/integration-tests/services-basic/arithmetic.js
+++ b/integration-tests/services-basic/arithmetic.js
@@ -16,6 +16,10 @@ export function divide(x, y) {
     }
 }
 
+export async function asyncDivide(x, y) {
+    return divide(x, y);
+}
+
 export function currentUnixEpoch() {
     return Math.floor(Date.now() / 1000)
 }

--- a/integration-tests/services-basic/exceptions_async.claytest
+++ b/integration-tests/services-basic/exceptions_async.claytest
@@ -1,0 +1,15 @@
+operation: |
+    query Foo {
+      asyncDivide(x: 10, y: 0) {
+        quotient
+        remainder
+      }
+    }
+response: |
+    {
+      "errors": [
+        {
+          "message": "Division by zero is not allowed"
+        }
+      ]
+    } 

--- a/payas-deno/src/deno_error.rs
+++ b/payas-deno/src/deno_error.rs
@@ -1,4 +1,7 @@
-use deno_core::{error::AnyError, v8::DataError};
+use deno_core::{
+    error::{AnyError, JsError},
+    v8::DataError,
+};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -6,6 +9,13 @@ pub enum DenoError {
     // Explicit error thrown by a script (this should be propagated to the user)
     #[error("{0}")]
     Explicit(String),
+
+    // Non-explicit error thrown by the runtime (such as undefined variable)
+    #[error(transparent)]
+    JsError(#[from] JsError),
+
+    #[error(transparent)]
+    AnyError(#[from] AnyError),
 
     // Show it to developers (such as missing "await") so they may possibly fix it.
     #[error(transparent)]

--- a/payas-deno/src/deno_module.rs
+++ b/payas-deno/src/deno_module.rs
@@ -199,18 +199,18 @@ impl DenoModule {
             .execute_script("", &func_value_string)
             .map_err(DenoInternalError::Any)?;
 
-        let shim_objects_vals: Vec<_> = self
-            .shim_object_names
-            .iter()
-            .map(|name| runtime.execute_script("", name))
-            .collect::<Result<_, _>>()
-            .map_err(DenoInternalError::Any)?;
-
-        let shim_objects: HashMap<_, _> = self
-            .shim_object_names
-            .iter()
-            .zip(shim_objects_vals.into_iter())
-            .collect();
+        let shim_objects: HashMap<_, _> = {
+            let shim_objects_vals: Vec<_> = self
+                .shim_object_names
+                .iter()
+                .map(|name| runtime.execute_script("", name))
+                .collect::<Result<_, _>>()
+                .map_err(DenoInternalError::Any)?;
+            self.shim_object_names
+                .iter()
+                .zip(shim_objects_vals.into_iter())
+                .collect()
+        };
 
         let global = {
             let scope = &mut runtime.handle_scope();
@@ -256,24 +256,16 @@ impl DenoModule {
             let local = match local {
                 Some(value) => value,
                 None => {
+                    // We will get the exception here for sync functions
                     let exception = tc_scope_ref.exception().unwrap();
                     let js_error = JsError::from_v8_exception(tc_scope_ref, exception);
 
                     error!(%js_error, "Exception executing function");
 
-                    match self.explicit_error_class_name {
-                        Some(_) if js_error.name.as_deref() == self.explicit_error_class_name => {
-                            // code threw an explicit Error(...), expose to user
-                            let message = js_error
-                                .message
-                                .unwrap_or_else(|| "Unknown error".to_string());
-                            return Err(DenoError::Explicit(message));
-                        }
-                        _ => {
-                            // generic error message
-                            return Err(DenoError::Explicit("Internal server error".into()));
-                        }
-                    }
+                    return Err(Self::process_js_error(
+                        self.explicit_error_class_name,
+                        js_error,
+                    ));
                 }
             };
 
@@ -284,7 +276,13 @@ impl DenoModule {
             let value = runtime.resolve_value(global).await.map_err(|err| {
                 // got some AnyError from Deno internals...
                 error!(%err);
-                DenoError::Explicit("Internal server error".into())
+
+                // If the function is async, we will get access to the error here. If it is an JsError, we process
+                // it to define the error returned to the user (just like we do for the sync case above).
+                match err.downcast::<JsError>() {
+                    Ok(err) => Self::process_js_error(self.explicit_error_class_name, err),
+                    Err(err) => DenoError::AnyError(err),
+                }
             })?;
 
             let scope = &mut runtime.handle_scope();
@@ -314,6 +312,25 @@ impl DenoModule {
             .try_borrow_mut()
             .map_err(DenoDiagnosticError::BorrowMutError)?
             .try_take())
+    }
+
+    fn process_js_error(
+        explicit_error_class_name: Option<&'static str>,
+        js_error: JsError,
+    ) -> DenoError {
+        match explicit_error_class_name {
+            Some(_) if js_error.name.as_deref() == explicit_error_class_name => {
+                // code threw an explicit error, expose it to user
+                let message = js_error
+                    .message
+                    .unwrap_or_else(|| "Unknown error".to_string());
+                DenoError::Explicit(message)
+            }
+            _ => {
+                // generic error message
+                DenoError::JsError(js_error)
+            }
+        }
     }
 }
 

--- a/payas-resolver-deno/src/deno_execution_error.rs
+++ b/payas-resolver-deno/src/deno_execution_error.rs
@@ -16,3 +16,13 @@ pub enum DenoExecutionError {
     #[error(transparent)]
     Delegate(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
+
+impl DenoExecutionError {
+    pub fn user_error_message(&self) -> String {
+        match self {
+            DenoExecutionError::Authorization => "Not authorized".to_string(),
+            DenoExecutionError::Deno(DenoError::Explicit(error)) => error.to_string(),
+            _ => "Internal server error".to_string(), // Do not reveal too much information about the error
+        }
+    }
+}

--- a/payas-server-core/src/graphql/execution_error.rs
+++ b/payas-server-core/src/graphql/execution_error.rs
@@ -35,12 +35,15 @@ impl ExecutionError {
     pub fn user_error_message(&self) -> String {
         match self {
             ExecutionError::Database(error) => error.user_error_message(),
-            ExecutionError::Deno(DenoExecutionError::Delegate(error)) => {
-                match error.downcast_ref::<ExecutionError>() {
-                    Some(error) => error.user_error_message(),
-                    None => error.to_string(),
+            ExecutionError::Deno(error) => match error {
+                DenoExecutionError::Delegate(underlying) => {
+                    match underlying.downcast_ref::<ExecutionError>() {
+                        Some(error) => error.user_error_message(),
+                        None => error.user_error_message(),
+                    }
                 }
-            }
+                _ => error.user_error_message(),
+            },
             _ => match self.source() {
                 Some(source) => source.to_string(),
                 None => self.to_string(),


### PR DESCRIPTION
Earlier, we handled only the sync case. This change extends the same
logic to the async case.