### PR TITLE
Update Dockerfile to match the latest layout

### DIFF
--- a/docker/Dockerfile.template
+++ b/docker/Dockerfile.template
@@ -17,78 +17,37 @@ WORKDIR /usr/src
 
 ## Build and cache the dependencies
 ### Create empty projects with the right type (lib/bin)
-RUN USER=root cargo new --vcs none --bin cli
-RUN USER=root cargo new --vcs none --lib core-subsystem/core-model-builder
-RUN USER=root cargo new --vcs none --lib database-subsystem/database-model-builder
-RUN USER=root cargo new --vcs none --lib payas-deno
-RUN USER=root cargo new --vcs none --lib payas-model
-RUN USER=root cargo new --vcs none --lib builder
-RUN USER=root cargo new --vcs none --lib core-resolver
-RUN USER=root cargo new --vcs none --lib database-resolver
-RUN USER=root cargo new --vcs none --lib deno-resolver
-RUN USER=root cargo new --vcs none --lib wasm-resolver
-RUN USER=root cargo new --vcs none --bin server-actix
-RUN USER=root cargo new --vcs none --bin server-aws-lambda
-RUN USER=root cargo new --vcs none --lib resolver
-RUN USER=root cargo new --vcs none --lib deno-plugin/deno-model-builder
-RUN USER=root cargo new --vcs none --lib payas-sql
-RUN USER=root cargo new --vcs none --lib test
-RUN USER=root cargo new --vcs none --lib payas-wasm
+
+%%CREATE_EMPTY_PROJECTS%%
 
 ### Copy over Cargo.toml and Cargo.lock files so that we can build just
 ### the dependencies and cache this layer when only source files change
 COPY ./Cargo.toml ./Cargo.toml
 COPY ./Cargo.lock ./Cargo.lock
-COPY ./cli/Cargo.toml ./cli/Cargo.toml
-COPY ./core-subsystem/core-model-builder/Cargo.toml ./core-subsystem/core-model-builder/Cargo.toml
-COPY ./database-subsystem/database-model-builder/Cargo.toml ./database-subsystem/database-model-builder/Cargo.toml
-COPY ./payas-deno/Cargo.toml ./payas-deno/Cargo.toml
-COPY ./payas-model/Cargo.toml ./payas-model/Cargo.toml
-COPY ./builder/Cargo.toml ./builder/Cargo.toml
-COPY ./core-resolver/Cargo.toml ./core-resolver/Cargo.toml
-COPY ./database-resolver/Cargo.toml ./database-resolver/Cargo.toml
-COPY ./deno-resolver/Cargo.toml ./deno-resolver/Cargo.toml
-COPY ./wasm-resolver/Cargo.toml ./wasm-resolver/Cargo.toml
-COPY ./server-actix/Cargo.toml ./server-actix/Cargo.toml
-COPY ./server-aws-lambda/Cargo.toml ./server-aws-lambda/Cargo.toml
-COPY ./resolver/Cargo.toml ./resolver/Cargo.toml
-COPY ./deno-plugin/deno-model-builder/Cargo.toml ./deno-plugin/deno-model-builder/Cargo.toml
-COPY ./payas-sql/Cargo.toml ./payas-sql/Cargo.toml
-COPY ./test/Cargo.toml ./test/Cargo.toml
-COPY ./payas-wasm/Cargo.toml ./payas-wasm/Cargo.toml
+
+%%COPY_CARGO_TOMLS%%
+
 
 COPY ./graphiql/package.json ./graphiql/package.json
 COPY ./graphiql/package-lock.json ./graphiql/package-lock.json
 
 ### Compile the depdencies and remove artifacts related to the non-dependency parts (so that when we use real code, they get rebuilt)
-RUN cargo build ${BUILD_FLAG} && rm */src/*.rs && rm target/${BUILD_DIR}/deps/payas* && rm -rf target/${BUILD_DIR}/.fingerprint/payas* 
+RUN cargo build --all ${BUILD_FLAG} 
+
+%%RM_DEPS%% 
+## Build GraphiQL bundle
 RUN cd graphiql && npm install
 
 ## Build the actual image
 ### Copy over the source files
-ADD cli cli/
-ADD core-subsystem/core-model-builder/ core-subsystem/core-model-builder/
-ADD database-subsystem/database-model-builder database-subsystem/database-model-builder/
-ADD payas-deno payas-deno/
-ADD payas-model payas-model/
-ADD builder builder/
-ADD core-resolver core-resolver/
-ADD database-resolver database-resolver/
-ADD deno-resolver deno-resolver/
-ADD wasm-resolver wasm-resolver/
-ADD server-actix server-actix/
-ADD server-aws-lambda server-aws-lambda/
-ADD resolver resolver/
-ADD deno-subsystem/deno-model-builder/ deno-subsystem/deno-model-builder/ 
-ADD payas-sql payas-sql/
-ADD test test/
-ADD payas-wasm payas-wasm/
-
+ADD crates crates/
+ADD libs libs/
 ADD graphiql graphiql/
+
 
 ### Build the binaries (first the graphiql app and then the rest)
 RUN cd graphiql && npm run prod-build
-RUN cargo build ${BUILD_FLAG}
+RUN cargo build --all ${BUILD_FLAG}
 
 # Create an image to include the compiled binaries
 ARG BASE_IMAGE

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -11,8 +11,8 @@ buildType="$2" # "release" or "debug"
 # TODO: Resolve the openssl issues and then "BASE_IMAGE=debian:buster-slim"
 
 ## DEFAULTS ##
-BUILD_IMAGE=rust:1.63.0-buster # image to build Claytip with
-BASE_IMAGE=rust:1.63.0-slim-buster # image to use when actually running Claytip
+BUILD_IMAGE=rust:1.64.0-buster # image to build Claytip with
+BASE_IMAGE=rust:1.64.0-slim-buster # image to use when actually running Claytip
 DEPENDENCY_STYLE=deb # how to install or setup dependencies
 TAG_SUFFIX="" # docker tag suffix
 
@@ -49,6 +49,91 @@ else
     exit 1
 fi
 
+# Tuples of (name kind path)
+declare -a SUBCRATES=(
+    "cli bin crates"
+    "server-actix bin crates"
+    "server-aws-lambda bin crates"
+    "builder lib crates"
+    "resolver lib crates"
+    "testing lib crates"
+    "payas-sql lib libs"
+    "payas-deno lib libs"
+    "payas-wasm lib libs"
+    "core-model lib crates\/core-subsystem"
+    "core-model-builder lib crates\/core-subsystem"
+    "core-plugin lib crates\/core-subsystem"
+    "core-resolver lib crates\/core-subsystem"
+    "database-model lib crates\/database-subsystem"
+    "database-model-builder lib crates\/database-subsystem"
+    "database-resolver lib crates\/database-subsystem"
+    "deno-model lib crates\/deno-subsystem"
+    "deno-model-builder lib crates\/deno-subsystem"
+    "deno-resolver lib crates\/deno-subsystem"
+    "wasm-model lib crates\/wasm-subsystem"
+    "wasm-model-builder lib crates\/wasm-subsystem"
+    "wasm-resolver lib crates\/wasm-subsystem"
+    "introspection-resolver lib crates\/introspection-subsystem"
+    "subsystem-model-builder-util lib crates\/subsystem-util"
+    "subsystem-model-util lib crates\/subsystem-util"
+)
+
+compute_create_empty_projects() {
+    local RESULT
+
+    for crate_info in "${SUBCRATES[@]}"
+    do
+        set -- $crate_info
+        name="$1"
+        kind="$2"
+        path="$3"
+        RESULT="${RESULT}RUN USER=root cargo new --vcs none --$kind $path\/$name\n"
+    done
+
+    echo $RESULT
+}
+
+compute_copy_cargo_tomls() {
+    local RESULT
+
+    for crate_info in "${SUBCRATES[@]}"
+    do
+        set -- $crate_info
+        name="$1"
+        path="$3"
+        RESULT="${RESULT}COPY .\/$path\/$name\/Cargo.toml .\/$path\/$name\/Cargo.toml\n"
+    done
+
+    echo $RESULT
+}
+
+compute_rm_deps() {
+    local RESULT
+
+    artifacts_dir="target\/\${BUILD_DIR}"
+    deps_dir="$artifacts_dir\/deps"
+    for crate_info in "${SUBCRATES[@]}"
+    do
+        set -- $crate_info
+        name="$1"
+        path="$3"
+        module_name=$(echo $name | sed 's/-/_/g')
+
+        # Remove sources that were created by the empty projects
+        RESULT="${RESULT}RUN rm $path\/$name\/src\/\*.rs "
+        # Remove the artifacts created by the empty projects
+        ## First, all the lib* files for our modules
+        RESULT="${RESULT}\&\& rm -f ${artifact_dir}\/lib${module_name}.\* "
+        ## Then, all the .d files for our modules (lib<module_name>.rlib, lib<module_name>.rmeta, <module_name>.d)
+        RESULT="${RESULT}\&\& rm -f ${deps_dir}\/${module_name}* \&\& rm -f ${deps_dir}\/lib${module_name}* "
+        ## Also remove the fingerprint files for our modules (note the names here use the crate name, not the module name)
+        RESULT="${RESULT}\&\& rm -rf ${artifact_dir}\/.fingerprint\/${name}*\n"
+    done
+
+    echo $RESULT
+}
+
+
 # Generates Dockerfile.generated and builds a docker image from it to the specified target.
 # Final image is tagged with the specified tag.
 docker_build() {
@@ -72,6 +157,14 @@ docker_build() {
         | sed -e '/%%BUILD_SETUP%%/ {' -e "r $BUILD_SETUP" -e 'd' -e '}' \
         | sed -e '/%%RUNTIME_SETUP%%/ {' -e "r $RUNTIME_SETUP" -e 'd' -e '}' \
         > $GENERATED_DOCKERFILE
+
+    CREATE_EMPTY_PROJECTS=$(compute_create_empty_projects)
+    COPY_CARGO_TOMLS=$(compute_copy_cargo_tomls)
+    RM_DEPS=$(compute_rm_deps)
+
+    sed -i "s/%%CREATE_EMPTY_PROJECTS%%/$CREATE_EMPTY_PROJECTS/" $GENERATED_DOCKERFILE
+    sed -i "s/%%COPY_CARGO_TOMLS%%/$COPY_CARGO_TOMLS/" $GENERATED_DOCKERFILE
+    sed -i "s/%%RM_DEPS%%/$RM_DEPS/g" $GENERATED_DOCKERFILE
 
     docker build \
             -t $TAG \


### PR DESCRIPTION
Since we have a lot more packages and we no longer have a single prefix, we shift the generation of the Dockerfile to a script. We also cleanup up the artifacts from running the empty projects a bit more thoroughly.

Fixes #536