### PR TITLE
Enhance import resolution to match that in js/ts

### DIFF
--- a/integration-tests/imports/mailing_list.clay
+++ b/integration-tests/imports/mailing_list.clay
@@ -1,4 +1,4 @@
-import "users/users.clay"
+import "users"  // Example of not specifying the index.clay file in a directory
 
 model MailingList {
     id: Int = autoincrement() @pk

--- a/integration-tests/imports/users/index.clay
+++ b/integration-tests/imports/users/index.clay
@@ -1,0 +1,1 @@
+import "users"

--- a/integration-tests/imports/users/users.clay
+++ b/integration-tests/imports/users/users.clay
@@ -1,4 +1,4 @@
-import "../mailing_list.clay"
+import "../mailing_list" // An example of not specifying the .clay extension
 
 model User {
     id: Int = autoincrement() @pk


### PR DESCRIPTION
If an import specifies a directory, we try to look for index.clay
file in that directory.