### PR TITLE
Update VS Code extension for recent syntax changes

### DIFF
--- a/vscode-extension/src/package.json
+++ b/vscode-extension/src/package.json
@@ -14,7 +14,7 @@
       {
         "id": "claytip",
         "aliases": [
-          "claytip",
+          "Claytip",
           "claytip"
         ],
         "extensions": [

--- a/vscode-extension/src/syntaxes/claytip.tmLanguage.template.json
+++ b/vscode-extension/src/syntaxes/claytip.tmLanguage.template.json
@@ -238,7 +238,7 @@
       "patterns": [
         {
           "name": "meta.method.declaration.claytip",
-          "begin": "(?:(export){{ws}})?(?:(async){{ws}})?(query|mutation|interceptor)(?:(?:{{ws}}|(?<=\\*))({{identifier}}))?{{opt_ws}}",
+          "begin": "(?:(export){{ws}})?(query|mutation|interceptor)(?:(?:{{ws}}|(?<=\\*))({{identifier}}))?{{opt_ws}}",
           "beginCaptures": {
             "1": {
               "name": "keyword.control.export.claytip"

--- a/vscode-extension/test/example.clay
+++ b/vscode-extension/test/example.clay
@@ -6,16 +6,16 @@ service ConcertVenues {
   type Concert {
     @pk id: Int = autoIncrement() // comment after annotation
     title: String // comment after type
-    venue: Venue @column("venueid")
+    @column("venueid") venue: Venue 
     published: Boolean
-    price: Decimal @precision(20) @scale(2)
+    @precision(20) @scale(2) price: Decimal 
   }
 
   @table("venues")
   type Venue {
     @pk id: Int = autoIncrement() // highlighting of functions in default field
     name: String = "abc" // highlighting of strings in default field
-    concerts: Set<Concert> @column("venueid")
+    @column("venueid") concerts: Set<Concert> 
     published: Boolean
     occupancy: Int = 200 // highlighting of numbers in default field
     latitude: Float @size(4)
@@ -36,11 +36,11 @@ service _ServiceStartWithAnUnderscore_AndHas_Underscores {
 
 context AuthContext {
   @jwt("sub") id: Int 
-  role: String @jwt("role")
+  @jwt("role") role: String 
 }
 
 service MyService {
-  export async mutation foo(i: Int, zz: String): number
+  export mutation foo(i: Int, zz: String): number
 
   query get_this(in: Concert_Info): Concert
   query get_this_too(in: Concert_Info): Concert_Output
@@ -86,5 +86,5 @@ service Authentication {
     info: String
   }
 
-  export async mutation authenticate(loginInfo: LoginInput, @inject claytip: Claytip): Result<String, LoginError>
+  export mutation authenticate(loginInfo: LoginInput, @inject claytip: Claytip): Result<String, LoginError>
 }


### PR DESCRIPTION
- Change example.clay to use new syntax (mainly move field annotation to the beginning of the line)
- Remove highlighting of `async`, since we no longer support that for queries and mutations
- Update alias so that "Claytip" and not "claytip" shows up in the language selection menu