### PR TITLE
Upgrade clap to 4.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,24 +841,22 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_lex",
- "indexmap",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -6105,12 +6103,6 @@ checksum = "7fd5828de7deaa782e1dd713006ae96b3bee32d3279b79eb67ecf8072c059bcf"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
-clap = "3.2.16"
+clap = "4.0.18"
 heck = "0.4.0"
 notify = "4.0.17"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -19,7 +19,7 @@ const DEFAULT_MODEL_FILE: &str = "index.clay";
 pub static SIGINT: AtomicBool = AtomicBool::new(false);
 pub static EXIT_ON_SIGINT: AtomicBool = AtomicBool::new(true);
 
-fn model_file_arg() -> Arg<'static> {
+fn model_file_arg() -> Arg {
     Arg::new("model")
         .help("The path to the Claytip model file.")
         .hide_default_value(false)
@@ -29,14 +29,14 @@ fn model_file_arg() -> Arg<'static> {
         .index(1)
 }
 
-fn database_arg() -> Arg<'static> {
+fn database_arg() -> Arg {
     Arg::new("database")
         .help("The PostgreSQL database connection string to use. If not specified, the program will attempt to read it from the environment (`CLAY_DATABASE_URL`).")
         .long("database")
         .required(false)
 }
 
-fn output_arg() -> Arg<'static> {
+fn output_arg() -> Arg {
     Arg::new("output")
         .help("Output file path")
         .help("If specified, the output will be written to this file path instead of stdout.")
@@ -44,10 +44,10 @@ fn output_arg() -> Arg<'static> {
         .long("output")
         .required(false)
         .value_parser(clap::value_parser!(PathBuf))
-        .takes_value(true)
+        .num_args(1)
 }
 
-fn port_arg() -> Arg<'static> {
+fn port_arg() -> Arg {
     Arg::new("port")
         .help("Listen port")
         .long_help("The port the server should listen for HTTP requests on.")
@@ -55,7 +55,7 @@ fn port_arg() -> Arg<'static> {
         .long("port")
         .required(false)
         .value_parser(clap::value_parser!(u32))
-        .takes_value(true)
+        .num_args(1)
 }
 
 fn main() -> Result<()> {
@@ -113,7 +113,7 @@ fn main() -> Result<()> {
                                 .help("By default, destructive changes in the model file are commented out. If specified, this option will uncomment such changes.")
                                 .long("allow-destructive-changes")
                                 .required(false)
-                                .takes_value(false),
+                                .num_args(0),
                         )
 
                 )


### PR DESCRIPTION
This upgrade removes the colorization of the output of the `--help` command. We will track https://github.com/clap-rs/clap/issues/3108 to restore it in the future.