### PR TITLE
Produce a validation error on duplicated fields

### DIFF
--- a/crates/core-subsystem/core-resolver/src/validation/validation_error.rs
+++ b/crates/core-subsystem/core-resolver/src/validation/validation_error.rs
@@ -49,8 +49,8 @@ pub enum ValidationError {
     #[error("No operation found")]
     NoOperationFound,
 
-    #[error("Duplicate operations '{0:?}' (consider using alias)")]
-    DuplicateOperations(Vec<(Pos, String)>),
+    #[error("Duplicate field names '{0:?}' (consider using alias)")]
+    DuplicateFields(Vec<String>, Vec<Pos>),
 
     #[error("Must provide operation name if query contains multiple operations")]
     MultipleOperationsNoOperationName,
@@ -60,31 +60,26 @@ pub enum ValidationError {
 }
 
 impl ValidationError {
-    pub fn position1(&self) -> Pos {
+    pub fn positions(&self) -> Vec<Pos> {
         match self {
-            ValidationError::QueryParsingFailed(_, pos, _) => *pos,
-            ValidationError::VariableNotFound(_, pos) => *pos,
-            ValidationError::MalformedVariable(_, pos, _) => *pos,
-            ValidationError::FragmentDefinitionNotFound(_, pos) => *pos,
-            ValidationError::InlineFragmentNotSupported(pos) => *pos,
-            ValidationError::OperationNotFound(_, pos) => *pos,
-            ValidationError::InvalidField(_, _, pos) => *pos,
-            ValidationError::InvalidFieldType(_, pos) => *pos,
-            ValidationError::ScalarWithField(_, pos) => *pos,
-            ValidationError::RequiredArgumentNotFound(_, pos) => *pos,
-            ValidationError::StrayArguments(_, _, pos) => *pos,
-            ValidationError::NoOperationFound => Pos::default(),
-            ValidationError::MultipleOperationsNoOperationName => Pos::default(),
-            ValidationError::MultipleOperationsUnmatchedOperationName(_) => Pos::default(),
-            ValidationError::InvalidArgumentType { pos, .. } => *pos,
-            ValidationError::DuplicateOperations(value) => value.first().unwrap().0,
-        }
-    }
-
-    pub fn position2(&self) -> Option<Pos> {
-        match self {
-            ValidationError::QueryParsingFailed(_, _, pos) => *pos,
-            _ => None,
+            ValidationError::QueryParsingFailed(_, pos1, pos2) => {
+                vec![Some(*pos1), *pos2].into_iter().flatten().collect()
+            }
+            ValidationError::VariableNotFound(_, pos) => vec![*pos],
+            ValidationError::MalformedVariable(_, pos, _) => vec![*pos],
+            ValidationError::FragmentDefinitionNotFound(_, pos) => vec![*pos],
+            ValidationError::InlineFragmentNotSupported(pos) => vec![*pos],
+            ValidationError::OperationNotFound(_, pos) => vec![*pos],
+            ValidationError::InvalidField(_, _, pos) => vec![*pos],
+            ValidationError::InvalidFieldType(_, pos) => vec![*pos],
+            ValidationError::ScalarWithField(_, pos) => vec![*pos],
+            ValidationError::RequiredArgumentNotFound(_, pos) => vec![*pos],
+            ValidationError::StrayArguments(_, _, pos) => vec![*pos],
+            ValidationError::NoOperationFound => vec![],
+            ValidationError::MultipleOperationsNoOperationName => vec![],
+            ValidationError::MultipleOperationsUnmatchedOperationName(_) => vec![],
+            ValidationError::InvalidArgumentType { pos, .. } => vec![*pos],
+            ValidationError::DuplicateFields(_, positions) => positions.clone(),
         }
     }
 }

--- a/integration-tests/error-reporting/mutiple-same-name-fields-thru-fragment.claytest
+++ b/integration-tests/error-reporting/mutiple-same-name-fields-thru-fragment.claytest
@@ -1,0 +1,45 @@
+operation: |
+    {
+      venue(id: 1) {
+        id
+        name
+        ...venueInfo
+        name
+        name
+        published
+      }
+    }
+
+    fragment venueInfo on Venue {
+        id
+    }
+response: |
+    {
+      "errors": [
+        {
+          "message": "Duplicate field names '[id, name]' (consider using alias)",
+          "locations": [
+            {
+              "line": 3,
+              "column": 5
+            },
+            {
+              "line": 4,
+              "column": 5
+            },
+            {
+              "line": 13,
+              "column": 5
+            },
+            {
+              "line": 6,
+              "column": 5
+            },
+            {
+              "line": 7,
+              "column": 5
+            }
+          ]
+        }
+      ]
+    }

--- a/integration-tests/error-reporting/mutiple-same-name-fields.claytest
+++ b/integration-tests/error-reporting/mutiple-same-name-fields.claytest
@@ -1,0 +1,41 @@
+operation: |
+    {
+      venue(id: 1) {
+        id
+        name
+        id
+        name
+        name
+        published
+      }
+    }
+response: |
+    {
+      "errors": [
+        {
+          "message": "Duplicate field names '[id, name]' (consider using alias)",
+          "locations": [
+            {
+              "line": 3,
+              "column": 5
+            },
+            {
+              "line": 4,
+              "column": 5
+            },
+            {
+              "line": 5,
+              "column": 5
+            },
+            {
+              "line": 6,
+              "column": 5
+            },
+            {
+              "line": 7,
+              "column": 5
+            }
+          ]
+        }
+      ]
+    }

--- a/integration-tests/error-reporting/mutiple-same-name-queries.claytest
+++ b/integration-tests/error-reporting/mutiple-same-name-queries.claytest
@@ -11,13 +11,17 @@ response: |
     {
       "errors": [
         {
-          "message": "Argument 'data' is not of a valid type. Expected 'VenueCreationInput', got '[VenueCreationInput]'",
+          "message": "Duplicate field names '[venue]' (consider using alias)",
           "locations": [
             {
               "line": 2,
-              "column": 21
+              "column": 3
+            },
+            {
+              "line": 5,
+              "column": 3
             }
           ]
         }
       ]
-    }    
+    }


### PR DESCRIPTION
GraphQL spec doesn't allow duplicated fields on the same level of the
query. This change adds a validation error for this case.

Note that queries and mutations are just another kind of fields, so
this change also takes care of duplicated queries and mutations.

Fixes #487