### PR TITLE
Fix return type modifiers for postgres mutations

### DIFF
--- a/crates/core-subsystem/core-model/src/type_normalization.rs
+++ b/crates/core-subsystem/core-model/src/type_normalization.rs
@@ -69,7 +69,7 @@ impl InputValueProvider for &dyn Parameter {
     parameter_input_value_provider!();
 }
 
-pub fn value_type(name: &str, type_modifier: &TypeModifier) -> Type {
+fn value_type(name: &str, type_modifier: &TypeModifier) -> Type {
     let base_field_type = BaseType::Named(Name::new(name));
     match type_modifier {
         TypeModifier::Optional => Type {
@@ -83,7 +83,7 @@ pub fn value_type(name: &str, type_modifier: &TypeModifier) -> Type {
         TypeModifier::List => Type {
             base: BaseType::List(Box::new(Type {
                 base: base_field_type,
-                nullable: true,
+                nullable: false, // Reasonable default; See https://github.com/payalabs/payas/issues/599 for a proper fix
             })),
             nullable: true,
         },

--- a/crates/postgres-subsystem/postgres-model-builder/src/create_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/create_mutation_builder.rs
@@ -5,7 +5,7 @@ use core_plugin_interface::core_model::mapped_arena::{MappedArena, SerializableS
 
 use postgres_model::{
     operation::{CreateDataParameter, CreateDataParameterTypeWithModifier, PostgresMutationKind},
-    types::{PostgresCompositeType, PostgresType, PostgresTypeKind},
+    types::{PostgresCompositeType, PostgresType, PostgresTypeKind, PostgresTypeModifier},
 };
 
 use super::{
@@ -71,6 +71,10 @@ impl MutationBuilder for CreateMutationBuilder {
         building: &SystemContextBuilding,
     ) -> PostgresMutationKind {
         PostgresMutationKind::Create(Self::data_param(model_type, building, false))
+    }
+
+    fn single_mutation_type_modifier() -> PostgresTypeModifier {
+        PostgresTypeModifier::NonNull
     }
 
     fn multi_mutation_name(model_type: &PostgresType) -> String {

--- a/crates/postgres-subsystem/postgres-model-builder/src/delete_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/delete_mutation_builder.rs
@@ -3,7 +3,7 @@
 
 use core_plugin_interface::core_model::mapped_arena::{MappedArena, SerializableSlabIndex};
 use postgres_model::operation::PostgresMutationKind;
-use postgres_model::types::{PostgresType, PostgresTypeKind};
+use postgres_model::types::{PostgresType, PostgresTypeKind, PostgresTypeModifier};
 
 use super::{
     builder::Builder,
@@ -65,6 +65,10 @@ impl MutationBuilder for DeleteMutationBuilder {
             model_type,
             building,
         ))
+    }
+
+    fn single_mutation_type_modifier() -> PostgresTypeModifier {
+        PostgresTypeModifier::Optional // We return null if the specified id doesn't exist
     }
 
     fn multi_mutation_name(model_type: &PostgresType) -> String {

--- a/crates/postgres-subsystem/postgres-model-builder/src/mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/mutation_builder.rs
@@ -53,6 +53,7 @@ pub trait MutationBuilder {
         model_type: &PostgresType,
         building: &SystemContextBuilding,
     ) -> PostgresMutationKind;
+    fn single_mutation_type_modifier() -> PostgresTypeModifier;
 
     fn multi_mutation_name(model_type: &PostgresType) -> String;
     fn multi_mutation_kind(
@@ -73,7 +74,7 @@ pub trait MutationBuilder {
             return_type: OperationReturnType {
                 type_id: model_type_id,
                 type_name: model_type.name.clone(),
-                type_modifier: PostgresTypeModifier::Optional,
+                type_modifier: Self::single_mutation_type_modifier(),
             },
         };
 

--- a/crates/postgres-subsystem/postgres-model-builder/src/update_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/update_mutation_builder.rs
@@ -6,6 +6,7 @@ use postgres_model::{
     operation::{PostgresMutationKind, UpdateDataParameter},
     types::{
         PostgresCompositeType, PostgresField, PostgresFieldType, PostgresType, PostgresTypeKind,
+        PostgresTypeModifier,
     },
 };
 
@@ -80,6 +81,10 @@ impl MutationBuilder for UpdateMutationBuilder {
             data_param: Self::data_param(model_type, building, false),
             predicate_param: query_builder::pk_predicate_param(model_type_id, model_type, building),
         }
+    }
+
+    fn single_mutation_type_modifier() -> PostgresTypeModifier {
+        PostgresTypeModifier::Optional // We return null if the specified id doesn't exist
     }
 
     fn multi_mutation_name(model_type: &PostgresType) -> String {


### PR DESCRIPTION
We were returning optional types all for mutations, which is not correct for the creation mutations. We also returned list of optional types for all bulk mutations.

Now we return non-optional types for creation mutations and list of non-optional types for all bulk mutations.

Filed https://github.com/payalabs/payas/issues/599 to fix this properly (the behavior will remain the same, but the code will be cleaner).