### PR TITLE
Use workspace dependencies to avoid duplicate versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4912,9 +4912,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tokio-postgres",
  "tracing",
- "typed-generational-arena",
  "wasm-model",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,44 @@ default-members = [
     "libs/payas-deno",
     "libs/payas-sql",
     "libs/payas-wasm"
-]  
+]
+
 resolver = "2"
+
+[workspace.dependencies]
+ansi_term = "0.12"
+anyhow = "1.0"
+async-graphql-parser = "5.0.6"
+async-graphql-value = "5.0.6"
+async-recursion = "1.0.0"
+async-trait = "0.1.53"
+bincode = "1.3.3"
+bytes = "1"
+chrono = "0.4.20"
+codemap = "0.1.3"
+codemap-diagnostic = "0.1.1"
+deno_core = "0.171.0"
+futures = "0.3"
+heck = "0.4.0"
+include_dir = "0.7.2"
+insta = "1.14.0"
+jsonwebtoken = "8.1.1"
+lazy_static = "1.4.0"
+maybe-owned = "0.3.4"
+rand = "0.8"
+regex = "1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+tempfile = "3.0.0"
+thiserror = "1.0.31"
+tracing = "0.1"
+tokio = "1"
+tokio-postgres = "0.7.6"
+tree-sitter = "0.20.6"
+typed-generational-arena = "0.2"
+wasmtime = "2.0.0"
+wasmtime-wasi = "2.0.0"
+wildmatch = "2.1.0"
 
 [profile.release]
 lto = true

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -7,14 +7,14 @@ edition = "2021"
 test-context = []
 
 [dependencies]
-tree-sitter = "0.20.6"
-regex = "1"
-serde = { version = "1.0.136", features = ["derive"] }
-codemap = "0.1.3"
-codemap-diagnostic = "0.1.1"
+tree-sitter.workspace = true
+regex.workspace = true
+serde.workspace = true
+codemap.workspace = true
+codemap-diagnostic.workspace = true
 
-wildmatch = "2.1.0"
-thiserror = "1.0.30"
+wildmatch.workspace = true
+thiserror.workspace = true
 core-model = { path = "../core-subsystem/core-model" }
 core-plugin-shared = { path = "../core-subsystem/core-plugin-shared" }
 core-plugin-interface = { path = "../core-subsystem/core-plugin-interface" }
@@ -22,12 +22,13 @@ core-model-builder = { path = "../core-subsystem/core-model-builder" }
 
 [build-dependencies]
 cc = "*"
-tree-sitter = "0.20.6"
+tree-sitter.workspace = true
 tree-sitter-cli = "0.20.7"
-tempfile = "3.0.0"
+tempfile.workspace = true
 
 [dev-dependencies]
-insta = "1.14.0"
-serde_json = "1.0"
+insta.workspace = true
+serde_json.workspace = true
+codemap-diagnostic.workspace = true
 
 [lib]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -8,18 +8,18 @@ name = "clay"
 path = "src/main.rs"
 
 [dependencies]
-ansi_term = "0.12"
-tokio = "1"
-anyhow = "1.0"
-clap = "4.1.4"
-heck = "0.4.0"
-lazy_static = "1.4.0"
+ansi_term.workspace = true
+tokio.workspace = true
+anyhow.workspace = true
+heck.workspace = true
+lazy_static.workspace = true
 notify-debouncer-mini = "0.2.1"
-serde = { version = "1.0", features = ["derive"] }
-futures = "0.3.25"
-rand = "0.8"
+serde.workspace = true
+clap = "4.1.4"
+futures.workspace = true
+rand.workspace = true
 ctrlc = "3.2"
-tempfile = "3.3.0"
+tempfile.workspace = true
 urlencoding = "2.1.2"
 which = "4.4.0"
 

--- a/crates/core-subsystem/core-model-builder/Cargo.toml
+++ b/crates/core-subsystem/core-model-builder/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-codemap = "0.1.3"
-serde = { version = "1.0.136", features = ["derive"] }
-codemap-diagnostic = "0.1.1"
-thiserror = "1.0.30"
+codemap.workspace = true
+serde.workspace = true
+codemap-diagnostic.workspace = true
+thiserror.workspace = true
 
 core-model = { path = "../core-model" }
 core-plugin-shared = { path = "../core-plugin-shared" }

--- a/crates/core-subsystem/core-model/Cargo.toml
+++ b/crates/core-subsystem/core-model/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+serde.workspace = true
 typed-generational-arena = { version = "0.2", features = ["serde"] }
-serde = "1.0"
-async-graphql-parser = "5.0.6"
-async-graphql-value = "5.0.6"
+async-graphql-parser.workspace = true
+async-graphql-value.workspace = true
 
 [dev-dependencies]
 

--- a/crates/core-subsystem/core-plugin-interface/Cargo.toml
+++ b/crates/core-subsystem/core-plugin-interface/Cargo.toml
@@ -8,11 +8,11 @@ built = "0.5"
 
 [dependencies]
 libloading = "0.7.3"
-thiserror = "1.0.30"
-async-trait = "0.1.57"
-async-graphql-value = "5.0.6"
-async-graphql-parser = "5.0.6"
-codemap-diagnostic = "0.1.1"
+thiserror.workspace = true
+async-trait.workspace = true
+async-graphql-value.workspace = true
+async-graphql-parser.workspace = true
+codemap-diagnostic.workspace = true
 core-model-builder = { path = "../core-model-builder" }
 core-resolver = { path = "../core-resolver" }
 core-model = { path = "../core-model" }

--- a/crates/core-subsystem/core-plugin-shared/Cargo.toml
+++ b/crates/core-subsystem/core-plugin-shared/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde = "1.0"
-bincode = "1.3.3"
-thiserror = "1.0.30"
-bytes = "1"
+serde.workspace = true
+bincode.workspace = true
+thiserror.workspace = true
+bytes.workspace = true
 
 core-model = { path = "../core-model" }
 

--- a/crates/core-subsystem/core-resolver/Cargo.toml
+++ b/crates/core-subsystem/core-resolver/Cargo.toml
@@ -7,28 +7,28 @@ edition = "2021"
 test-context = []
 
 [dependencies]
-async-graphql-parser = "5.0.6"
-async-graphql-value = "5.0.6"
-async-recursion = "1.0.0"
-async-trait = "0.1.53"
-bytes = "1"
-futures = "0.3"
-serde_json = { version = "1.0", features = ["preserve_order"] }
-serde = { version = "1.0", features = ["derive"] }
-thiserror = "1.0.30"
-jsonwebtoken = "8.1.1"
+async-graphql-parser.workspace = true
+async-graphql-value.workspace = true
+async-recursion.workspace = true
+async-trait.workspace = true
+bytes.workspace = true
+futures.workspace = true
+serde_json = { workspace = true, features = ["preserve_order"] }
+jsonwebtoken.workspace = true
+serde.workspace = true
+thiserror.workspace = true
 cookie = "0.16"
-tokio = "1"
+tokio.workspace = true
 
-tracing = "0.1"
+tracing.workspace = true
 
 payas-sql = { path = "../../../libs/payas-sql" }
 core-model = { path = "../core-model" }
 core-plugin-shared = { path = "../core-plugin-shared" }
 
 [dev-dependencies]
-tokio = "1"
-insta = "1.14.0"
+tokio.workspace = true
+insta.workspace = true
 
 builder = { path = "../../builder", features = ["test-context"] }
 resolver = { path = "../../resolver" }

--- a/crates/deno-subsystem/deno-model-builder/Cargo.toml
+++ b/crates/deno-subsystem/deno-model-builder/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bincode = "1.3.3"
+bincode.workspace = true
 
 core-plugin-interface = { path = "../../core-subsystem/core-plugin-interface" }
 subsystem-model-builder-util = { path = "../../subsystem-util/subsystem-model-builder-util" }

--- a/crates/deno-subsystem/deno-model/Cargo.toml
+++ b/crates/deno-subsystem/deno-model/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-async-graphql-parser = "5.0.6"
-async-graphql-value = "5.0.6"
-serde = { version = "1.0.136", features = ["derive"] }
-bincode = "1.3.3"
+async-graphql-parser.workspace = true
+async-graphql-value.workspace = true
+serde.workspace = true
 
+bincode.workspace = true
 subsystem-model-util = { path = "../../subsystem-util/subsystem-model-util" }
 core-plugin-interface = { path = "../../core-subsystem/core-plugin-interface" }
 

--- a/crates/deno-subsystem/deno-resolver/Cargo.toml
+++ b/crates/deno-subsystem/deno-resolver/Cargo.toml
@@ -4,19 +4,19 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0"
-async-graphql-parser = "5.0.6"
-async-graphql-value = "5.0.6"
-async-recursion = "1.0.0"
-async-trait = "0.1.53"
+anyhow.workspace = true
+async-graphql-parser.workspace = true
+async-graphql-value.workspace = true
+async-recursion.workspace = true
+async-trait.workspace = true
 # Make sure deno_core version matches the one in the Cargo.toml of the payas_deno crate
 # It looks like if we re-export the deno_core crate from the payas_deno crate, the #[op] macro panics (it looks for the deno_core crate local Cargo.toml)
-deno_core = "0.171.0" 
-futures = "0.3"
-maybe-owned = "0.3.4"
-serde_json = { version = "1.0", features = ["preserve_order"] }
-thiserror = "1.0.30"
-tokio = "1"
+deno_core.workspace = true
+futures.workspace = true
+serde_json = { workspace = true, features = ["preserve_order"] }
+maybe-owned.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
 
 payas-deno = { path = "../../../libs/payas-deno" }
 core-plugin-interface = { path = "../../core-subsystem/core-plugin-interface" }
@@ -24,7 +24,7 @@ deno-model = { path = "../deno-model" }
 
 
 [dev-dependencies]
-tokio = "1"
+tokio.workspace = true
 builder = { path = "../../builder" }
 
 

--- a/crates/introspection-subsystem/introspection-resolver/Cargo.toml
+++ b/crates/introspection-subsystem/introspection-resolver/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-async-graphql-parser = "5.0.6"
-async-graphql-value = "5.0.6"
-async-recursion = "1.0.0"
-async-trait = "0.1.53"
-futures = "0.3"
-serde_json = { version = "1.0", features = ["preserve_order"] }
-tokio = "1"
+async-graphql-parser.workspace = true
+async-graphql-value.workspace = true
+async-recursion.workspace = true
+futures.workspace = true
+serde_json = { workspace = true, features = ["preserve_order"] }
+async-trait.workspace = true
+tokio.workspace = true
 
 core-resolver = { path = "../../core-subsystem/core-resolver" }
 core-model = { path = "../../core-subsystem/core-model" }

--- a/crates/postgres-subsystem/postgres-model-builder/Cargo.toml
+++ b/crates/postgres-subsystem/postgres-model-builder/Cargo.toml
@@ -4,20 +4,20 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-heck = "0.4.0"
-bincode = "1.3.3"
-serde = { version = "1.0.136", features = ["derive"] }
-codemap = "0.1.3"
-codemap-diagnostic = "0.1.1"
-lazy_static = "1.4.0"
-typed-generational-arena = { version = "0.2", features = ["serde"] }
+heck.workspace = true
+bincode.workspace = true
+serde.workspace = true
+codemap-diagnostic.workspace = true
+codemap.workspace = true
+lazy_static.workspace = true
+typed-generational-arena.workspace = true
 
 core-plugin-interface = { path = "../../core-subsystem/core-plugin-interface" }
 postgres-model = { path = "../postgres-model" }
 payas-sql = { path = "../../../libs/payas-sql" }
 
 [dev-dependencies]
-insta = "1.14.0"
+insta.workspace = true
 builder = { path = "../../builder" }
 
 

--- a/crates/postgres-subsystem/postgres-model/Cargo.toml
+++ b/crates/postgres-subsystem/postgres-model/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-typed-generational-arena = { version = "0.2", features = ["serde"] }
-serde = "1.0"
-async-graphql-parser = "5.0.6"
-async-graphql-value = "5.0.6"
-bincode = "1.3.3"
+typed-generational-arena.workspace = true
+serde.workspace = true
+bincode.workspace = true
+async-graphql-parser.workspace = true
+async-graphql-value.workspace = true
 
 payas-sql = { path = "../../../libs/payas-sql" }
 core-plugin-interface = { path = "../../core-subsystem/core-plugin-interface" }

--- a/crates/postgres-subsystem/postgres-resolver/Cargo.toml
+++ b/crates/postgres-subsystem/postgres-resolver/Cargo.toml
@@ -4,20 +4,20 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-async-graphql-parser = "5.0.6"
-async-graphql-value = "5.0.6"
-async-recursion = "1.0.0"
-async-trait = "0.1.57"
-futures = "0.3"
-maybe-owned = "0.3.4"
-serde_json = { version = "1.0", features = ["preserve_order"] }
-serde = { version = "1.0", features = ["derive"] }
+async-graphql-parser.workspace = true
+async-graphql-value.workspace = true
+async-recursion.workspace = true
+async-trait.workspace = true
+futures.workspace = true
+serde_json = { workspace = true, features = ["preserve_order"] }
+maybe-owned.workspace = true
+serde.workspace = true
 thiserror = "1.0.32"
-tokio = { version = "1.0" }
-tokio-postgres = "0.7.6"
+tokio.workspace = true
+tokio-postgres.workspace = true
 postgres-types = "0.2"
 base64 = "0.13"
-chrono = "0.4.20"
+chrono.workspace = true
 pg_bigdecimal = "0.1.4"
 uuid = "1.1.2"
 
@@ -26,7 +26,7 @@ core-plugin-interface = { path = "../../core-subsystem/core-plugin-interface" }
 postgres-model = { path = "../postgres-model" }
 
 [dev-dependencies]
-tokio = "1"
+tokio.workspace = true
 builder = { path = "../../builder" }
 core-resolver = { path = "../../core-subsystem/core-resolver", features = [
     "test-context",

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -4,24 +4,21 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0"
-async-recursion = "1.0.0"
-async-graphql-parser = "5.0.6"
-async-graphql-value = "5.0.6"
+anyhow.workspace = true
+async-recursion.workspace = true
+async-graphql-parser.workspace = true
+async-graphql-value.workspace = true
 async-stream = "0.3.3"
-async-trait = "0.1.53"
-bytes = "1"
-futures = "0.3"
-serde_json = { version = "1.0", features = ["preserve_order"] }
-serde = { version = "1.0", features = ["derive"] }
-tokio-postgres = "0.7.6"
-
-typed-generational-arena = { version = "0.2", features = ["serde"] }
-thiserror = "1.0.30"
-include_dir = "0.7.2"
-bincode = "1.3.3"
-tokio = "1"
-
+async-trait.workspace = true
+bytes.workspace = true
+futures.workspace = true
+serde_json = { workspace = true, features = ["preserve_order"] }
+insta.workspace = true
+serde.workspace = true
+tokio.workspace = true
+thiserror.workspace = true
+include_dir.workspace = true
+bincode.workspace = true
 tracing = { version = "0.1", features = ["log"] }
 
 payas-sql = { path = "../../libs/payas-sql" }
@@ -36,6 +33,5 @@ wasm-model = { path = "../wasm-subsystem/wasm-model" }
 introspection-resolver = { path = "../introspection-subsystem/introspection-resolver" }
 
 [dev-dependencies]
-insta = "1.14.0"
-tokio = "1"
+tokio.workspace = true
 builder = { path = "../builder" }

--- a/crates/server-actix/Cargo.toml
+++ b/crates/server-actix/Cargo.toml
@@ -4,14 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-async-trait = "0.1.57"
+async-trait.workspace = true
 actix-web = { version = "4.1.0", default-features = false, features = ["macros", "cookies"] }
 actix-cors = "0.6.2"
 actix-files = "0.6.2"
-futures = "0.3"
 
-serde_json = { version = "1.0", features = ["preserve_order"] }
-tracing = "0.1"
+serde_json = { workspace = true, features = ["preserve_order"] }
+futures.workspace = true
+tracing.workspace = true
 tracing-actix-web = "0.6.0"
 resolver = { path = "../resolver" }
 core-resolver = { path = "../core-subsystem/core-resolver" }

--- a/crates/server-aws-lambda/Cargo.toml
+++ b/crates/server-aws-lambda/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-async-trait = "0.1.53"
+async-trait.workspace = true
 lambda_runtime = "0.6.1"
-futures = "0.3"
+futures.workspace = true
 opentelemetry = { version = "0.17", default-features = false, features = ["trace"] }
 opentelemetry-jaeger = "0.16"
-serde_json = { version = "1.0", features = ["preserve_order"] }
-tokio = { version = "1", features = ["full"] }
+serde_json = { workspace = true, features = ["preserve_order"] }
+tokio = { workspace = true, features = ["full"] }
 
 resolver = { path = "../resolver" }
 core-resolver = { path = "../core-subsystem/core-resolver" }

--- a/crates/subsystem-util/subsystem-model-builder-util/Cargo.toml
+++ b/crates/subsystem-util/subsystem-model-builder-util/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0.136", features = ["derive"] }
-codemap = "0.1.3"
-codemap-diagnostic = "0.1.1"
+serde.workspace = true
+codemap-diagnostic.workspace = true
+codemap.workspace = true
 
 core-model = { path = "../../core-subsystem/core-model" }
 core-plugin-shared = { path = "../../core-subsystem/core-plugin-shared" }

--- a/crates/subsystem-util/subsystem-model-util/Cargo.toml
+++ b/crates/subsystem-util/subsystem-model-util/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-typed-generational-arena = { version = "0.2", features = ["serde"] }
-serde = "1.0"
-async-graphql-parser = "5.0.6"
-async-graphql-value = "5.0.6"
+typed-generational-arena.workspace = true
+serde.workspace = true
+async-graphql-parser.workspace = true
+async-graphql-value.workspace = true
 
 core-model = { path = "../../core-subsystem/core-model" }
 core-plugin-shared = { path = "../../core-subsystem/core-plugin-shared" }

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -6,26 +6,26 @@ edition = "2021"
 [lib]
 
 [dependencies]
-anyhow = "1.0"
-ansi_term = "0.12"
-jsonwebtoken = "8.0.1"
+anyhow.workspace = true
+ansi_term.workspace = true
 isahc = { version = "1.7", features = ["json", "cookies"] }
 num_cpus = "1.13.1"
-serde = { version = "1.0", features = ["derive"] }
+serde.workspace = true
+jsonwebtoken.workspace = true
 serde_yaml = "0.9.4"
-serde_json = "1.0"
+serde_json.workspace = true
 postgres = { version = "0.19.2", features = ["with-chrono-0_4"] }
-rand = "0.8"
+rand.workspace = true
 rayon = "1.5.1"
-regex = "1"
-tokio = "1"
-async-graphql-parser = "5.0.6"
-async-graphql-value = "5.0.6"
+regex.workspace = true
+tokio.workspace = true
+async-graphql-parser.workspace = true
+async-graphql-value.workspace = true
 md5 = "0.7"
-wildmatch = "2.1.0"
-include_dir = "0.7.2"
+wildmatch.workspace = true
+include_dir.workspace = true
 
 payas-deno = { path = "../../libs/payas-deno" }
 
 [dev-dependencies]
-insta = { version = "1.14.0", features = [ "yaml" ] }
+insta = { workspace = true, features = [ "yaml" ] }

--- a/crates/wasm-subsystem/wasm-model/Cargo.toml
+++ b/crates/wasm-subsystem/wasm-model/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-async-graphql-parser = "5.0.6"
-async-graphql-value = "5.0.6"
-serde = { version = "1.0.136", features = ["derive"] }
-bincode = "1.3.3"
+async-graphql-parser.workspace = true
+async-graphql-value.workspace = true
+serde.workspace = true
+bincode.workspace = true
 
 subsystem-model-util = { path = "../../subsystem-util/subsystem-model-util" }
 core-plugin-interface = { path = "../../core-subsystem/core-plugin-interface" }

--- a/crates/wasm-subsystem/wasm-resolver-dynamic/Cargo.toml
+++ b/crates/wasm-subsystem/wasm-resolver-dynamic/Cargo.toml
@@ -4,15 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-async-graphql-parser = "5.0.6"
-async-graphql-value = "5.0.6"
-async-recursion = "1.0.0"
-async-trait = "0.1.53"
-futures = "0.3"
-serde_json = { version = "1.0", features = ["preserve_order"] }
-thiserror = "1.0.30"
-wasmtime = "2.0.0"
-wasmtime-wasi = "2.0.0"
+async-graphql-parser.workspace = true
+async-graphql-value.workspace = true
+async-recursion.workspace = true
+async-trait.workspace = true
+futures.workspace = true
+serde_json = { workspace = true, features = ["preserve_order"] }
+thiserror.workspace = true
+wasmtime.workspace = true
+wasmtime-wasi.workspace = true
 
 payas-wasm = { path = "../../../libs/payas-wasm" }
 core-plugin-interface = { path = "../../core-subsystem/core-plugin-interface" }

--- a/libs/payas-deno/Cargo.toml
+++ b/libs/payas-deno/Cargo.toml
@@ -4,20 +4,20 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-thiserror = "1.0.31"
-async-trait = "0.1.53"
+thiserror.workspace = true
+async-trait.workspace = true
 deno_runtime = "0.97.0"
-deno_core = "0.171.0"
+deno_core.workspace = true
 deno_ast = { version = "0.23.2", features = ["transpiling"], optional = true }
-tokio = "1"
+tokio.workspace = true
 http_req = "0.9.0"
-futures = "0.3"
-lazy_static = "1.4.0"
-serde = { version = "1.0", features = ["derive"] }
+futures.workspace = true
+lazy_static.workspace = true
+serde = { workspace = true, features = ["derive"] }
 serde_v8 = "0.82.0"
-serde_json = "1.0"
-tracing = "0.1"
-include_dir = "0.7.2"
+serde_json.workspace = true
+tracing.workspace = true
+include_dir.workspace = true
 
 [lib]
 

--- a/libs/payas-sql/Cargo.toml
+++ b/libs/payas-sql/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bytes = "1"
+bytes.workspace = true
 openssl = "0.10.30"
-tokio-postgres = { version = "0.7.6", features = [
+tokio-postgres = { workspace = true, features = [
   "runtime",
   "with-chrono-0_4",
   "with-serde_json-1",
@@ -15,18 +15,18 @@ tokio-postgres = { version = "0.7.6", features = [
 postgres-openssl = "0.5.0"
 postgres_array = "0.11.0"
 deadpool-postgres = "0.10"
-chrono = "0.4.19"
-regex = "1"
-serde = { version = "1.0", features = ["derive"] }
-maybe-owned = "0.3.4"
+chrono.workspace = true
+regex.workspace = true
+serde.workspace = true
+maybe-owned.workspace = true
 once_cell = "1.8.0"
-tracing = "0.1"
+lazy_static.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
 url = "2.2.2"
-lazy_static = "1.4.0"
-thiserror = "1.0.31"
-tokio = "1"
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json.workspace = true
 
 [lib]

--- a/libs/payas-wasm/Cargo.toml
+++ b/libs/payas-wasm/Cargo.toml
@@ -4,15 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.60"
-thiserror = "1.0.31"
-async-trait = "0.1.53"
-wasmtime = "2.0.0"
-wasmtime-wasi = "2.0.0"
+anyhow.workspace = true
+thiserror.workspace = true
+async-trait.workspace = true
+wasmtime.workspace = true
+wasmtime-wasi.workspace = true
 wasi-common = "2.0.0"
-lazy_static = "1.4.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-tracing = "0.1"
+lazy_static.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
 
 [lib]


### PR DESCRIPTION
Where multiple crates in the workspace share a dependency, we now set the version in the root Cargo.toml so that it can be maintained in a single place.