### PR TITLE
Document low-level primitives in payas-sql.

### DIFF
--- a/crates/cli/src/commands/schema/import.rs
+++ b/crates/cli/src/commands/schema/import.rs
@@ -151,7 +151,7 @@ impl ToModel for PhysicalColumn {
         WithIssues {
             value: format!(
                 "{}: {}{}{}",
-                self.column_name,
+                self.name,
                 data_type + &annots,
                 autoinc_str,
                 pk_str,

--- a/crates/cli/src/commands/schema/verify.rs
+++ b/crates/cli/src/commands/schema/verify.rs
@@ -95,12 +95,12 @@ pub async fn verify(model: &Path, database: Option<&str>) -> Result<(), Verifica
     for op in migration.iter() {
         match op {
                     SchemaOp::CreateTable { table } => errors.push(format!("The table `{}` exists in the model, but does not exist in the database.", table.name)),
-                    SchemaOp::CreateColumn { column } => errors.push(format!("The column `{}` in the table `{}` exists in the model, but does not exist in the database table.", column.column_name, column.table_name)),
-                    SchemaOp::SetColumnDefaultValue { column, default_value } => errors.push(format!("The default value for column `{}` in table `{}` does not match `{}`", column.column_name, column.table_name, default_value)),
-                    SchemaOp::UnsetColumnDefaultValue { column } => errors.push(format!("The column `{}` in table `{}` is not set in the model.", column.column_name, column.table_name)),
+                    SchemaOp::CreateColumn { column } => errors.push(format!("The column `{}` in the table `{}` exists in the model, but does not exist in the database table.", column.name, column.table_name)),
+                    SchemaOp::SetColumnDefaultValue { column, default_value } => errors.push(format!("The default value for column `{}` in table `{}` does not match `{}`", column.name, column.table_name, default_value)),
+                    SchemaOp::UnsetColumnDefaultValue { column } => errors.push(format!("The column `{}` in table `{}` is not set in the model.", column.name, column.table_name)),
                     SchemaOp::CreateExtension { extension } => errors.push(format!("The model requires the extension `{extension}`.")),
                     SchemaOp::CreateUniqueConstraint { table, columns, constraint_name } => errors.push(format!("The model requires a unique constraint named `{}` for the following columns in table `{}`: {}", constraint_name, table.name, columns.join(", "))),
-                    SchemaOp::SetNotNull { column } => errors.push(format!("The model requires that the column `{}` in table `{}` is not nullable. All records in the database must have a non-null value for this column before migration.", column.column_name, column.table_name)),
+                    SchemaOp::SetNotNull { column } => errors.push(format!("The model requires that the column `{}` in table `{}` is not nullable. All records in the database must have a non-null value for this column before migration.", column.name, column.table_name)),
                     _ => {}
                 }
     }

--- a/crates/postgres-subsystem/postgres-model-builder/src/system_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/system_builder.rs
@@ -355,7 +355,7 @@ mod tests {
 
     fn get_column_from_table<'a>(name: &'a str, table: &'a PhysicalTable) -> &'a PhysicalColumn {
         for item in table.columns.iter() {
-            if item.column_name == name {
+            if item.name == name {
                 return item;
             }
         }

--- a/crates/postgres-subsystem/postgres-model-builder/src/type_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/type_builder.rs
@@ -348,7 +348,7 @@ fn create_column(
             match field_type {
                 ResolvedType::Primitive(pt) => Some(PhysicalColumn {
                     table_name: table_name.to_string(),
-                    column_name: field.column_name.to_string(),
+                    name: field.column_name.to_string(),
                     typ: determine_column_type(pt, field),
                     is_pk: field.is_pk,
                     is_auto_increment: if field.get_is_auto_increment() {
@@ -371,7 +371,7 @@ fn create_column(
                     let other_pk_field = ct.pk_field().unwrap();
                     Some(PhysicalColumn {
                         table_name: table_name.to_string(),
-                        column_name: field.column_name.to_string(),
+                        name: field.column_name.to_string(),
                         typ: PhysicalColumnType::ColumnReference {
                             ref_table_name: ct.table_name.to_string(),
                             ref_column_name: other_pk_field.column_name.to_string(),
@@ -424,7 +424,7 @@ fn create_column(
 
                 Some(PhysicalColumn {
                     table_name: table_name.to_string(),
-                    column_name: field.column_name.to_string(),
+                    name: field.column_name.to_string(),
                     typ: determine_column_type(&pt, field),
                     is_pk: false,
                     is_auto_increment: false,

--- a/crates/postgres-subsystem/postgres-resolver/src/cast.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/cast.rs
@@ -45,7 +45,7 @@ pub(crate) fn literal_column<'a>(
     associated_column: &PhysicalColumn,
 ) -> Result<Column<'a>, PostgresExecutionError> {
     cast_value(value, &associated_column.typ)
-        .map(|value| value.map(Column::Literal).unwrap_or(Column::Null))
+        .map(|value| value.map(Column::Param).unwrap_or(Column::Null))
         .map_err(PostgresExecutionError::CastError)
 }
 

--- a/crates/postgres-subsystem/postgres-resolver/src/create_data_param_mapper.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/create_data_param_mapper.rs
@@ -105,7 +105,7 @@ fn map_self_column<'a>(
             let other_type = &subsystem.entity_types[*other_type_id];
             let other_type_pk_field_name = other_type
                 .pk_column_id()
-                .map(|column_id| &column_id.get_column(subsystem).column_name)
+                .map(|column_id| &column_id.get_column(subsystem).name)
                 .ok_or_else(|| {
                     PostgresExecutionError::Generic(format!(
                         "{} did not have a primary key field when computing many-to-one for {}",
@@ -122,7 +122,7 @@ fn map_self_column<'a>(
 
     let value_column = cast::literal_column(argument_value, key_column).with_context(format!(
         "While trying to get literal column for {}.{}",
-        key_column.table_name, key_column.column_name
+        key_column.table_name, key_column.name
     ))?;
 
     Ok(InsertionElement::SelfInsert(ColumnValuePair::new(
@@ -185,7 +185,7 @@ fn map_foreign<'a>(
                     ..
                 } => {
                     ref_table_name == &parent_pk_physical_column.table_name
-                        && ref_column_name == &parent_pk_physical_column.column_name
+                        && ref_column_name == &parent_pk_physical_column.name
                 }
                 _ => false,
             },

--- a/crates/postgres-subsystem/postgres-resolver/src/update_data_param_mapper.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/update_data_param_mapper.rs
@@ -78,7 +78,7 @@ fn compute_update_columns<'a>(
                             let other_type = &subsystem.entity_types[*other_type_id];
                             let other_type_pk_field_name = other_type
                                 .pk_column_id()
-                                .map(|column_id| &column_id.get_column(subsystem).column_name)
+                                .map(|column_id| &column_id.get_column(subsystem).name)
                                 .unwrap();
                             match get_argument_field(argument_value, other_type_pk_field_name) {
                                 Some(other_type_pk_arg) => other_type_pk_arg,
@@ -173,9 +173,7 @@ fn compute_nested_reference_column<'a>(
                 ref_table_name,
                 ref_column_name,
                 ..
-            } => {
-                &pk_column.table_name == ref_table_name && &pk_column.column_name == ref_column_name
-            }
+            } => &pk_column.table_name == ref_table_name && &pk_column.name == ref_column_name,
             _ => false,
         })
 }
@@ -242,7 +240,7 @@ fn compute_nested_update_object_arg<'a>(
         .into_iter()
         .fold(AbstractPredicate::True, |acc, (pk_col, value)| {
             let value = match value {
-                Column::Literal(value) => ColumnPath::Literal(value),
+                Column::Param(value) => ColumnPath::Literal(value),
                 _ => panic!("Expected literal"),
             };
             AbstractPredicate::and(
@@ -412,7 +410,7 @@ fn compute_nested_delete_object_arg<'a>(
         .into_iter()
         .fold(AbstractPredicate::True, |acc, (pk_col, value)| {
             let value = match value {
-                Column::Literal(value) => ColumnPath::Literal(value),
+                Column::Param(value) => ColumnPath::Literal(value),
                 _ => panic!("Expected literal"),
             };
             AbstractPredicate::and(

--- a/libs/payas-sql/src/asql/column_path.rs
+++ b/libs/payas-sql/src/asql/column_path.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 
 use crate::{
-    sql::{physical_column::PhysicalColumn, predicate::LiteralEquality, SQLParamContainer},
+    sql::{physical_column::PhysicalColumn, predicate::ParamEquality, SQLParamContainer},
     PhysicalTable,
 };
 
@@ -18,8 +18,8 @@ pub enum ColumnPath<'a> {
     Null,
 }
 
-impl LiteralEquality for ColumnPath<'_> {
-    fn literal_eq(&self, other: &Self) -> Option<bool> {
+impl ParamEquality for ColumnPath<'_> {
+    fn param_eq(&self, other: &Self) -> Option<bool> {
         match (self, other) {
             (Self::Literal(v1), Self::Literal(v2)) => Some(v1 == v2),
             _ => None,
@@ -39,9 +39,9 @@ impl<'a> Ord for ColumnPathLink<'a> {
             link: &'a ColumnPathLink,
         ) -> (&'a str, &'a str, Option<&'a str>, Option<&'a str>) {
             (
-                &link.self_column.0.column_name,
+                &link.self_column.0.name,
                 &link.self_column.1.name,
-                link.linked_column.map(|ref c| c.0.column_name.as_str()),
+                link.linked_column.map(|ref c| c.0.name.as_str()),
                 link.linked_column.map(|ref c| c.1.name.as_str()),
             )
         }

--- a/libs/payas-sql/src/lib.rs
+++ b/libs/payas-sql/src/lib.rs
@@ -57,5 +57,6 @@ pub use sql::{
     order::Ordering,
     physical_column::{FloatBits, IntBits, PhysicalColumn, PhysicalColumnType},
     physical_table::PhysicalTable,
+    predicate::{CaseSensitivity, ParamEquality, Predicate},
     SQLBytes, SQLParam, SQLParamContainer,
 };

--- a/libs/payas-sql/src/schema/column.rs
+++ b/libs/payas-sql/src/schema/column.rs
@@ -12,7 +12,7 @@ impl PhysicalColumn {
     pub fn diff<'a>(&'a self, new: &'a Self) -> Vec<SchemaOp<'a>> {
         let mut changes = vec![];
         let table_name_same = self.table_name == new.table_name;
-        let column_name_same = self.column_name == new.column_name;
+        let column_name_same = self.name == new.name;
         let type_same = self.typ == new.typ;
         let is_pk_same = self.is_pk == new.is_pk;
         let is_auto_increment_same = self.is_auto_increment == new.is_auto_increment;
@@ -150,7 +150,7 @@ impl PhysicalColumn {
         Ok(WithIssues {
             value: db_type.map(|typ| PhysicalColumn {
                 table_name: table_name.to_owned(),
-                column_name: column_name.to_owned(),
+                name: column_name.to_owned(),
                 typ,
                 is_pk,
                 is_auto_increment,
@@ -170,7 +170,7 @@ impl PhysicalColumn {
             ..
         } = self
             .typ
-            .to_sql(&self.table_name, &self.column_name, self.is_auto_increment);
+            .to_sql(&self.table_name, &self.name, self.is_auto_increment);
         let pk_str = if self.is_pk { " PRIMARY KEY" } else { "" };
         let not_null_str = if !self.is_nullable && !self.is_pk {
             // primary keys are implied to be not null
@@ -187,7 +187,7 @@ impl PhysicalColumn {
         SchemaStatement {
             statement: format!(
                 "\"{}\" {}{}{}{}",
-                self.column_name, statement, pk_str, not_null_str, default_value_part
+                self.name, statement, pk_str, not_null_str, default_value_part
             ),
             pre_statements: vec![],
             post_statements,

--- a/libs/payas-sql/src/schema/op.rs
+++ b/libs/payas-sql/src/schema/op.rs
@@ -58,7 +58,7 @@ impl SchemaOp<'_> {
             if !column.is_pk {
                 post_statements.push(format!(
                     "CREATE INDEX ON \"{}\" ({});",
-                    column.table_name, column.column_name
+                    column.table_name, column.name
                 ))
             }
         }
@@ -91,7 +91,7 @@ impl SchemaOp<'_> {
             SchemaOp::DeleteColumn { column } => SchemaStatement {
                 statement: format!(
                     "ALTER TABLE \"{}\" DROP COLUMN \"{}\";",
-                    &column.table_name, column.column_name
+                    &column.table_name, column.name
                 ),
                 ..Default::default()
             },
@@ -101,14 +101,14 @@ impl SchemaOp<'_> {
             } => SchemaStatement {
                 statement: format!(
                     "ALTER TABLE \"{}\" ALTER COLUMN \"{}\" SET DEFAULT {};",
-                    column.table_name, column.column_name, default_value
+                    column.table_name, column.name, default_value
                 ),
                 ..Default::default()
             },
             SchemaOp::UnsetColumnDefaultValue { column } => SchemaStatement {
                 statement: format!(
                     "ALTER TABLE \"{}\" ALTER COLUMN \"{}\" DROP DEFAULT;",
-                    column.table_name, column.column_name
+                    column.table_name, column.name
                 ),
                 ..Default::default()
             },
@@ -143,14 +143,14 @@ impl SchemaOp<'_> {
             SchemaOp::SetNotNull { column } => SchemaStatement {
                 statement: format!(
                     "ALTER TABLE \"{}\" ALTER COLUMN \"{}\" SET NOT NULL;",
-                    column.table_name, column.column_name,
+                    column.table_name, column.name,
                 ),
                 ..Default::default()
             },
             SchemaOp::UnsetNotNull { column } => SchemaStatement {
                 statement: format!(
                     "ALTER TABLE \"{}\" ALTER COLUMN \"{}\" DROP NOT NULL;",
-                    column.table_name, column.column_name
+                    column.table_name, column.name
                 ),
                 ..Default::default()
             },

--- a/libs/payas-sql/src/schema/table.rs
+++ b/libs/payas-sql/src/schema/table.rs
@@ -17,17 +17,15 @@ impl PhysicalTable {
 
         let existing_column_map: HashMap<_, _> = existing_columns
             .iter()
-            .map(|c| (c.column_name.clone(), c))
+            .map(|c| (c.name.clone(), c))
             .collect();
-        let new_column_map: HashMap<_, _> = new_columns
-            .iter()
-            .map(|c| (c.column_name.clone(), c))
-            .collect();
+        let new_column_map: HashMap<_, _> =
+            new_columns.iter().map(|c| (c.name.clone(), c)).collect();
 
         let mut changes = vec![];
 
         for existing_column in self.columns.iter() {
-            let new_column = new_column_map.get(&existing_column.column_name);
+            let new_column = new_column_map.get(&existing_column.name);
 
             match new_column {
                 Some(new_column) => {
@@ -43,7 +41,7 @@ impl PhysicalTable {
         }
 
         for new_column in new.columns.iter() {
-            let existing_column = existing_column_map.get(&new_column.column_name);
+            let existing_column = existing_column_map.get(&new_column.name);
 
             if existing_column.is_none() {
                 // new column
@@ -248,7 +246,7 @@ impl PhysicalTable {
             {
                 for name in c.unique_constraints.iter() {
                     let entry: &mut Vec<String> = map.entry(name).or_insert_with(Vec::new);
-                    (*entry).push(c.column_name.clone());
+                    (*entry).push(c.name.clone());
                 }
             }
             map

--- a/libs/payas-sql/src/sql/cte.rs
+++ b/libs/payas-sql/src/sql/cte.rs
@@ -1,23 +1,29 @@
 use super::{select::Select, sql_operation::SQLOperation, ExpressionBuilder, SQLBuilder};
 
+/// A query with common table expressions of the form `WITH <expressions> <select>`.
 #[derive(Debug)]
-pub struct Cte<'a> {
+pub struct WithQuery<'a> {
+    /// The "WITH" expressions
     pub expressions: Vec<CteExpression<'a>>,
+    /// The select statement
     pub select: Select<'a>,
 }
 
+/// A common table expression of the form `<name> AS (<operation>)`.
 #[derive(Debug)]
 pub struct CteExpression<'a> {
+    /// The name of the expression
     pub name: String,
+    /// The SQL operation to be bound to the name
     pub operation: SQLOperation<'a>,
 }
 
-impl<'a> ExpressionBuilder for Cte<'a> {
+impl<'a> ExpressionBuilder for WithQuery<'a> {
     /// Build a CTE for the `WITH <expressions> <select>` syntax.
     fn build(&self, builder: &mut SQLBuilder) {
         builder.push_str("WITH ");
         builder.push_elems(&self.expressions, ", ");
-        builder.push(' ');
+        builder.push_space();
         self.select.build(builder);
     }
 }

--- a/libs/payas-sql/src/sql/delete.rs
+++ b/libs/payas-sql/src/sql/delete.rs
@@ -5,14 +5,21 @@ use super::{
     SQLBuilder,
 };
 
+/// A delete operation.
 #[derive(Debug)]
 pub struct Delete<'a> {
+    /// The table to delete from.
     pub table: &'a PhysicalTable,
+    /// The predicate to filter rows by.
     pub predicate: MaybeOwned<'a, ConcretePredicate<'a>>,
+    /// The columns to return.
     pub returning: Vec<MaybeOwned<'a, Column<'a>>>,
 }
 
 impl<'a> ExpressionBuilder for Delete<'a> {
+    /// Build a delete operation for the `DELETE FROM <table> WHERE <predicate> RETURNING <returning>`.
+    /// The `WHERE` clause is omitted if the predicate is `true` and the `RETURNING` clause is omitted
+    /// if the list of columns to return is empty.
     fn build(&self, builder: &mut SQLBuilder) {
         builder.push_str("DELETE FROM ");
         self.table.build(builder);

--- a/libs/payas-sql/src/sql/expression_builder.rs
+++ b/libs/payas-sql/src/sql/expression_builder.rs
@@ -7,18 +7,19 @@ use std::sync::Arc;
 
 use super::SQLBuilder;
 
-/// A trait for types that can be build into SQL expressions
+/// A trait for types that can build themselves into an SQL expression.
 ///
-/// Each of the constituent of an SQL expression (column, table, function, select, etc.) should
-/// implement this trait, which can then be used to hierarchically build SQL
+/// Each constituent of an SQL expression (column, table, function, select, etc.) should implement
+/// this trait, which can then be used to hierarchically build an SQL string and the list of
+/// parameters to be supplied to it.
 pub trait ExpressionBuilder {
     /// Build the SQL expression into the given SQL builder
     fn build(&self, builder: &mut SQLBuilder);
 
     /// Build the SQL expression into a string and return it This is useful for testing, where we
-    /// want to assert on the generated SQL without going through the whole process creating an
+    /// want to assert on the generated SQL without going through the whole process of creating an
     /// SQLBuilder, then building the SQL expression into it, and finally extracting the SQL string
-    /// and params
+    /// and params.
     #[cfg(test)]
     fn into_sql(self) -> (String, Vec<Arc<dyn SQLParam>>)
     where

--- a/libs/payas-sql/src/sql/group_by.rs
+++ b/libs/payas-sql/src/sql/group_by.rs
@@ -2,10 +2,12 @@ use crate::PhysicalColumn;
 
 use super::{ExpressionBuilder, SQLBuilder};
 
+/// A group by clause
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GroupBy<'a>(pub Vec<&'a PhysicalColumn>);
 
 impl<'a> ExpressionBuilder for GroupBy<'a> {
+    /// Build expression of the form `GROUP BY <comma-separated-columns>`
     fn build(&self, builder: &mut SQLBuilder) {
         builder.push_str("GROUP BY ");
         builder.push_elems(&self.0, ", ");

--- a/libs/payas-sql/src/sql/join.rs
+++ b/libs/payas-sql/src/sql/join.rs
@@ -1,34 +1,38 @@
 use maybe_owned::MaybeOwned;
 
-use super::{predicate::ConcretePredicate, table::TableQuery, ExpressionBuilder, SQLBuilder};
+use super::{predicate::ConcretePredicate, table::Table, ExpressionBuilder, SQLBuilder};
 
 /// Represents a join between two tables. Currently, supports only left join.
 #[derive(Debug, PartialEq)]
-pub struct Join<'a> {
-    left: Box<TableQuery<'a>>,
-    right: Box<TableQuery<'a>>,
+pub struct LeftJoin<'a> {
+    /// The left table in the join such as `concerts`.
+    left: Box<Table<'a>>,
+    /// The right table in the join such as `venues`.
+    right: Box<Table<'a>>,
+    /// The join predicate such as `concerts.venue_id = venues.id`.
     predicate: MaybeOwned<'a, ConcretePredicate<'a>>,
 }
 
-impl<'a> Join<'a> {
+impl<'a> LeftJoin<'a> {
     pub fn new(
-        left: TableQuery<'a>,
-        right: TableQuery<'a>,
+        left: Table<'a>,
+        right: Table<'a>,
         predicate: MaybeOwned<'a, ConcretePredicate<'a>>,
     ) -> Self {
-        Join {
+        LeftJoin {
             left: Box::new(left),
             right: Box::new(right),
             predicate,
         }
     }
 
-    pub fn left(&self) -> &TableQuery<'a> {
+    pub fn left(&self) -> &Table<'a> {
         &self.left
     }
 }
 
-impl ExpressionBuilder for Join<'_> {
+impl ExpressionBuilder for LeftJoin<'_> {
+    /// Build expression of the form `<left> LEFT JOIN <right> ON <predicate>`.
     fn build(&self, builder: &mut SQLBuilder) {
         self.left.build(builder);
         builder.push_str(" LEFT JOIN ");
@@ -54,14 +58,14 @@ mod tests {
             columns: vec![
                 PhysicalColumn {
                     table_name: "concerts".to_string(),
-                    column_name: "id".to_string(),
+                    name: "id".to_string(),
                     typ: PhysicalColumnType::Int { bits: IntBits::_16 },
                     is_pk: true,
                     ..Default::default()
                 },
                 PhysicalColumn {
                     table_name: "concerts".to_string(),
-                    column_name: "venue_id".to_string(),
+                    name: "venue_id".to_string(),
                     typ: PhysicalColumnType::Int { bits: IntBits::_16 },
                     ..Default::default()
                 },
@@ -73,27 +77,27 @@ mod tests {
             columns: vec![
                 PhysicalColumn {
                     table_name: "venues".to_string(),
-                    column_name: "id".to_string(),
+                    name: "id".to_string(),
                     typ: PhysicalColumnType::Int { bits: IntBits::_16 },
                     ..Default::default()
                 },
                 PhysicalColumn {
                     table_name: "venues".to_string(),
-                    column_name: "capacity".to_string(),
+                    name: "capacity".to_string(),
                     typ: PhysicalColumnType::Int { bits: IntBits::_16 },
                     ..Default::default()
                 },
             ],
         };
 
-        let concert_table = TableQuery::Physical(&concert_physical_table);
-        let venue_table = TableQuery::Physical(&venue_physical_table);
+        let concert_table = Table::Physical(&concert_physical_table);
+        let venue_table = Table::Physical(&venue_physical_table);
         let join_predicate = ConcretePredicate::Eq(
             concert_physical_table.get_column("venue_id").unwrap(),
             venue_physical_table.get_column("id").unwrap(),
         )
         .into();
-        let join = Join::new(concert_table, venue_table, join_predicate);
+        let join = LeftJoin::new(concert_table, venue_table, join_predicate);
 
         let mut builder = SQLBuilder::new();
         join.build(&mut builder);

--- a/libs/payas-sql/src/sql/json_agg.rs
+++ b/libs/payas-sql/src/sql/json_agg.rs
@@ -2,12 +2,14 @@ use crate::Column;
 
 use super::{ExpressionBuilder, SQLBuilder};
 
+/// A JSON aggregation corresponding to the Postgres' `json_agg` function.
 #[derive(Debug, PartialEq)]
 pub struct JsonAgg<'a>(pub Box<Column<'a>>);
 
 impl<'a> ExpressionBuilder for JsonAgg<'a> {
+    /// Build expression of the form `COALESCE(json_agg(<column>)), '[]'::json)`. The COALESCE
+    /// wrapper ensures that return an empty array if we have no matching entities.
     fn build(&self, builder: &mut SQLBuilder) {
-        // coalesce to return an empty array if we have no matching entities
         builder.push_str("COALESCE(json_agg(");
         self.0.build(builder);
         builder.push_str("), '[]'::json)");

--- a/libs/payas-sql/src/sql/json_object.rs
+++ b/libs/payas-sql/src/sql/json_object.rs
@@ -5,9 +5,11 @@ use super::{
     ExpressionBuilder, SQLBuilder,
 };
 
+/// A JSON object corresponding to the Postgres' `json_build_object` function.
 #[derive(Debug, PartialEq)]
 pub struct JsonObject<'a>(pub Vec<JsonObjectElement<'a>>);
 
+/// A key-value pair in a JSON object.
 #[derive(Debug, PartialEq)]
 pub struct JsonObjectElement<'a> {
     pub key: String,
@@ -21,6 +23,7 @@ impl<'a> JsonObjectElement<'a> {
 }
 
 impl<'a> ExpressionBuilder for JsonObject<'a> {
+    /// Build expression of the form `json_build_object(<comma-separated-elements>)`.
     fn build(&self, builder: &mut SQLBuilder) {
         builder.push_str("json_build_object(");
         builder.push_elems(&self.0, ", ");
@@ -28,11 +31,11 @@ impl<'a> ExpressionBuilder for JsonObject<'a> {
     }
 }
 
-/// Build a SQL query for an element in a JSON object. The SQL expression will be `'<key>',
-/// <value>`, where `<value>` is the SQL expression for the value of the JSON object element. The
-/// value of the JSON object element is encoded as base64 if it is a blob, and as text if it is a
-/// numeric.
 impl<'a> ExpressionBuilder for JsonObjectElement<'a> {
+    /// Build an SQL query for an element in a JSON object. The SQL expression will be `'<key>',
+    /// <value>`, where `<value>` is the SQL expression for the value of the JSON object element. The
+    /// value of the JSON object element is encoded as base64 if it is a blob, and as text if it is a
+    /// numeric.
     fn build(&self, builder: &mut SQLBuilder) {
         builder.push_str("'");
         builder.push_str(&self.key);

--- a/libs/payas-sql/src/sql/limit.rs
+++ b/libs/payas-sql/src/sql/limit.rs
@@ -6,8 +6,9 @@ use super::{ExpressionBuilder, SQLBuilder};
 pub struct Limit(pub i64);
 
 impl ExpressionBuilder for Limit {
+    /// Build expression of the form `LIMIT <limit>`
     fn build(&self, builder: &mut SQLBuilder) {
-        builder.push_str(" LIMIT ");
+        builder.push_str("LIMIT ");
         builder.push_param(Arc::new(self.0))
     }
 }

--- a/libs/payas-sql/src/sql/offset.rs
+++ b/libs/payas-sql/src/sql/offset.rs
@@ -6,8 +6,9 @@ use super::{ExpressionBuilder, SQLBuilder};
 pub struct Offset(pub i64);
 
 impl ExpressionBuilder for Offset {
+    /// Build expression of the form `OFFSET <offset>`
     fn build(&self, builder: &mut SQLBuilder) {
-        builder.push_str(" OFFSET ");
+        builder.push_str("OFFSET ");
         builder.push_param(Arc::new(self.0))
     }
 }

--- a/libs/payas-sql/src/sql/order.rs
+++ b/libs/payas-sql/src/sql/order.rs
@@ -20,7 +20,7 @@ impl<'a> OrderByElement<'a> {
 impl<'a> ExpressionBuilder for OrderByElement<'a> {
     fn build(&self, builder: &mut SQLBuilder) {
         self.0.build(builder);
-        builder.push(' ');
+        builder.push_space();
         if self.1 == Ordering::Asc {
             builder.push_str("ASC");
         } else {
@@ -45,7 +45,7 @@ mod test {
     fn single() {
         let age_col = PhysicalColumn {
             table_name: "people".to_string(),
-            column_name: "age".to_string(),
+            name: "age".to_string(),
             typ: PhysicalColumnType::Int { bits: IntBits::_16 },
             ..Default::default()
         };
@@ -59,14 +59,14 @@ mod test {
     fn multiple() {
         let name_col = PhysicalColumn {
             table_name: "people".to_string(),
-            column_name: "name".to_string(),
+            name: "name".to_string(),
             typ: PhysicalColumnType::String { length: None },
             ..Default::default()
         };
 
         let age_col = PhysicalColumn {
             table_name: "people".to_string(),
-            column_name: "age".to_string(),
+            name: "age".to_string(),
             typ: PhysicalColumnType::Int { bits: IntBits::_16 },
             ..Default::default()
         };

--- a/libs/payas-sql/src/sql/physical_table.rs
+++ b/libs/payas-sql/src/sql/physical_table.rs
@@ -6,12 +6,17 @@ use super::{
 use maybe_owned::MaybeOwned;
 use serde::{Deserialize, Serialize};
 
+/// A physical table in the database such as "concerts" or "users".
 #[derive(Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct PhysicalTable {
+    /// The name of the table.
     pub name: String,
+    /// The columns of the table.
     pub columns: Vec<PhysicalColumn>,
 }
 
+/// The derived implementation of `Debug` is quite verbose, so we implement it manually
+/// to print the table name only.
 impl std::fmt::Debug for PhysicalTable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("Table: ")?;
@@ -21,7 +26,7 @@ impl std::fmt::Debug for PhysicalTable {
 
 impl PhysicalTable {
     pub fn column_index(&self, name: &str) -> Option<usize> {
-        self.columns.iter().position(|c| c.column_name == name)
+        self.columns.iter().position(|c| c.name == name)
     }
 
     pub fn get_column(&self, name: &str) -> Option<Column> {
@@ -29,9 +34,7 @@ impl PhysicalTable {
     }
 
     pub fn get_physical_column(&self, name: &str) -> Option<&PhysicalColumn> {
-        self.columns
-            .iter()
-            .find(|column| column.column_name == name)
+        self.columns.iter().find(|column| column.name == name)
     }
 
     pub fn get_pk_physical_column(&self) -> Option<&PhysicalColumn> {
@@ -49,8 +52,8 @@ impl PhysicalTable {
     {
         Insert {
             table: self,
-            column_names,
-            column_values_seq: column_values_seq
+            columns: column_names,
+            values_seq: column_values_seq
                 .into_iter()
                 .map(|rows| rows.into_iter().map(|col| col.into()).collect())
                 .collect(),
@@ -92,6 +95,7 @@ impl PhysicalTable {
 }
 
 impl ExpressionBuilder for PhysicalTable {
+    /// Build a table reference for the `<table>`.
     fn build(&self, builder: &mut crate::sql::SQLBuilder) {
         builder.push_identifier(&self.name);
     }

--- a/libs/payas-sql/src/sql/sql_builder.rs
+++ b/libs/payas-sql/src/sql/sql_builder.rs
@@ -33,11 +33,17 @@ impl SQLBuilder {
         self.sql.push(c);
     }
 
-    /// Push a string surrounded by double quotes. Useful for identifier.
+    /// Push a string surrounded by double quotes. Useful for identifier such as table names, column
+    /// names, etc. Without the quotes, the identifier with uppercase letters will be interpreted
+    /// the same as the identifier with lowercase letters.
     pub fn push_identifier<T: AsRef<str>>(&mut self, s: T) {
         self.sql.push('"');
         self.sql.push_str(s.as_ref());
         self.sql.push('"');
+    }
+
+    pub fn push_space(&mut self) {
+        self.sql.push(' ');
     }
 
     /// Push a parameter, which will be replaced with a placeholder in the SQL string
@@ -48,18 +54,19 @@ impl SQLBuilder {
         self.push_str(&self.params.len().to_string());
     }
 
-    /// Push elements of an iterator, separated by `sep`. The `mapping` function provides
+    /// Push elements of an iterator, separated by `sep`. The `push_elem` function provides
     /// the flexibility to map the elements (compared to [`SQLBuilder::push_elems`], which assumes that
     /// the elements implement [`ExpressionBuilder`] and [`build`](ExpressionBuilder::build) is all you need to call).
     pub fn push_iter<T>(
         &mut self,
         iter: impl ExactSizeIterator<Item = T>,
         sep: &str,
-        mapping: impl Fn(&mut Self, T),
+        push_elem: impl Fn(&mut Self, T),
     ) {
         let len = iter.len();
         for (i, item) in iter.enumerate() {
-            mapping(self, item);
+            push_elem(self, item);
+
             if i < len - 1 {
                 self.sql.push_str(sep);
             }

--- a/libs/payas-sql/src/sql/sql_operation.rs
+++ b/libs/payas-sql/src/sql/sql_operation.rs
@@ -1,5 +1,5 @@
 use super::{
-    cte::Cte,
+    cte::WithQuery,
     delete::Delete,
     delete::TemplateDelete,
     insert::{Insert, TemplateInsert},
@@ -15,7 +15,7 @@ pub enum SQLOperation<'a> {
     Insert(Insert<'a>),
     Delete(Delete<'a>),
     Update(Update<'a>),
-    Cte(Cte<'a>),
+    Cte(WithQuery<'a>),
 }
 
 impl<'a> ExpressionBuilder for SQLOperation<'a> {

--- a/libs/payas-sql/src/sql/update.rs
+++ b/libs/payas-sql/src/sql/update.rs
@@ -78,7 +78,7 @@ impl<'a> TemplateUpdate<'a> {
                         let resolved_col = match col {
                             ProxyColumn::Concrete(col) => col.as_ref().into(),
                             ProxyColumn::Template { col_index, step_id } => {
-                                MaybeOwned::Owned(Column::Literal(SQLParamContainer::new(
+                                MaybeOwned::Owned(Column::Param(SQLParamContainer::new(
                                     transaction_context
                                         .resolve_value(*step_id, row_index, *col_index),
                                 )))

--- a/libs/payas-sql/src/transform/join_util.rs
+++ b/libs/payas-sql/src/transform/join_util.rs
@@ -1,6 +1,6 @@
 use crate::{
     asql::column_path::ColumnPathLink,
-    sql::{column::Column, predicate::ConcretePredicate, table::TableQuery},
+    sql::{column::Column, predicate::ConcretePredicate, table::Table},
     transform::table_dependency::{DependencyLink, TableDependency},
     PhysicalTable,
 };
@@ -8,10 +8,10 @@ use crate::{
 pub fn compute_join<'a>(
     table: &'a PhysicalTable,
     paths_list: Vec<Vec<ColumnPathLink<'a>>>,
-) -> TableQuery<'a> {
-    fn from_dependency(dependency: TableDependency) -> TableQuery {
+) -> Table<'a> {
+    fn from_dependency(dependency: TableDependency) -> Table {
         dependency.dependencies.into_iter().fold(
-            TableQuery::Physical(dependency.table),
+            Table::Physical(dependency.table),
             |acc, DependencyLink { link, dependency }| {
                 let join_predicate = ConcretePredicate::Eq(
                     Column::Physical(link.self_column.0),

--- a/libs/payas-sql/src/transform/pg/delete_transformer.rs
+++ b/libs/payas-sql/src/transform/pg/delete_transformer.rs
@@ -4,7 +4,7 @@ use crate::{
     asql::{delete::AbstractDelete, select::SelectionLevel},
     sql::{
         column::Column,
-        cte::{Cte, CteExpression},
+        cte::{CteExpression, WithQuery},
         sql_operation::SQLOperation,
         transaction::{ConcreteTransactionStep, TransactionScript, TransactionStep},
     },
@@ -33,7 +33,7 @@ impl DeleteTransformer for Postgres {
     /// Ignore the selection (instead returns a `*` and relies on to_transaction_script to use a CTE to do the selection).
     /// This way, we can do nested selection if needed.
     #[instrument(name = "DeleteTransformer::to_delete for Postgres", skip(self))]
-    fn to_delete<'a>(&self, abstract_delete: &'a AbstractDelete) -> Cte<'a> {
+    fn to_delete<'a>(&self, abstract_delete: &'a AbstractDelete) -> WithQuery<'a> {
         let predicate = self.to_subselect_predicate(&abstract_delete.predicate);
 
         let root_delete = SQLOperation::Delete(
@@ -49,7 +49,7 @@ impl DeleteTransformer for Postgres {
             SelectionLevel::TopLevel,
         );
 
-        Cte {
+        WithQuery {
             expressions: vec![CteExpression {
                 name: abstract_delete.table.name.clone(),
                 operation: root_delete,

--- a/libs/payas-sql/src/transform/pg/predicate_transformer.rs
+++ b/libs/payas-sql/src/transform/pg/predicate_transformer.rs
@@ -85,7 +85,7 @@ impl PredicateTransformer for Postgres {
                         table,
                         selection: Selection::Seq(vec![ColumnSelection {
                             column: SelectionElement::Physical(foreign_column),
-                            alias: foreign_column.column_name.clone(),
+                            alias: foreign_column.name.clone(),
                         }]),
                         predicate: predicate_op(
                             ColumnPath::Physical(tail_links.to_vec()),
@@ -103,7 +103,7 @@ impl PredicateTransformer for Postgres {
                         SelectionLevel::Nested,
                     );
 
-                    let right_select_column = Column::SelectionTableWrapper(Box::new(right_select));
+                    let right_select_column = Column::SubSelect(Box::new(right_select));
 
                     Some(ConcretePredicate::In(
                         Column::Physical(left_column),
@@ -169,7 +169,7 @@ impl PredicateTransformer for Postgres {
 fn leaf_column<'c>(column_path: &ColumnPath<'c>) -> Column<'c> {
     match column_path {
         ColumnPath::Physical(links) => Column::Physical(links.last().unwrap().self_column.0),
-        ColumnPath::Literal(l) => Column::Literal(l.clone()),
+        ColumnPath::Literal(l) => Column::Param(l.clone()),
         ColumnPath::Null => Column::Null,
     }
 }

--- a/libs/payas-sql/src/transform/pg/update_transformer.rs
+++ b/libs/payas-sql/src/transform/pg/update_transformer.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     sql::{
         column::{Column, ProxyColumn},
-        cte::{Cte, CteExpression},
+        cte::{CteExpression, WithQuery},
         delete::TemplateDelete,
         insert::TemplateInsert,
         physical_column::PhysicalColumn,
@@ -122,7 +122,7 @@ impl UpdateTransformer for Postgres {
             ));
         } else {
             transaction_script.add_step(TransactionStep::Concrete(ConcreteTransactionStep::new(
-                SQLOperation::Cte(Cte {
+                SQLOperation::Cte(WithQuery {
                     expressions: vec![CteExpression {
                         name: abstract_update.table.name.clone(),
                         operation: root_update,
@@ -268,7 +268,7 @@ mod tests {
                     predicate,
                     column_values: vec![(
                         venues_name_column,
-                        Column::Literal(SQLParamContainer::new("new_name".to_string())),
+                        Column::Param(SQLParamContainer::new("new_name".to_string())),
                     )],
                     nested_updates: vec![],
                     nested_inserts: vec![],
@@ -329,7 +329,7 @@ mod tests {
                         predicate: Predicate::True,
                         column_values: vec![(
                             concerts_name_column,
-                            Column::Literal(SQLParamContainer::new("new_concert_name".to_string())),
+                            Column::Param(SQLParamContainer::new("new_concert_name".to_string())),
                         )],
                         selection: AbstractSelect {
                             selection: Selection::Seq(vec![]),
@@ -350,7 +350,7 @@ mod tests {
                     predicate,
                     column_values: vec![(
                         venues_name_column,
-                        Column::Literal(SQLParamContainer::new("new_name".to_string())),
+                        Column::Param(SQLParamContainer::new("new_name".to_string())),
                     )],
                     nested_updates: vec![nested_abs_update],
                     nested_inserts: vec![],

--- a/libs/payas-sql/src/transform/test_util.rs
+++ b/libs/payas-sql/src/transform/test_util.rs
@@ -37,7 +37,7 @@ impl TestSetup<'_> {
             columns: vec![
                 PhysicalColumn {
                     table_name: "concerts".to_string(),
-                    column_name: "id".to_string(),
+                    name: "id".to_string(),
                     typ: PhysicalColumnType::Int { bits: IntBits::_16 },
                     is_pk: true,
                     is_auto_increment: false,
@@ -47,7 +47,7 @@ impl TestSetup<'_> {
                 },
                 PhysicalColumn {
                     table_name: "concerts".to_string(),
-                    column_name: "name".to_string(),
+                    name: "name".to_string(),
                     typ: PhysicalColumnType::String { length: None },
                     is_pk: false,
                     is_auto_increment: false,
@@ -57,7 +57,7 @@ impl TestSetup<'_> {
                 },
                 PhysicalColumn {
                     table_name: "concerts".to_string(),
-                    column_name: "venue_id".to_string(),
+                    name: "venue_id".to_string(),
                     typ: PhysicalColumnType::Int { bits: IntBits::_16 },
                     is_pk: false,
                     is_auto_increment: false,
@@ -77,7 +77,7 @@ impl TestSetup<'_> {
             columns: vec![
                 PhysicalColumn {
                     table_name: "venues".to_string(),
-                    column_name: "id".to_string(),
+                    name: "id".to_string(),
                     typ: PhysicalColumnType::Int { bits: IntBits::_16 },
                     is_pk: true,
                     is_auto_increment: false,
@@ -87,7 +87,7 @@ impl TestSetup<'_> {
                 },
                 PhysicalColumn {
                     table_name: "venues".to_string(),
-                    column_name: "name".to_string(),
+                    name: "name".to_string(),
                     typ: PhysicalColumnType::String { length: None },
                     is_pk: false,
                     is_auto_increment: false,
@@ -106,7 +106,7 @@ impl TestSetup<'_> {
             columns: vec![
                 PhysicalColumn {
                     table_name: "concert_artists".to_string(),
-                    column_name: "id".to_string(),
+                    name: "id".to_string(),
                     typ: PhysicalColumnType::Int { bits: IntBits::_16 },
                     is_pk: true,
                     is_auto_increment: false,
@@ -116,7 +116,7 @@ impl TestSetup<'_> {
                 },
                 PhysicalColumn {
                     table_name: "concert_artists".to_string(),
-                    column_name: "concert_id".to_string(),
+                    name: "concert_id".to_string(),
                     typ: PhysicalColumnType::Int { bits: IntBits::_16 },
                     is_pk: false,
                     is_auto_increment: false,
@@ -126,7 +126,7 @@ impl TestSetup<'_> {
                 },
                 PhysicalColumn {
                     table_name: "concert_artists".to_string(),
-                    column_name: "artist_id".to_string(),
+                    name: "artist_id".to_string(),
                     typ: PhysicalColumnType::Int { bits: IntBits::_16 },
                     is_pk: false,
                     is_auto_increment: false,
@@ -150,7 +150,7 @@ impl TestSetup<'_> {
             columns: vec![
                 PhysicalColumn {
                     table_name: "artists".to_string(),
-                    column_name: "id".to_string(),
+                    name: "id".to_string(),
                     typ: PhysicalColumnType::Int { bits: IntBits::_16 },
                     is_pk: true,
                     is_auto_increment: false,
@@ -160,7 +160,7 @@ impl TestSetup<'_> {
                 },
                 PhysicalColumn {
                     table_name: "artists".to_string(),
-                    column_name: "name".to_string(),
+                    name: "name".to_string(),
                     typ: PhysicalColumnType::String { length: None },
                     is_pk: false,
                     is_auto_increment: false,
@@ -170,7 +170,7 @@ impl TestSetup<'_> {
                 },
                 PhysicalColumn {
                     table_name: "artists".to_string(),
-                    column_name: "address_id".to_string(),
+                    name: "address_id".to_string(),
                     typ: PhysicalColumnType::Int { bits: IntBits::_16 },
                     is_pk: false,
                     is_auto_increment: false,
@@ -190,7 +190,7 @@ impl TestSetup<'_> {
             columns: vec![
                 PhysicalColumn {
                     table_name: "addresses".to_string(),
-                    column_name: "id".to_string(),
+                    name: "id".to_string(),
                     typ: PhysicalColumnType::Int { bits: IntBits::_16 },
                     is_pk: true,
                     is_auto_increment: false,
@@ -200,7 +200,7 @@ impl TestSetup<'_> {
                 },
                 PhysicalColumn {
                     table_name: "addresses".to_string(),
-                    column_name: "city".to_string(),
+                    name: "city".to_string(),
                     typ: PhysicalColumnType::String { length: None },
                     is_pk: false,
                     is_auto_increment: false,

--- a/libs/payas-sql/src/transform/transformer.rs
+++ b/libs/payas-sql/src/transform/transformer.rs
@@ -7,7 +7,7 @@ use crate::{
         update::AbstractUpdate,
     },
     sql::{
-        cte::Cte, group_by::GroupBy, predicate::ConcretePredicate, select::Select,
+        cte::WithQuery, group_by::GroupBy, predicate::ConcretePredicate, select::Select,
         transaction::TransactionScript,
     },
     AbstractPredicate,
@@ -60,7 +60,7 @@ pub trait SelectTransformer {
 }
 
 pub trait DeleteTransformer {
-    fn to_delete<'a>(&self, abstract_delete: &'a AbstractDelete) -> Cte<'a>;
+    fn to_delete<'a>(&self, abstract_delete: &'a AbstractDelete) -> WithQuery<'a>;
 
     fn to_transaction_script<'a>(
         &self,


### PR DESCRIPTION
Here we document and clean the content of the `sql` module in payas-sql.