### PR TITLE
Detect and report fragment recursion

### DIFF
--- a/crates/core-subsystem/core-resolver/src/validation/document_validator.rs
+++ b/crates/core-subsystem/core-resolver/src/validation/document_validator.rs
@@ -596,6 +596,60 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
+    #[test]
+    fn fragment_recursion_direct() {
+        let schema = create_test_schema();
+
+        let query = r#"
+            query {
+                concerts {
+                    ...concertFields
+                }
+            }
+
+            fragment concertFields on Concert {
+                ...concertFields
+            }
+        "#;
+
+        let validator = DocumentValidator {
+            schema: &schema,
+            operation_name: None,
+            variables: None,
+        };
+
+        insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
+    }
+
+    #[test]
+    fn fragment_recursion_indirect() {
+        let schema = create_test_schema();
+
+        let query = r#"
+            query {
+                concerts {
+                    ...concertInfo
+                }
+            }
+
+            fragment concertInfo on Concert {
+                ...concertDetails
+            }
+
+            fragment concertDetails on Concert {
+                ...concertInfo
+            }
+        "#;
+
+        let validator = DocumentValidator {
+            schema: &schema,
+            operation_name: None,
+            variables: None,
+        };
+
+        insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
+    }
+
     fn create_variables(variables: &str) -> Map<String, Value> {
         serde_json::from_str(variables).unwrap()
     }

--- a/crates/core-subsystem/core-resolver/src/validation/snapshots/core_resolver__validation__document_validator__tests__fragment_recursion_direct.snap
+++ b/crates/core-subsystem/core-resolver/src/validation/snapshots/core_resolver__validation__document_validator__tests__fragment_recursion_direct.snap
@@ -1,0 +1,10 @@
+---
+source: crates/core-subsystem/core-resolver/src/validation/document_validator.rs
+expression: validator.validate(create_query_document(query))
+---
+Err(
+    FragmentCycle(
+        "concertFields",
+        Pos(9:17),
+    ),
+)

--- a/crates/core-subsystem/core-resolver/src/validation/snapshots/core_resolver__validation__document_validator__tests__fragment_recursion_indirect.snap
+++ b/crates/core-subsystem/core-resolver/src/validation/snapshots/core_resolver__validation__document_validator__tests__fragment_recursion_indirect.snap
@@ -1,0 +1,10 @@
+---
+source: crates/core-subsystem/core-resolver/src/validation/document_validator.rs
+expression: validator.validate(create_query_document(query))
+---
+Err(
+    FragmentCycle(
+        "concertInfo",
+        Pos(13:17),
+    ),
+)

--- a/crates/core-subsystem/core-resolver/src/validation/validation_error.rs
+++ b/crates/core-subsystem/core-resolver/src/validation/validation_error.rs
@@ -59,6 +59,9 @@ pub enum ValidationError {
 
     #[error("operationName '{0}' doesn't match any operation")]
     MultipleOperationsUnmatchedOperationName(String),
+
+    #[error("Fragment cycle detected: {0}")]
+    FragmentCycle(String, Pos),
 }
 
 impl ValidationError {
@@ -82,6 +85,7 @@ impl ValidationError {
             ValidationError::MultipleOperationsNoOperationName => vec![],
             ValidationError::MultipleOperationsUnmatchedOperationName(_) => vec![],
             ValidationError::InvalidArgumentType { pos, .. } => vec![*pos],
+            ValidationError::FragmentCycle(_, pos) => vec![*pos],
         }
     }
 }

--- a/integration-tests/error-reporting/fragment-recursion-direct.claytest
+++ b/integration-tests/error-reporting/fragment-recursion-direct.claytest
@@ -1,0 +1,24 @@
+# Fragment directly referenced itself
+operation: |
+    query {
+      venues {
+        ...VenueInfo
+      }
+    }
+    fragment VenueInfo on Venue {
+      ...VenueInfo
+    }
+response: |
+    {
+      "errors": [
+        {
+          "message": "Fragment cycle detected: VenueInfo",
+          "locations": [
+            {
+              "line": 7,
+              "column": 3
+            }
+          ]
+        }
+      ]
+    }

--- a/integration-tests/error-reporting/fragment-recursion-indirect.claytest
+++ b/integration-tests/error-reporting/fragment-recursion-indirect.claytest
@@ -1,0 +1,27 @@
+# Fragment directly referenced itself
+operation: |
+    query {
+      venues {
+        ...VenueInfo
+      }
+    }
+    fragment VenueInfo on Venue {
+      ...VenueDetails
+    }
+    fragment VenueDetails on Venue {
+      ...VenueInfo
+    }
+response: |
+    {
+      "errors": [
+        {
+          "message": "Fragment cycle detected: VenueInfo",
+          "locations": [
+            {
+              "line": 10,
+              "column": 3
+            }
+          ]
+        }
+      ]
+    }


### PR DESCRIPTION
If we have a fragment that recursively references itself (either directly or through another fragment), we now detect and report an error. This ensures that we don't stack overflow when we try to validate the fragment.

Fixes #404