### PR TITLE
Rename "clay serve" to "clay dev"

### DIFF
--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -15,12 +15,12 @@ use crate::{
 use super::command::Command;
 
 /// Run local claytip server
-pub struct ServeCommand {
+pub struct DevCommand {
     pub model: PathBuf,
     pub port: Option<u32>,
 }
 
-impl Command for ServeCommand {
+impl Command for DevCommand {
     fn run(&self, _system_start_time: Option<SystemTime>) -> Result<()> {
         println!(
             "{}",

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2,7 +2,7 @@
 
 pub(crate) mod build;
 pub(crate) mod command;
+pub(crate) mod dev;
 pub(crate) mod schema;
-pub(crate) mod serve;
 pub(crate) mod test;
 pub(crate) mod yolo;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -7,7 +7,7 @@ use std::{
 
 use anyhow::{anyhow, Result};
 use clap::{Arg, Command};
-use commands::{serve::ServeCommand, test::TestCommand, yolo::YoloCommand};
+use commands::{dev::DevCommand, test::TestCommand, yolo::YoloCommand};
 use tokio::sync::{
     broadcast::{Receiver, Sender},
     Mutex,
@@ -135,7 +135,7 @@ fn main() -> Result<()> {
                 ),
         )
         .subcommand(
-            Command::new("serve")
+            Command::new("dev")
                 .about("Run claytip server in development mode")
                 .arg(model_file_arg())
                 .arg(port_arg()),
@@ -210,7 +210,7 @@ fn main() -> Result<()> {
             }),
             _ => panic!("Unhandled command name"),
         },
-        Some(("serve", matches)) => Box::new(ServeCommand {
+        Some(("dev", matches)) => Box::new(DevCommand {
             model: get_required(matches, "model")?,
             port: get(matches, "port"),
         }),


### PR DESCRIPTION
The "serve" part didn't convey the meaning (that it will run in the development mode with watching and schema checking). Furthermore, due to "clay-server" which is production mode, it caused confusion.

So, we now have "clay dev" for development mode and "clay-server" for production mode. It also matches how node.js ecosystem uses the "dev" subcommand (such as "npm run dev", "yarn dev", or "next run dev").