### PR TITLE
Fix nested predicate for update mutations

### DIFF
--- a/integration-tests/basic-model-no-auth/concerts-mixed-update-logical-and.claytest
+++ b/integration-tests/basic-model-no-auth/concerts-mixed-update-logical-and.claytest
@@ -1,0 +1,27 @@
+# Mixed level predicates connected by AND
+operation: |
+    mutation {
+      updateConcerts(where: {and: [{title: {eq: "Concert1"}}, {venue: {id: {eq: 1}}}]}, data: {price: "100"}) {
+        id
+        price
+        venue {
+          id
+          name
+        }
+      }
+    }
+response: |
+    {
+      "data": {
+        "updateConcerts": [
+          {
+            "id": 1,
+            "price": "100.00",
+            "venue": {
+              "id": 1,
+              "name": "Venue1"
+            }
+          }
+        ]
+      }
+    }

--- a/integration-tests/basic-model-no-auth/concerts-nested-update-logical-and.claytest
+++ b/integration-tests/basic-model-no-auth/concerts-nested-update-logical-and.claytest
@@ -1,0 +1,34 @@
+operation: |
+    mutation {
+      updateConcerts(where: {and: [{venue: {name: {eq: "Venue1"}}}, {venue: {id: {eq: 1}}}]}, data: {price: "100"}) {
+        id
+        price
+        venue {
+          id
+          name
+        }
+      }
+    }
+response: |
+    {
+      "data": {
+        "updateConcerts": [
+          {
+            "id": 1,
+            "price": "100.00",
+            "venue": {
+              "id": 1,
+              "name": "Venue1"
+            }
+          },
+          {
+            "id": 3,
+            "price": "100.00",
+            "venue": {
+              "id": 1,
+              "name": "Venue1"
+            }
+          },
+        ]
+      }
+    }

--- a/integration-tests/basic-model-no-auth/concerts-nested-update-logical-or.claytest
+++ b/integration-tests/basic-model-no-auth/concerts-nested-update-logical-or.claytest
@@ -1,0 +1,50 @@
+operation: |
+    mutation {
+      updateConcerts(where: {or: [{venue: {name: {eq: "Venue1"}}}, {venue: {name: {eq: "Venue2"}}}]}, data: {price: "100"}) {
+        id
+        price
+        venue {
+          id
+          name
+        }
+      }
+    }
+response: |
+    {
+      "data": {
+        "updateConcerts": [
+          {
+            "id": 1,
+            "price": "100.00",
+            "venue": {
+              "id": 1,
+              "name": "Venue1"
+            }
+          },
+          {
+            "id": 2,
+            "price": "100.00",
+            "venue": {
+              "id": 2,
+              "name": "Venue2"
+            }
+          },
+          {
+            "id": 3,
+            "price": "100.00",
+            "venue": {
+              "id": 1,
+              "name": "Venue1"
+            }
+          },
+          {
+            "id": 4,
+            "price": "100.00",
+            "venue": {
+              "id": 2,
+              "name": "Venue2"
+            }
+          }
+        ]
+      }
+    }

--- a/integration-tests/basic-model-no-auth/concerts-nested-update.claytest
+++ b/integration-tests/basic-model-no-auth/concerts-nested-update.claytest
@@ -1,0 +1,34 @@
+operation: |
+    mutation {
+      updateConcerts(where: {venue: {name: {eq: "Venue1"}}}, data: {price: "50"}) {
+        id
+        price
+        venue {
+          id
+          name
+        }
+      }
+    }
+response: |
+    {
+      "data": {
+        "updateConcerts": [
+          {
+            "id": 3,
+            "price": "50.00",
+            "venue": {
+              "id": 1,
+              "name": "Venue1"
+            }
+          },
+          {
+            "id": 1,
+            "price": "50.00",
+            "venue": {
+              "id": 1,
+              "name": "Venue1"
+            }
+          }
+        ]
+      }
+    }

--- a/integration-tests/basic-model-no-auth/concerts-update.claytest
+++ b/integration-tests/basic-model-no-auth/concerts-update.claytest
@@ -1,0 +1,27 @@
+operation: |
+    mutation {
+      updateConcerts(where: {title: {eq: "Concert1"}}, data: {price: "50"}) {
+        id
+        price
+        venue {
+          id
+          name
+        }
+      }
+    }
+response: |
+    {
+      "data": {
+        "updateConcerts": [
+          {
+            "id": 1,
+            "price": "50.00",
+            "venue": {
+              "id": 1,
+              "name": "Venue1"
+            }
+          }
+        ]
+      }
+    }
+    


### PR DESCRIPTION
Like the d49a2bff76ee2a26515fb34e86476482d9c6c698 commit that dealt with nested predicate for delete mutations, this one deal in an identical manner for update mutations.