### PR TITLE
Fix syntax highlighting for query/mutation names

### DIFF
--- a/vscode-extension/src/syntaxes/claytip.tmLanguage.template.json
+++ b/vscode-extension/src/syntaxes/claytip.tmLanguage.template.json
@@ -244,12 +244,9 @@
               "name": "keyword.control.export.claytip"
             },
             "2": {
-              "name": "storage.modifier.async.claytip"
-            },
-            "3": {
               "name": "storage.type.function.claytip"
             },
-            "4": {
+            "3": {
               "name": "meta.definition.function.claytip entity.name.function.claytip"
             }
           },


### PR DESCRIPTION
When we remove the async keyword from the query/mutation name, we had a leftover code in matching function components. As a result, the query/mutation name was not highlighted correctly.