### PR TITLE
Fix a possible race condition in CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,7 +23,7 @@ steps:
       path: /sccache
     commands:
       - cargo fmt --all -- --check
-      - cargo clippy --all --all-targets --all-features -- -D warnings
+      - cargo clippy --all --all-targets --all-features -- -D warnings --no-deps
 
   - name: build
     image: payas-ci-image


### PR DESCRIPTION
Currently, we build multiple times in parallel (test and test-integration). It seems that graphiql build from one clashes with the other. So we now introduce a separate build step and have the test and test-integration steps depend on it.