### PR TITLE
Fix invalid schema diff with uniqueness constraints

### DIFF
--- a/libs/payas-sql/src/schema/constraint.rs
+++ b/libs/payas-sql/src/schema/constraint.rs
@@ -132,3 +132,22 @@ impl Constraints {
             .collect()
     }
 }
+
+/// Returns a comma separated list of the items in the set, sorted alphabetically If `quote_name` is
+/// true, then the items will be quoted Useful when generating SQL unique constraints, where columns
+/// provided will be a set but we need to generate a stable string to compare against the existing
+/// constraints
+pub(super) fn sorted_comma_list<T: ToString>(list: &HashSet<T>, quote_name: bool) -> String {
+    let mut list = list
+        .iter()
+        .map(|item| {
+            if quote_name {
+                format!("\"{}\"", item.to_string())
+            } else {
+                item.to_string()
+            }
+        })
+        .collect::<Vec<_>>();
+    list.sort();
+    list.join(", ")
+}


### PR DESCRIPTION
We used a `Vec` to store column names in `CreateUniqueConstraint`. This meant if the order in that `Vec` is swapped  (which can happen depending on how we read information from the database), we would declare it as a mismatch during migrations and schema verification.

We now use a `HashSet` to correctly model columns in a uniqueness constraint.