### PR TITLE
Fix __typename in aggregate queries

### DIFF
--- a/crates/postgres-subsystem/postgres-model/src/operation.rs
+++ b/crates/postgres-subsystem/postgres-model/src/operation.rs
@@ -2,7 +2,6 @@ use std::fmt::Debug;
 
 use core_plugin_interface::core_model::mapped_arena::SerializableSlabIndex;
 use core_plugin_interface::core_model::type_normalization::{Operation, Parameter, TypeModifier};
-use payas_sql::PhysicalTable;
 use serde::{Deserialize, Serialize};
 
 use crate::types::EntityType;
@@ -123,11 +122,6 @@ pub struct OperationReturnType {
 impl OperationReturnType {
     pub fn typ<'a>(&'a self, system: &'a PostgresSubsystem) -> &EntityType {
         &system.entity_types[self.type_id]
-    }
-
-    pub fn physical_table<'a>(&self, system: &'a PostgresSubsystem) -> &'a PhysicalTable {
-        let return_type = self.typ(system);
-        &system.tables[return_type.table_id]
     }
 }
 

--- a/crates/postgres-subsystem/postgres-model/src/types.rs
+++ b/crates/postgres-subsystem/postgres-model/src/types.rs
@@ -111,23 +111,9 @@ impl EntityType {
 }
 
 impl MutationType {
-    pub fn entity_type<'a>(
-        &'a self,
-        entity_types: &'a SerializableSlab<EntityType>,
-    ) -> &'a EntityType {
-        &entity_types[self.entity_type]
-    }
-
-    pub fn table_id(
-        &self,
-        entity_types: &SerializableSlab<EntityType>,
-    ) -> SerializableSlabIndex<PhysicalTable> {
-        let entity_type = self.entity_type(entity_types);
-        entity_type.table_id
-    }
-
     pub fn table<'a>(&'a self, system: &'a PostgresSubsystem) -> &'a PhysicalTable {
-        let table_id = self.table_id(&system.entity_types);
+        let entity_type = &system.entity_types[self.entity_type];
+        let table_id = entity_type.table_id;
         &system.tables[table_id]
     }
 }

--- a/crates/postgres-subsystem/postgres-resolver/src/create_data_param_mapper.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/create_data_param_mapper.rs
@@ -31,9 +31,8 @@ impl<'a> SQLMapper<'a, AbstractInsert<'a>> for InsertOperation<'a> {
         argument: &'a ConstValue,
         subsystem: &'a PostgresSubsystem,
     ) -> Result<AbstractInsert<'a>, PostgresExecutionError> {
-        let table = self.return_type.physical_table(subsystem);
-
         let data_type = &subsystem.mutation_types[self.data_param.typ.type_id];
+        let table = data_type.table(subsystem);
 
         let rows = map_argument(data_type, argument, subsystem)?;
 

--- a/crates/postgres-subsystem/postgres-resolver/src/postgres_query.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/postgres_query.rs
@@ -19,7 +19,7 @@ use payas_sql::{
 };
 use postgres_model::{
     aggregate::AggregateField,
-    operation::{CollectionQuery, OperationReturnType, PkQuery},
+    operation::{CollectionQuery, CollectionQueryParameter, OperationReturnType, PkQuery},
     order::OrderByParameter,
     predicate::PredicateParameter,
     relation::{PostgresRelation, RelationCardinality},
@@ -57,13 +57,18 @@ impl OperationSelectionResolver for CollectionQuery {
         request_context: &'a RequestContext<'a>,
         subsystem: &'a PostgresSubsystem,
     ) -> Result<AbstractSelect<'a>, PostgresExecutionError> {
-        let parameter = &self.parameter;
+        let CollectionQueryParameter {
+            predicate_param,
+            order_by_param,
+            limit_param,
+            offset_param,
+        } = &self.parameter;
 
         compute_select(
-            &parameter.predicate_param,
-            compute_order_by(&parameter.order_by_param, &field.arguments, subsystem)?,
-            extract_and_map(&parameter.limit_param, &field.arguments, subsystem)?,
-            extract_and_map(&parameter.offset_param, &field.arguments, subsystem)?,
+            predicate_param,
+            compute_order_by(order_by_param, &field.arguments, subsystem)?,
+            extract_and_map(limit_param, &field.arguments, subsystem)?,
+            extract_and_map(offset_param, &field.arguments, subsystem)?,
             &self.return_type,
             field,
             subsystem,

--- a/integration-tests/basic-model-no-auth/top-level-agg.claytest
+++ b/integration-tests/basic-model-no-auth/top-level-agg.claytest
@@ -1,6 +1,7 @@
 operation: |
     query {
       venuesAgg {
+          __typename
           id {
             count
           }
@@ -13,6 +14,7 @@ operation: |
       }
 
       higherLatitudeVenuesAgg: venuesAgg(where: {latitude: {gt: 36}}) {
+          __typename
           id {
             count
           }
@@ -25,6 +27,7 @@ operation: |
       }
 
       concertsAgg {
+          __typename
           id {
             count
           }
@@ -37,6 +40,7 @@ operation: |
       }
 
       expensiveConcertsAgg: concertsAgg(where: {price: {gt: "20"}}) {
+          __typename
           id {
             count
           }
@@ -49,6 +53,7 @@ operation: |
       }
 
       highLatitudeConcertsAgg: concertsAgg(where: {venue: {latitude: {gt: 36}}}) { # An example of predicate on nested element
+          __typename
           id {
             count
           }
@@ -64,6 +69,7 @@ response: |
     {
       "data": {
         "venuesAgg": {
+          "__typename": "VenueAgg",
           "id": {
             "count": 2
           },
@@ -75,6 +81,7 @@ response: |
           }
         },
         "higherLatitudeVenuesAgg": {
+          "__typename": "VenueAgg",
           "id": {
             "count": 1
           },
@@ -86,6 +93,7 @@ response: |
           }
         },
         "concertsAgg": {
+          "__typename": "ConcertAgg",
           "id": {
             "count": 4
           },
@@ -97,6 +105,7 @@ response: |
           }
         },
         "expensiveConcertsAgg": {
+          "__typename": "ConcertAgg",
           "id": {
             "count": 3
           },
@@ -108,6 +117,7 @@ response: |
           }
         },
         "highLatitudeConcertsAgg": {
+          "__typename": "ConcertAgg",
           "id": {
             "count": 2
           },

--- a/integration-tests/basic-model-no-auth/venues-with-concert-agg.claytest
+++ b/integration-tests/basic-model-no-auth/venues-with-concert-agg.claytest
@@ -8,6 +8,7 @@ operation: |
           price
         }
         concertsAgg {
+          __typename
           id {
             count
           }
@@ -27,6 +28,7 @@ operation: |
           price
         }
         expensiveConcertsAgg: concertsAgg(where: {price: {gt: "20"}}) {
+          __typename
           id {
             count
           }
@@ -46,6 +48,7 @@ operation: |
           price
         }
         concertsAgg {
+          __typename
           id {
             count
           }
@@ -75,6 +78,7 @@ response: |
               }
             ],
             "concertsAgg": {
+              "__typename": "ConcertAgg",
               "id": {
                 "count": 2
               },
@@ -99,6 +103,7 @@ response: |
               }
             ],
             "concertsAgg": {
+              "__typename": "ConcertAgg",
               "id": {
                 "count": 2
               },
@@ -125,6 +130,7 @@ response: |
               }
             ],
             "expensiveConcertsAgg": {
+              "__typename": "ConcertAgg",
               "id": {
                 "count": 2
               },
@@ -149,6 +155,7 @@ response: |
               }
             ],
             "expensiveConcertsAgg": {
+              "__typename": "ConcertAgg",
               "id": {
                 "count": 1
               },
@@ -174,6 +181,7 @@ response: |
             }
           ],
           "concertsAgg": {
+            "__typename": "ConcertAgg",
             "id": {
               "count": 2
             },


### PR DESCRIPTION
We were returning the entity type name (say "Concert") instead of the aggregate type name (say "ConcertAgg") in aggregate queries. This fixes that as well as adds a test for it.

Also remove some unused code.