### PR TITLE
Default the key for a context source to the field name

### DIFF
--- a/crates/core-subsystem/core-resolver/src/request_context/cookie.rs
+++ b/crates/core-subsystem/core-resolver/src/request_context/cookie.rs
@@ -46,11 +46,12 @@ impl ParsedContext for ParsedCookieContext {
     async fn extract_context_field<'r>(
         &self,
         key: Option<&str>,
+        field_name: &str,
         _request_context: &'r RequestContext<'r>,
         _request: &'r (dyn Request + Send + Sync),
     ) -> Option<Value> {
         self.cookies
-            .get(key?)
+            .get(key.unwrap_or(field_name))
             .map(|c| (*c.value()).to_string().into())
     }
 }

--- a/crates/core-subsystem/core-resolver/src/request_context/environment.rs
+++ b/crates/core-subsystem/core-resolver/src/request_context/environment.rs
@@ -14,9 +14,12 @@ impl ParsedContext for EnvironmentContextExtractor {
     async fn extract_context_field<'r>(
         &self,
         key: Option<&str>,
+        field_name: &str,
         _request_context: &'r RequestContext<'r>,
         _request: &'r (dyn Request + Send + Sync),
     ) -> Option<Value> {
-        std::env::var(key?).ok().map(|v| v.into())
+        std::env::var(key.unwrap_or(field_name))
+            .ok()
+            .map(|v| v.into())
     }
 }

--- a/crates/core-subsystem/core-resolver/src/request_context/header.rs
+++ b/crates/core-subsystem/core-resolver/src/request_context/header.rs
@@ -15,11 +15,12 @@ impl ParsedContext for HeaderExtractor {
     async fn extract_context_field<'r>(
         &self,
         key: Option<&str>,
+        field_name: &str,
         _request_context: &'r RequestContext<'r>,
         request: &'r (dyn Request + Send + Sync),
     ) -> Option<Value> {
         request
-            .get_header(&key?.to_ascii_lowercase())
+            .get_header(&key.unwrap_or(field_name).to_ascii_lowercase())
             .map(|str| str.as_str().into())
     }
 }

--- a/crates/core-subsystem/core-resolver/src/request_context/ip.rs
+++ b/crates/core-subsystem/core-resolver/src/request_context/ip.rs
@@ -15,6 +15,7 @@ impl ParsedContext for IpExtractor {
     async fn extract_context_field<'r>(
         &self,
         _key: Option<&str>,
+        _field_name: &str,
         _request_context: &'r RequestContext<'r>,
         request: &'r (dyn Request + Send + Sync),
     ) -> Option<Value> {

--- a/crates/core-subsystem/core-resolver/src/request_context/jwt.rs
+++ b/crates/core-subsystem/core-resolver/src/request_context/jwt.rs
@@ -100,9 +100,10 @@ impl ParsedContext for ParsedJwtContext {
     async fn extract_context_field<'r>(
         &self,
         key: Option<&str>,
+        field_name: &str,
         _request_context: &'r RequestContext<'r>,
         _request: &'r (dyn Request + Send + Sync),
     ) -> Option<Value> {
-        self.jwt_claims.get(key?).cloned()
+        self.jwt_claims.get(key.unwrap_or(field_name)).cloned()
     }
 }

--- a/crates/core-subsystem/core-resolver/src/request_context/mod.rs
+++ b/crates/core-subsystem/core-resolver/src/request_context/mod.rs
@@ -154,6 +154,7 @@ impl<'a> RequestContext<'a> {
         parsed_context_map: &HashMap<String, BoxedParsedContext<'a>>,
         request: &'a (dyn Request + Send + Sync),
         annotation_name: &str,
+        field_name: &str,
         value: Option<&str>,
     ) -> Result<Option<Value>, ContextParsingError> {
         let parsed_context = parsed_context_map
@@ -161,7 +162,7 @@ impl<'a> RequestContext<'a> {
             .ok_or_else(|| ContextParsingError::SourceNotFound(annotation_name.into()))?;
 
         Ok(parsed_context
-            .extract_context_field(value, self, request)
+            .extract_context_field(value, field_name, self, request)
             .await)
     }
 
@@ -182,6 +183,7 @@ impl<'a> RequestContext<'a> {
                         parsed_context_map,
                         *request,
                         &field.source.annotation_name,
+                        &field.name,
                         field.source.value.as_deref(),
                     )
                     .await?;
@@ -218,6 +220,7 @@ pub trait ParsedContext {
     async fn extract_context_field<'r>(
         &self,
         key: Option<&str>,
+        field_name: &str,
         request_context: &'r RequestContext<'r>,
         request: &'r (dyn Request + Send + Sync),
     ) -> Option<Value>;
@@ -239,6 +242,7 @@ impl ParsedContext for TestRequestContext {
     async fn extract_context_field<'r>(
         &self,
         key: Option<&str>,
+        _field_name: &str,
         _request_context: &'r RequestContext<'r>,
         _request: &'r (dyn Request + Send + Sync),
     ) -> Option<Value> {

--- a/crates/core-subsystem/core-resolver/src/request_context/query.rs
+++ b/crates/core-subsystem/core-resolver/src/request_context/query.rs
@@ -25,10 +25,11 @@ impl ParsedContext for QueryExtractor<'_> {
     async fn extract_context_field<'r>(
         &self,
         key: Option<&str>,
+        field_name: &str,
         request_context: &'r RequestContext<'r>,
         _request: &'r (dyn Request + Send + Sync),
     ) -> Option<serde_json::Value> {
-        let key = key?;
+        let key = key.unwrap_or(field_name);
         let query = format!("query {{ {} }}", key.to_owned());
 
         let result = self

--- a/integration-tests/basic-model-with-auth/concerts-auth.clay
+++ b/integration-tests/basic-model-with-auth/concerts-auth.clay
@@ -1,6 +1,6 @@
 context AuthContext {
   @jwt("sub") id: Int 
-  @jwt("role") role: String 
+  @jwt role: String 
 }
 
 @postgres


### PR DESCRIPTION
This allows skipping the annotation value if the key is the same as the field name. For example, users can now write just `@jwt role: String` instead of `@jwt("role") role: String`.