### PR TITLE
Upgrade to Rust 1.68.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,4 @@
 [toolchain]
-channel = "1.68.0"
+channel = "1.68.1"
+components = ["clippy", "rustfmt"]
+targets = ["wasm32-wasi"]


### PR DESCRIPTION
Also update `rust-toolchain.toml` to add:
- `components` set to `clippy` and `rustfmt`.
- `target` set to `wasm32-wasi` for the same reason.

These changes obviate the need to update the CI Docker image for every Rust ungrade.