### PR TITLE
Exposed only used scalars through introspection

### DIFF
--- a/crates/core-subsystem/core-resolver/src/validation/mod.rs
+++ b/crates/core-subsystem/core-resolver/src/validation/mod.rs
@@ -13,7 +13,7 @@ mod arguments_validator;
 mod operation_validator;
 mod selection_set_validator;
 
-fn underlying_type(typ: &Type) -> &Name {
+pub fn underlying_type(typ: &Type) -> &Name {
     match &typ.base {
         BaseType::Named(name) => name,
         BaseType::List(typ) => underlying_type(typ),


### PR DESCRIPTION
We had two issues:
1. We exposed all scalars through introspection, even if they were not used in the schema.
2. We exposed scalars multiple times.

Fixes #518