### PR TITLE
Use FieldType mechanism for context field types

### DIFF
--- a/crates/core-subsystem/core-model-builder/src/builder/context_builder.rs
+++ b/crates/core-subsystem/core-model-builder/src/builder/context_builder.rs
@@ -70,7 +70,7 @@ fn expand(context: &ResolvedContext, building: &mut SystemContextBuilding) {
 
 fn create_context_field_type(field_type: &ResolvedContextFieldType) -> ContextFieldType {
     match field_type {
-        ResolvedContextFieldType::Plain(pt) => ContextFieldType::Reference(pt.clone()),
+        ResolvedContextFieldType::Plain(pt) => ContextFieldType::Plain(pt.clone()),
         ResolvedContextFieldType::Optional(underlying) => {
             ContextFieldType::Optional(Box::new(create_context_field_type(underlying)))
         }

--- a/crates/core-subsystem/core-model-builder/src/builder/resolved_builder.rs
+++ b/crates/core-subsystem/core-model-builder/src/builder/resolved_builder.rs
@@ -1,5 +1,5 @@
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
-use core_model::{mapped_arena::MappedArena, primitive_type::PrimitiveType};
+use core_model::{mapped_arena::MappedArena, primitive_type::PrimitiveType, types::FieldType};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -38,25 +38,20 @@ impl AstAnnotationHelper for AstAnnotation<Typed> {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ResolvedContext {
     pub name: String,
     pub fields: Vec<ResolvedContextField>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ResolvedContextField {
     pub name: String,
     pub typ: ResolvedContextFieldType,
     pub source: ResolvedContextSource,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub enum ResolvedContextFieldType {
-    Plain(PrimitiveType),
-    Optional(Box<ResolvedContextFieldType>),
-    List(Box<ResolvedContextFieldType>),
-}
+pub type ResolvedContextFieldType = FieldType<PrimitiveType>;
 
 // For now, ResolvedContextSource and ContextSource have the same structure
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]

--- a/crates/core-subsystem/core-model/src/context_type.rs
+++ b/crates/core-subsystem/core-model/src/context_type.rs
@@ -21,7 +21,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::primitive_type::PrimitiveType;
+use crate::{primitive_type::PrimitiveType, types::FieldType};
 
 /// A context type to represent objects such as `AuthContext` and `IPContext`
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -44,14 +44,7 @@ pub struct ContextField {
 }
 
 /// The type of a context field such as `Int` and `Array<String>`
-///
-/// TODO: We should model this using `FieldType<PrimitiveType>`
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum ContextFieldType {
-    Reference(PrimitiveType),
-    Optional(Box<ContextFieldType>),
-    List(Box<ContextFieldType>),
-}
+pub type ContextFieldType = FieldType<PrimitiveType>;
 
 /// The source of a context field such as JWT or client IP
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -60,15 +53,4 @@ pub struct ContextSource {
     pub annotation_name: String,
     /// Annotation arguments such as `id` and `roles`
     pub value: Option<String>,
-}
-
-impl ContextFieldType {
-    pub fn primitive_type(&self) -> &PrimitiveType {
-        match self {
-            ContextFieldType::Optional(underlying) | ContextFieldType::List(underlying) => {
-                underlying.primitive_type()
-            }
-            ContextFieldType::Reference(pt) => pt,
-        }
-    }
 }

--- a/crates/deno-subsystem/deno-model-builder/src/service_skeleton_generator.rs
+++ b/crates/deno-subsystem/deno-model-builder/src/service_skeleton_generator.rs
@@ -242,7 +242,7 @@ impl TypeScriptType for ContextFieldType {
     fn typescript_type(&self) -> String {
         match self {
             ContextFieldType::Optional(typ) => format!("{}?", typ.typescript_type()),
-            ContextFieldType::Reference(pt) => typescript_base_type(&pt.name()),
+            ContextFieldType::Plain(pt) => typescript_base_type(&pt.name()),
             ContextFieldType::List(typ) => format!("{}[]", typ.typescript_type()),
         }
     }

--- a/crates/postgres-subsystem/postgres-model-builder/src/access_utils.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/access_utils.rs
@@ -69,7 +69,7 @@ pub fn compute_predicate_expression(
                     }
                 }
                 PathSelection::Context(context_selection, field_type) => {
-                    if field_type.primitive_type() == &PrimitiveType::Boolean {
+                    if field_type.innermost() == &PrimitiveType::Boolean {
                         // Treat boolean context expressions in the same way as an "eq" relational expression
                         // For example, treat `AuthContext.superUser` the same way as `AuthContext.superUser == true`
                         Ok(AccessPredicateExpression::RelationalOp(

--- a/crates/subsystem-util/subsystem-model-builder-util/src/builder/access_utils.rs
+++ b/crates/subsystem-util/subsystem-model-builder-util/src/builder/access_utils.rs
@@ -26,7 +26,7 @@ pub fn compute_predicate_expression(
     match expr {
         AstExpr::FieldSelection(selection) => match compute_selection(selection, resolved_env) {
             PathSelection::Context(context_selection, field_type) => {
-                if field_type.primitive_type() == &PrimitiveType::Boolean {
+                if field_type.innermost() == &PrimitiveType::Boolean {
                     // Treat boolean context expressions in the same way as an "eq" relational expression
                     // For example, treat `AuthContext.superUser` the same way as `AuthContext.superUser == true`
                     Ok(AccessPredicateExpression::RelationalOp(


### PR DESCRIPTION
We now use `FieldType` for `ContextField` and `ResolvedContextFieldType`. This makes it more consistent with the rest.