### PR TITLE
Fix 'clay test --run-introspection-tests' to not error with no arguments

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -150,7 +150,7 @@ fn main() -> Result<()> {
                     Arg::new("run-introspection-tests")
                         .help("When specified, run standard introspection tests on the tests' model files")
                         .required(false)
-                        .long("run-introspection-tests")
+                        .long("run-introspection-tests").num_args(0)
                 )
         )
         .subcommand(


### PR DESCRIPTION
It is a leftover issue from the previous commit (upgrading to the Clap 4.x). We needed to specify the the --run-introspection-tests option is a flag (i.e. does not take any arguments).