### PR TITLE
Improve DX for the 'clay serve' command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,6 +885,7 @@ dependencies = [
 name = "cli"
 version = "0.1.0"
 dependencies = [
+ "ansi_term",
  "anyhow",
  "builder",
  "clap",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -8,6 +8,7 @@ name = "clay"
 path = "src/main.rs"
 
 [dependencies]
+ansi_term = "0.12"
 tokio = "1"
 anyhow = "1.0"
 clap = "4.0.18"

--- a/crates/cli/src/util/watcher.rs
+++ b/crates/cli/src/util/watcher.rs
@@ -29,7 +29,13 @@ where
     })?;
 
     // start watcher
-    println!("Watching: {:?}", &parent_dir);
+    println!(
+        "{} {}",
+        ansi_term::Color::Blue.bold().paint("Watching:"),
+        ansi_term::Color::Cyan
+            .bold()
+            .paint(&parent_dir.display().to_string())
+    );
 
     let (watcher_tx, mut watcher_rx) = tokio::sync::mpsc::channel(1);
     let mut debouncer =
@@ -62,7 +68,11 @@ where
         match build_result {
             Ok(()) => {
                 if let Err(e) = prestart_callback().await {
-                    println!("Error: {e}");
+                    println!(
+                        "{} {}",
+                        ansi_term::Color::Red.bold().paint("Error:"),
+                        ansi_term::Color::Red.bold().paint(e.to_string())
+                    );
                 }
 
                 let mut command = tokio::process::Command::new(&server_binary);


### PR DESCRIPTION
- Always enable introspection and use relaxed CORS settings (allow all hosts)
- Print a message that the server is in the development mode (to point that this is not to be used in production)
- Use colors to call out important content in messages printed to the console

Fixes #614
Fixes #615