### PR TITLE
Show a better error message when the server fails to start

### DIFF
--- a/payas-cli/src/util/watcher.rs
+++ b/payas-cli/src/util/watcher.rs
@@ -17,7 +17,6 @@ use crate::commands::build::build;
 pub fn start_watcher<F>(
     model_path: &Path,
     server_port: Option<u32>,
-
     prestart_callback: F,
 ) -> Result<()>
 where

--- a/payas-server-actix/src/main.rs
+++ b/payas-server-actix/src/main.rs
@@ -3,7 +3,7 @@ use actix_web::http::header::{CacheControl, CacheDirective};
 use actix_web::{middleware, web, App, HttpRequest, HttpResponse, HttpServer, Responder};
 use payas_server_actix::request_context::ActixRequestContextProducer;
 use payas_server_actix::resolve;
-use payas_server_core::{create_system_context, SystemContext};
+use payas_server_core::{create_system_context_or_exit, SystemContext};
 use payas_server_core::{get_endpoint_http_path, get_playground_http_path, graphiql};
 use tracing_actix_web::TracingLogger;
 
@@ -20,7 +20,7 @@ async fn main() -> std::io::Result<()> {
 
     payas_server_core::init();
 
-    let system_context = web::Data::new(create_system_context(&claypot_file).unwrap());
+    let system_context = web::Data::new(create_system_context_or_exit(&claypot_file));
     let request_context_processor = web::Data::new(ActixRequestContextProducer::new());
 
     let server_port = env::var("CLAY_SERVER_PORT")

--- a/payas-server-aws-lambda/src/main.rs
+++ b/payas-server-aws-lambda/src/main.rs
@@ -2,7 +2,7 @@ use lambda_http::{Error, Request};
 
 use payas_server_aws_lambda::request_context::LambdaRequestContextProducer;
 use payas_server_aws_lambda::resolve;
-use payas_server_core::create_system_context;
+use payas_server_core::create_system_context_or_exit;
 
 use std::sync::Arc;
 use std::{env, process::exit};
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Error> {
 
     payas_server_core::init();
 
-    let system_context = Arc::new(create_system_context(&claypot_file).unwrap());
+    let system_context = Arc::new(create_system_context_or_exit(&claypot_file));
     let request_context_processor = Arc::new(LambdaRequestContextProducer::new());
 
     let service = lambda_http::service_fn(|request: Request| async {

--- a/payas-server-core/src/initialization_error.rs
+++ b/payas-server-core/src/initialization_error.rs
@@ -1,16 +1,20 @@
+use payas_sql::database_error::DatabaseError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum InitializationError {
-    #[error("{0}")]
-    Generic(String),
-
     #[error("No such file {0}")]
     FileNotFound(String),
+
+    #[error("{0}")]
+    Database(#[from] DatabaseError),
 
     #[error("Failed to open file {0}")]
     FileOpen(String, #[source] std::io::Error),
 
     #[error("Invalid claypot file {0}")]
     ClaypotDeserialization(String, #[source] bincode::Error),
+
+    #[error("Configuration error: {0}")]
+    Config(String),
 }

--- a/payas-sql/src/database_error.rs
+++ b/payas-sql/src/database_error.rs
@@ -2,8 +2,14 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum DatabaseError {
+    #[error("Configuration error: {0}")]
+    Config(String),
+
+    #[error("Failed to execute transaction {0}")]
+    Transaction(String),
+
     #[error("{0}")]
-    Generic(String),
+    Validation(String),
 
     #[error("{0}")]
     Delegate(#[from] tokio_postgres::Error),

--- a/payas-sql/src/sql/array_util.rs
+++ b/payas-sql/src/sql/array_util.rs
@@ -105,7 +105,7 @@ fn process_array<T>(
         }
         Entry::Occupied(entry) => {
             if *entry.get() != len {
-                return Err(DatabaseError::Generic(format!(
+                return Err(DatabaseError::Validation(format!(
                     "Array dimensions do not match in dimension {}. Expected {}, got {}",
                     depth,
                     *entry.get(),

--- a/payas-sql/src/sql/column.rs
+++ b/payas-sql/src/sql/column.rs
@@ -107,7 +107,7 @@ impl PhysicalColumnType {
                             dims = &dims[2..];
                             count += 1;
                         } else {
-                            return Err(DatabaseError::Generic(format!("unknown type {}", s)));
+                            return Err(DatabaseError::Validation(format!("unknown type {}", s)));
                         }
                     } else {
                         break;
@@ -179,7 +179,7 @@ impl PhysicalColumnType {
                         let regex =
                             Regex::new("NUMERIC\\((?P<precision>\\d+),?(?P<scale>\\d+)?\\)")
                                 .map_err(|_| {
-                                    DatabaseError::Generic("Invalid numeric column spec".into())
+                                    DatabaseError::Validation("Invalid numeric column spec".into())
                                 })?;
                         let captures = regex.captures(s).unwrap();
 
@@ -190,7 +190,7 @@ impl PhysicalColumnType {
 
                         PhysicalColumnType::Numeric { precision, scale }
                     } else {
-                        return Err(DatabaseError::Generic(format!("unknown type {}", s)));
+                        return Err(DatabaseError::Validation(format!("unknown type {}", s)));
                     }
                 }
             }),

--- a/payas-sql/src/sql/mod.rs
+++ b/payas-sql/src/sql/mod.rs
@@ -106,7 +106,7 @@ impl ToSql for SQLValue {
             out.extend(self.value.as_slice());
             Ok(tokio_postgres::types::IsNull::No)
         } else {
-            Err(DatabaseError::Generic("Type mismatch".into()).into())
+            Err(DatabaseError::Validation("Type mismatch".into()).into())
         }
     }
 

--- a/payas-sql/src/sql/transaction.rs
+++ b/payas-sql/src/sql/transaction.rs
@@ -62,7 +62,7 @@ impl<'a> TransactionScript<'a> {
             .results
             .into_iter()
             .last()
-            .ok_or_else(|| DatabaseError::Generic("Failed to execute transaction".into()))
+            .ok_or_else(|| DatabaseError::Transaction("".into()))
     }
 
     pub fn add_step(&mut self, step: TransactionStep<'a>) -> TransactionStepId {


### PR DESCRIPTION
Earlier, if, for example, user didn't set CLAY_DATABAE_URL, 'clay serve'
would fail with an error message along with a Rust stack trace.
```
$ clay serve
Watching: "/Users/ramnivas/open-source/claytip-docs/sample-code/todo-app"
thread 'main' panicked at 'Failed to access database: CLAY_DATABASE_URL must be provided

Caused by:
    environment variable not found', payas-server-core/src/lib.rs:54:45
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This change handles errors in place of `unwrap()`ing them and shows
a better error message:
```
$ clay serve
Watching: "/Users/ramnivas/open-source/claytip-docs/sample-code/todo-app"
Configuration error: Env CLAY_DATABASE_URL must be provided
```