### PR TITLE
Implement query depth limits

### DIFF
--- a/crates/core-subsystem/core-resolver/src/system_resolver.rs
+++ b/crates/core-subsystem/core-resolver/src/system_resolver.rs
@@ -39,6 +39,8 @@ pub struct SystemResolver {
     query_interception_map: InterceptionMap,
     mutation_interception_map: InterceptionMap,
     schema: Schema,
+    normal_query_depth_limit: usize,
+    introspection_query_depth_limit: usize,
 }
 
 impl SystemResolver {
@@ -47,12 +49,16 @@ impl SystemResolver {
         query_interception_map: InterceptionMap,
         mutation_interception_map: InterceptionMap,
         schema: Schema,
+        normal_query_depth_limit: usize,
+        introspection_query_depth_limit: usize,
     ) -> Self {
         Self {
             subsystem_resolvers,
             query_interception_map,
             mutation_interception_map,
             schema,
+            normal_query_depth_limit,
+            introspection_query_depth_limit,
         }
     }
 
@@ -189,6 +195,8 @@ impl SystemResolver {
             &self.schema,
             operations_payload.operation_name,
             operations_payload.variables,
+            self.normal_query_depth_limit,
+            self.introspection_query_depth_limit,
         );
 
         document_validator.validate(document)

--- a/crates/core-subsystem/core-resolver/src/validation/snapshots/core_resolver__validation__document_validator__tests__introspection_query_depth_limit_direct-2.snap
+++ b/crates/core-subsystem/core-resolver/src/validation/snapshots/core_resolver__validation__document_validator__tests__introspection_query_depth_limit_direct-2.snap
@@ -1,0 +1,10 @@
+---
+source: crates/core-subsystem/core-resolver/src/validation/document_validator.rs
+assertion_line: 660
+expression: validator.validate(create_query_document(query))
+---
+Err(
+    SelectionSetTooDeep(
+        Pos(5:25),
+    ),
+)

--- a/crates/core-subsystem/core-resolver/src/validation/snapshots/core_resolver__validation__document_validator__tests__introspection_query_depth_limit_direct.snap
+++ b/crates/core-subsystem/core-resolver/src/validation/snapshots/core_resolver__validation__document_validator__tests__introspection_query_depth_limit_direct.snap
@@ -1,0 +1,39 @@
+---
+source: crates/core-subsystem/core-resolver/src/validation/document_validator.rs
+assertion_line: 656
+expression: validator.validate(create_query_document(query))
+---
+Ok(
+    ValidatedOperation {
+        name: None,
+        typ: Query,
+        fields: [
+            ValidatedField {
+                alias: None,
+                name: Name(
+                    "__schema",
+                ),
+                arguments: {},
+                subfields: [
+                    ValidatedField {
+                        alias: None,
+                        name: Name(
+                            "types",
+                        ),
+                        arguments: {},
+                        subfields: [
+                            ValidatedField {
+                                alias: None,
+                                name: Name(
+                                    "name",
+                                ),
+                                arguments: {},
+                                subfields: [],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+)

--- a/crates/core-subsystem/core-resolver/src/validation/snapshots/core_resolver__validation__document_validator__tests__query_depth_limit_direct-2.snap
+++ b/crates/core-subsystem/core-resolver/src/validation/snapshots/core_resolver__validation__document_validator__tests__query_depth_limit_direct-2.snap
@@ -1,0 +1,10 @@
+---
+source: crates/core-subsystem/core-resolver/src/validation/document_validator.rs
+assertion_line: 604
+expression: validator.validate(create_query_document(query))
+---
+Err(
+    SelectionSetTooDeep(
+        Pos(8:37),
+    ),
+)

--- a/crates/core-subsystem/core-resolver/src/validation/snapshots/core_resolver__validation__document_validator__tests__query_depth_limit_direct.snap
+++ b/crates/core-subsystem/core-resolver/src/validation/snapshots/core_resolver__validation__document_validator__tests__query_depth_limit_direct.snap
@@ -1,0 +1,66 @@
+---
+source: crates/core-subsystem/core-resolver/src/validation/document_validator.rs
+assertion_line: 600
+expression: validator.validate(create_query_document(query))
+---
+Ok(
+    ValidatedOperation {
+        name: None,
+        typ: Query,
+        fields: [
+            ValidatedField {
+                alias: None,
+                name: Name(
+                    "concerts",
+                ),
+                arguments: {},
+                subfields: [
+                    ValidatedField {
+                        alias: None,
+                        name: Name(
+                            "venue",
+                        ),
+                        arguments: {},
+                        subfields: [
+                            ValidatedField {
+                                alias: None,
+                                name: Name(
+                                    "concerts",
+                                ),
+                                arguments: {},
+                                subfields: [
+                                    ValidatedField {
+                                        alias: None,
+                                        name: Name(
+                                            "venue",
+                                        ),
+                                        arguments: {},
+                                        subfields: [
+                                            ValidatedField {
+                                                alias: None,
+                                                name: Name(
+                                                    "concerts",
+                                                ),
+                                                arguments: {},
+                                                subfields: [
+                                                    ValidatedField {
+                                                        alias: None,
+                                                        name: Name(
+                                                            "id",
+                                                        ),
+                                                        arguments: {},
+                                                        subfields: [],
+                                                    },
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+)

--- a/crates/core-subsystem/core-resolver/src/validation/snapshots/core_resolver__validation__document_validator__tests__query_depth_limit_through_fragment-2.snap
+++ b/crates/core-subsystem/core-resolver/src/validation/snapshots/core_resolver__validation__document_validator__tests__query_depth_limit_through_fragment-2.snap
@@ -1,0 +1,10 @@
+---
+source: crates/core-subsystem/core-resolver/src/validation/document_validator.rs
+assertion_line: 636
+expression: validator.validate(create_query_document(query))
+---
+Err(
+    SelectionSetTooDeep(
+        Pos(14:25),
+    ),
+)

--- a/crates/core-subsystem/core-resolver/src/validation/snapshots/core_resolver__validation__document_validator__tests__query_depth_limit_through_fragment.snap
+++ b/crates/core-subsystem/core-resolver/src/validation/snapshots/core_resolver__validation__document_validator__tests__query_depth_limit_through_fragment.snap
@@ -1,0 +1,66 @@
+---
+source: crates/core-subsystem/core-resolver/src/validation/document_validator.rs
+assertion_line: 632
+expression: validator.validate(create_query_document(query))
+---
+Ok(
+    ValidatedOperation {
+        name: None,
+        typ: Query,
+        fields: [
+            ValidatedField {
+                alias: None,
+                name: Name(
+                    "concerts",
+                ),
+                arguments: {},
+                subfields: [
+                    ValidatedField {
+                        alias: None,
+                        name: Name(
+                            "venue",
+                        ),
+                        arguments: {},
+                        subfields: [
+                            ValidatedField {
+                                alias: None,
+                                name: Name(
+                                    "concerts",
+                                ),
+                                arguments: {},
+                                subfields: [
+                                    ValidatedField {
+                                        alias: None,
+                                        name: Name(
+                                            "venue",
+                                        ),
+                                        arguments: {},
+                                        subfields: [
+                                            ValidatedField {
+                                                alias: None,
+                                                name: Name(
+                                                    "concerts",
+                                                ),
+                                                arguments: {},
+                                                subfields: [
+                                                    ValidatedField {
+                                                        alias: None,
+                                                        name: Name(
+                                                            "id",
+                                                        ),
+                                                        arguments: {},
+                                                        subfields: [],
+                                                    },
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+)

--- a/crates/core-subsystem/core-resolver/src/validation/validation_error.rs
+++ b/crates/core-subsystem/core-resolver/src/validation/validation_error.rs
@@ -62,6 +62,9 @@ pub enum ValidationError {
 
     #[error("Fragment cycle detected: {0}")]
     FragmentCycle(String, Pos),
+
+    #[error("Selection set too deep")]
+    SelectionSetTooDeep(Pos),
 }
 
 impl ValidationError {
@@ -86,6 +89,7 @@ impl ValidationError {
             ValidationError::MultipleOperationsUnmatchedOperationName(_) => vec![],
             ValidationError::InvalidArgumentType { pos, .. } => vec![*pos],
             ValidationError::FragmentCycle(_, pos) => vec![*pos],
+            ValidationError::SelectionSetTooDeep(pos) => vec![*pos],
         }
     }
 }

--- a/crates/postgres-subsystem/postgres-resolver/src/access_solver.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/access_solver.rs
@@ -343,6 +343,8 @@ mod tests {
                 map: HashMap::new(),
             },
             Schema::new(vec![], vec![], vec![]),
+            10,
+            10,
         );
 
         TestSystem {

--- a/integration-tests/error-reporting/over-the-limit-query-depth.claytest
+++ b/integration-tests/error-reporting/over-the-limit-query-depth.claytest
@@ -1,0 +1,35 @@
+operation: |
+    query {
+      venues { # level 1
+        id # level 2
+        concerts {
+          id
+          venue { # level 3
+            id
+            concerts { # level 4
+              id
+              venue { # level 5
+                id
+                concerts { # level 6
+                  id
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+response: |
+    {
+      "errors": [
+        {
+          "message": "Selection set too deep",
+          "locations": [
+            {
+              "line": 11,
+              "column": 13
+            }
+          ]
+        }
+      ]
+    }

--- a/integration-tests/error-reporting/over-the-limit-query-depth_override.claytest
+++ b/integration-tests/error-reporting/over-the-limit-query-depth_override.claytest
@@ -1,0 +1,29 @@
+operation: |
+    query {
+      venues { # level 1
+        id # level 2
+        concerts {
+          id
+          venue { # level 3
+            id
+            concerts { # level 4
+              id
+              venue { # level 5
+                id
+                concerts { # level 6
+                  id # level 7
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+envs:
+  CLAY_MAX_SELECTION_DEPTH: "7"   
+response: |
+    {
+      "data": {
+        "venues": []
+      }
+    }

--- a/integration-tests/error-reporting/venues.clay
+++ b/integration-tests/error-reporting/venues.clay
@@ -6,5 +6,13 @@ service VenueService {
     name: String
     published: Boolean
     cost: Float? // Keep this optional so that we can test that not specifying it when creating a new venue is not an error
+    concerts: Set<Concert>?
+  }
+
+  @access(true)
+  type Concert {
+    @pk id: Int = autoIncrement()
+    venue: Venue
+    title: String
   }
 }


### PR DESCRIPTION
To prevent abuse throguh overly deep queries, this change now supports CLAY_MAX_SELECTION_DEPTH (defaults to 5). Any query with depth exceeding it is returned an error.