### PR TITLE
Fix queries using nested ordering by clauses

### DIFF
--- a/integration-tests/basic-model-no-auth/concerts-nested-order-by.claytest
+++ b/integration-tests/basic-model-no-auth/concerts-nested-order-by.claytest
@@ -1,0 +1,202 @@
+operation: |
+    fragment ConcertInfo on Concert {
+      id
+      venue {
+        id
+        name
+        latitude
+      }
+    }
+
+    query {
+      concerts {
+        ...ConcertInfo
+      }
+      concerts_oder_by_venue_id_asc: concerts(orderBy: {venue: {id: ASC}}) {
+        ...ConcertInfo
+      }
+      concerts_oder_by_venue_id_desc: concerts(orderBy: {venue: {id: DESC}}) {
+        ...ConcertInfo
+      }
+      concerts_oder_by_venue_latitude_asc: concerts(orderBy: {venue: {latitude: ASC}}) {
+        ...ConcertInfo
+      }
+      concerts_oder_by_venue_latitude_desc: concerts(orderBy: {venue: {latitude: DESC}}) {
+        ...ConcertInfo
+      }
+    }
+response: |
+    {
+      "data": {
+        "concerts": [
+          {
+            "id": 1,
+            "venue": {
+              "id": 1,
+              "name": "Venue1",
+              "latitude": 37.7749
+            }
+          },
+          {
+            "id": 2,
+            "venue": {
+              "id": 2,
+              "name": "Venue2",
+              "latitude": 35.6762
+            }
+          },
+          {
+            "id": 3,
+            "venue": {
+              "id": 1,
+              "name": "Venue1",
+              "latitude": 37.7749
+            }
+          },
+          {
+            "id": 4,
+            "venue": {
+              "id": 2,
+              "name": "Venue2",
+              "latitude": 35.6762
+            }
+          }
+        ],
+        "concerts_oder_by_venue_id_asc": [
+          {
+            "id": 1,
+            "venue": {
+              "id": 1,
+              "name": "Venue1",
+              "latitude": 37.7749
+            }
+          },
+          {
+            "id": 3,
+            "venue": {
+              "id": 1,
+              "name": "Venue1",
+              "latitude": 37.7749
+            }
+          },
+          {
+            "id": 2,
+            "venue": {
+              "id": 2,
+              "name": "Venue2",
+              "latitude": 35.6762
+            }
+          },
+          {
+            "id": 4,
+            "venue": {
+              "id": 2,
+              "name": "Venue2",
+              "latitude": 35.6762
+            }
+          }
+        ],
+        "concerts_oder_by_venue_id_desc": [
+          {
+            "id": 2,
+            "venue": {
+              "id": 2,
+              "name": "Venue2",
+              "latitude": 35.6762
+            }
+          },
+          {
+            "id": 4,
+            "venue": {
+              "id": 2,
+              "name": "Venue2",
+              "latitude": 35.6762
+            }
+          },
+          {
+            "id": 1,
+            "venue": {
+              "id": 1,
+              "name": "Venue1",
+              "latitude": 37.7749
+            }
+          },
+          {
+            "id": 3,
+            "venue": {
+              "id": 1,
+              "name": "Venue1",
+              "latitude": 37.7749
+            }
+          }
+        ],
+        "concerts_oder_by_venue_latitude_asc": [
+          {
+            "id": 2,
+            "venue": {
+              "id": 2,
+              "name": "Venue2",
+              "latitude": 35.6762
+            }
+          },
+          {
+            "id": 4,
+            "venue": {
+              "id": 2,
+              "name": "Venue2",
+              "latitude": 35.6762
+            }
+          },
+          {
+            "id": 1,
+            "venue": {
+              "id": 1,
+              "name": "Venue1",
+              "latitude": 37.7749
+            }
+          },
+          {
+            "id": 3,
+            "venue": {
+              "id": 1,
+              "name": "Venue1",
+              "latitude": 37.7749
+            }
+          }
+        ],
+        "concerts_oder_by_venue_latitude_desc": [
+          {
+            "id": 1,
+            "venue": {
+              "id": 1,
+              "name": "Venue1",
+              "latitude": 37.7749
+            }
+          },
+          {
+            "id": 3,
+            "venue": {
+              "id": 1,
+              "name": "Venue1",
+              "latitude": 37.7749
+            }
+          },
+          {
+            "id": 2,
+            "venue": {
+              "id": 2,
+              "name": "Venue2",
+              "latitude": 35.6762
+            }
+          },
+          {
+            "id": 4,
+            "venue": {
+              "id": 2,
+              "name": "Venue2",
+              "latitude": 35.6762
+            }
+          }
+        ]
+      }
+    }

--- a/payas-model/src/model/order.rs
+++ b/payas-model/src/model/order.rs
@@ -14,7 +14,6 @@ pub struct OrderByParameter {
 
     /// How does this parameter relates with the parent parameter?
     /// For example for parameter used as {order_by: {venue1: {id: Desc}}}, we will have following column links:
-    /// eq: None
     /// id: Some((<the venues.id column>, None))
     /// venue1: Some((<the concerts.venue1_id column>, <the venues.id column>))
     /// order_by: None

--- a/payas-resolver-database/src/database_query.rs
+++ b/payas-resolver-database/src/database_query.rs
@@ -129,7 +129,7 @@ impl<'content> DatabaseQuery<'content> {
             .and_then(|order_by_param| {
                 let argument_value = super::find_arg(arguments, &order_by_param.name);
                 argument_value.map(|argument_value| {
-                    order_by_param.map_to_order_by(argument_value, &None, system_context)
+                    order_by_param.map_to_order_by(argument_value, None, system_context)
                 })
             })
             .transpose()

--- a/payas-sql/src/sql/join.rs
+++ b/payas-sql/src/sql/join.rs
@@ -22,6 +22,10 @@ impl<'a> Join<'a> {
             predicate,
         }
     }
+
+    pub fn left(&self) -> &TableQuery<'a> {
+        &self.left
+    }
 }
 
 impl Expression for Join<'_> {

--- a/payas-sql/src/sql/table.rs
+++ b/payas-sql/src/sql/table.rs
@@ -43,6 +43,13 @@ impl<'a> TableQuery<'a> {
     ) -> TableQuery<'a> {
         TableQuery::Join(Join::new(self, other_table, predicate))
     }
+
+    pub fn base_table(&self) -> &PhysicalTable {
+        match self {
+            TableQuery::Physical(table) => table,
+            TableQuery::Join(join) => join.left().base_table(),
+        }
+    }
 }
 
 impl<'a> Expression for TableQuery<'a> {

--- a/payas-sql/src/sql/transaction.rs
+++ b/payas-sql/src/sql/transaction.rs
@@ -1,5 +1,5 @@
 use tokio_postgres::{types::ToSql, Client, GenericClient, Row};
-use tracing::{error, instrument};
+use tracing::{debug, error, instrument};
 
 use crate::{database_error::DatabaseError, sql::ExpressionContext};
 
@@ -143,6 +143,8 @@ impl<'a> ConcreteTransactionStep<'a> {
 
         let params: Vec<&(dyn ToSql + Sync)> =
             binding.params.iter().map(|p| (*p).as_pg()).collect();
+
+        debug!("Executing SQL operation: {}", binding.stmt.as_str());
 
         client
             .query(binding.stmt.as_str(), &params[..])


### PR DESCRIPTION
Earlier, queries such as the following were failing:
```graphql
{
  concerts(orderBy: {venue: {id: ASC}}) {
    id
    venue {
      id
    }
  }
}
```

This was due to a couple of issues:
- order_by_mapper didn't account for nested fields when computing the
  `Ordering`. We fix this by detecting if the field is nested and recursing.
- `select *` used when forming a subquery (when ordering, limit, or
  offset is used) was not correct when a join is involved (there could
  be identical columns in tables being joined, which would cause
  ambiguous column for the outer query). We fix this by only selecting
  the columns of the left-most table in a join.

Fixes #380