### PR TITLE
Weave correct interceptor even with multiple interceptors of the same name

### DIFF
--- a/crates/deno-subsystem/deno-resolver/src/interceptor_execution.rs
+++ b/crates/deno-subsystem/deno-resolver/src/interceptor_execution.rs
@@ -43,7 +43,7 @@ pub async fn execute_interceptor<'a>(
         .execute_and_get_r(
             &script.path,
             &script.script,
-            &interceptor.name,
+            &interceptor.method_name,
             arg_sequence,
             Some(InterceptedOperationInfo {
                 name: intercepted_operation.operation().name.to_string(),

--- a/crates/subsystem-util/subsystem-model-builder-util/src/builder/resolved_builder.rs
+++ b/crates/subsystem-util/subsystem-model-builder-util/src/builder/resolved_builder.rs
@@ -118,7 +118,8 @@ pub struct ResolvedArgument {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ResolvedInterceptor {
-    pub name: String,
+    pub service_name: String,
+    pub method_name: String,
     pub arguments: Vec<ResolvedArgument>,
     pub interceptor_kind: ResolvedInterceptorKind,
 }
@@ -303,7 +304,8 @@ fn resolve_service(
                     }?;
 
                     Result::<ResolvedInterceptor, ModelBuildingError>::Ok(ResolvedInterceptor {
-                        name: i.name.clone(),
+                        service_name: service.name.clone(),
+                        method_name: i.name.clone(),
                         arguments: i
                             .arguments
                             .iter()

--- a/crates/subsystem-util/subsystem-model-builder-util/src/builder/service_builder.rs
+++ b/crates/subsystem-util/subsystem-model-builder-util/src/builder/service_builder.rs
@@ -213,32 +213,24 @@ pub fn create_shallow_interceptor(
         building,
     );
 
-    building.interceptors.add(
-        &resolved_interceptor.name,
-        Interceptor {
-            name: resolved_interceptor.name.clone(),
-            script,
-            interceptor_kind: match resolved_interceptor.interceptor_kind {
-                super::resolved_builder::ResolvedInterceptorKind::Before(_) => {
-                    InterceptorKind::Before
-                }
-                super::resolved_builder::ResolvedInterceptorKind::After(_) => {
-                    InterceptorKind::After
-                }
-                super::resolved_builder::ResolvedInterceptorKind::Around(_) => {
-                    InterceptorKind::Around
-                }
-            },
-            arguments: resolved_interceptor
-                .arguments
-                .iter()
-                .map(|arg| Argument {
-                    name: arg.name.clone(),
-                    type_id: building.get_id(arg.typ.get_underlying_typename()).unwrap(),
-                    modifier: arg.typ.get_modifier(),
-                    is_injected: true, // implicitly set is_injected for interceptors
-                })
-                .collect(),
+    building.interceptors.insert(Interceptor {
+        service_name: resolved_service.name.clone(),
+        method_name: resolved_interceptor.method_name.clone(),
+        script,
+        interceptor_kind: match resolved_interceptor.interceptor_kind {
+            super::resolved_builder::ResolvedInterceptorKind::Before(_) => InterceptorKind::Before,
+            super::resolved_builder::ResolvedInterceptorKind::After(_) => InterceptorKind::After,
+            super::resolved_builder::ResolvedInterceptorKind::Around(_) => InterceptorKind::Around,
         },
-    );
+        arguments: resolved_interceptor
+            .arguments
+            .iter()
+            .map(|arg| Argument {
+                name: arg.name.clone(),
+                type_id: building.get_id(arg.typ.get_underlying_typename()).unwrap(),
+                modifier: arg.typ.get_modifier(),
+                is_injected: true, // implicitly set is_injected for interceptors
+            })
+            .collect(),
+    });
 }

--- a/crates/subsystem-util/subsystem-model-util/src/interceptor.rs
+++ b/crates/subsystem-util/subsystem-model-util/src/interceptor.rs
@@ -6,7 +6,8 @@ use core_plugin_shared::interception::InterceptorKind;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Interceptor {
-    pub name: String,
+    pub service_name: String,
+    pub method_name: String,
     pub script: SerializableSlabIndex<Script>,
     pub interceptor_kind: InterceptorKind,
     pub arguments: Vec<Argument>,

--- a/integration-tests/interceptor/same-name/core.ts
+++ b/integration-tests/interceptor/same-name/core.ts
@@ -1,0 +1,4 @@
+export async function getInt(): Promise<number> {
+	return 1;
+}
+

--- a/integration-tests/interceptor/same-name/index.clay
+++ b/integration-tests/interceptor/same-name/index.clay
@@ -1,0 +1,24 @@
+@external("core.ts")
+service Core {
+  query getInt(): Int  
+}
+
+// The same interceptor is named same as in all services.
+// This allow testing that we apply the correct interceptor (considering both the service and the interceptor name).
+@external("intercept2.ts")
+service Intercept2 {
+  @around("query notExistingMethod")
+  interceptor bypass()
+}
+
+@external("intercept1.ts")
+service Intercept1 {
+  @around("query getInt")
+  interceptor bypass()
+}
+
+@external("intercept3.ts")
+service Intercept2 {
+  @around("query notExistingMethod")
+  interceptor bypass()
+}

--- a/integration-tests/interceptor/same-name/intercept1.ts
+++ b/integration-tests/interceptor/same-name/intercept1.ts
@@ -1,0 +1,4 @@
+export async function bypass() {
+	return 10;
+}
+

--- a/integration-tests/interceptor/same-name/intercept2.ts
+++ b/integration-tests/interceptor/same-name/intercept2.ts
@@ -1,0 +1,4 @@
+export async function bypass() {
+	return 20;
+}
+

--- a/integration-tests/interceptor/same-name/intercept3.ts
+++ b/integration-tests/interceptor/same-name/intercept3.ts
@@ -1,0 +1,4 @@
+export async function bypass() {
+	return 30;
+}
+

--- a/integration-tests/interceptor/same-name/same-name.claytest
+++ b/integration-tests/interceptor/same-name/same-name.claytest
@@ -1,0 +1,10 @@
+operation: |
+  query {
+    getInt
+  }
+response: |
+  {
+    "data": {
+      "getInt": 10,
+    }
+  }


### PR DESCRIPTION
Earlier, we used the interceptor name as the key in the interceptor map. This meant that if there were multiple interceptors with the same name, an arbitrary one would be used. This commit fixes this by using the service name along with the interceptor name as the key in the map.

Fixes #526