### PR TITLE
Restructure CLI to colocate commands and execution

### DIFF
--- a/crates/cli/src/commands/command.rs
+++ b/crates/cli/src/commands/command.rs
@@ -1,7 +1,116 @@
-use std::time::SystemTime;
+use std::path::PathBuf;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+use clap::{Arg, ArgMatches, Command};
 
-pub trait Command {
-    fn run(&self, system_start_time: Option<SystemTime>) -> Result<()>;
+pub trait CommandDefinition {
+    fn command(&self) -> Command;
+
+    fn execute(&self, matches: &ArgMatches) -> Result<()>;
+}
+pub struct SubcommandDefinition {
+    pub name: &'static str,
+    pub about: &'static str,
+    pub command_definitions: Vec<Box<dyn CommandDefinition>>,
+}
+
+impl SubcommandDefinition {
+    pub fn new(
+        name: &'static str,
+        about: &'static str,
+        command_definitions: Vec<Box<dyn CommandDefinition>>,
+    ) -> Self {
+        Self {
+            name,
+            about,
+            command_definitions,
+        }
+    }
+}
+
+impl CommandDefinition for SubcommandDefinition {
+    fn command(&self) -> Command {
+        Command::new(self.name)
+            .about(self.about)
+            .subcommand_required(true)
+            .arg_required_else_help(true)
+            .disable_help_subcommand(true)
+            .subcommands(
+                self.command_definitions
+                    .iter()
+                    .map(|command_definition| command_definition.command()),
+            )
+    }
+
+    fn execute(&self, matches: &ArgMatches) -> Result<()> {
+        let subcommand = matches.subcommand().unwrap();
+        for command_definition in &self.command_definitions {
+            if command_definition.command().get_name() == subcommand.0 {
+                return command_definition.execute(subcommand.1);
+            }
+        }
+
+        Err(anyhow!("Unknown subcommand: {}", subcommand.0))
+    }
+}
+
+pub fn get_required<T: Clone + Send + Sync + 'static>(
+    matches: &ArgMatches,
+    arg_id: &str,
+) -> Result<T> {
+    get(matches, arg_id).ok_or_else(|| anyhow!("Required argument `{}` is not present", arg_id))
+}
+
+pub fn get<T: Clone + Send + Sync + 'static>(matches: &ArgMatches, arg_id: &str) -> Option<T> {
+    matches.get_one::<T>(arg_id).cloned()
+}
+
+const DEFAULT_MODEL_FILE: &str = "index.exo";
+
+pub fn model_file_arg() -> Arg {
+    Arg::new("model")
+        .help("The path to the Exograph model file.")
+        .hide_default_value(false)
+        .required(false)
+        .value_parser(clap::value_parser!(PathBuf))
+        .default_value(DEFAULT_MODEL_FILE)
+        .index(1)
+}
+
+pub fn new_project_arg() -> Arg {
+    Arg::new("path")
+        .help("Create a new project")
+        .long_help("Create a new project in the given path.")
+        .required(true)
+        .value_parser(clap::value_parser!(PathBuf))
+        .index(1)
+}
+
+pub fn database_arg() -> Arg {
+    Arg::new("database")
+        .help("The PostgreSQL database connection string to use. If not specified, the program will attempt to read it from the environment (`EXO_POSTGRES_URL`).")
+        .long("database")
+        .required(false)
+}
+
+pub fn output_arg() -> Arg {
+    Arg::new("output")
+        .help("Output file path")
+        .help("If specified, the output will be written to this file path instead of stdout.")
+        .short('o')
+        .long("output")
+        .required(false)
+        .value_parser(clap::value_parser!(PathBuf))
+        .num_args(1)
+}
+
+pub fn port_arg() -> Arg {
+    Arg::new("port")
+        .help("Listen port")
+        .long_help("The port the server should listen for HTTP requests on.")
+        .short('p')
+        .long("port")
+        .required(false)
+        .value_parser(clap::value_parser!(u32))
+        .num_args(1)
 }

--- a/crates/cli/src/commands/deploy/mod.rs
+++ b/crates/cli/src/commands/deploy/mod.rs
@@ -1,1 +1,11 @@
-pub(crate) mod fly;
+use super::command::SubcommandDefinition;
+
+mod fly;
+
+pub fn command_definition() -> SubcommandDefinition {
+    SubcommandDefinition::new(
+        "deploy",
+        "Deploy your Exograph project",
+        vec![Box::new(fly::FlyCommandDefinition {})],
+    )
+}

--- a/crates/cli/src/commands/new.rs
+++ b/crates/cli/src/commands/new.rs
@@ -1,35 +1,40 @@
 use std::fs::{create_dir_all, File};
 use std::io::Write;
 use std::path::PathBuf;
-use std::time::SystemTime;
 
 use anyhow::{anyhow, Result};
+use clap::{ArgMatches, Command};
 
-use super::command::Command;
-
-/// Create a new exograph project
-pub struct NewCommand {
-    pub path: PathBuf,
-}
+use super::command::{get_required, new_project_arg, CommandDefinition};
 
 static POSTGRES_TEMPLATE: &[u8] = include_bytes!("templates/postgres.exo");
 static GITIGNORE_TEMPLATE: &[u8] = include_bytes!("templates/gitignore");
 
-impl Command for NewCommand {
-    fn run(&self, _system_start_time: Option<SystemTime>) -> Result<()> {
-        if self.path.exists() {
+pub struct NewCommandDefinition {}
+
+impl CommandDefinition for NewCommandDefinition {
+    fn command(&self) -> Command {
+        Command::new("new")
+            .about("Create a new Exograph project")
+            .arg(new_project_arg())
+    }
+
+    fn execute(&self, matches: &ArgMatches) -> Result<()> {
+        let path: PathBuf = get_required(matches, "path")?;
+
+        if path.exists() {
             return Err(anyhow!(
                 "The path '{}' already exists. Please choose a different name.",
-                self.path.display()
+                path.display()
             ));
         }
 
-        create_dir_all(&self.path)?;
+        create_dir_all(&path)?;
 
-        let mut model_file = File::create(self.path.join("index.exo"))?;
+        let mut model_file = File::create(path.join("index.exo"))?;
         model_file.write_all(POSTGRES_TEMPLATE)?;
 
-        let mut gitignore_file = File::create(self.path.join(".gitignore"))?;
+        let mut gitignore_file = File::create(path.join(".gitignore"))?;
         gitignore_file.write_all(GITIGNORE_TEMPLATE)?;
 
         Ok(())

--- a/crates/cli/src/commands/schema/create.rs
+++ b/crates/cli/src/commands/schema/create.rs
@@ -1,23 +1,34 @@
 use anyhow::Result;
-use std::{io::Write, path::PathBuf, time::SystemTime};
+use clap::Command;
+use std::{io::Write, path::PathBuf};
 
 use exo_sql::schema::spec::SchemaSpec;
 
-use crate::{commands::command::Command, util::open_file_for_output};
+use crate::{
+    commands::command::{get, get_required, model_file_arg, output_arg, CommandDefinition},
+    util::open_file_for_output,
+};
 
 use super::{migration_helper::migration_statements, util};
 
-/// Create a database schema from a exograph model
-pub struct CreateCommand {
-    pub model: PathBuf,
-    pub output: Option<PathBuf>,
-}
+pub(super) struct CreateCommandDefinition {}
 
-impl Command for CreateCommand {
-    fn run(&self, _system_start_time: Option<SystemTime>) -> Result<()> {
-        let postgres_subsystem = util::create_postgres_system(&self.model)?;
+impl CommandDefinition for CreateCommandDefinition {
+    fn command(&self) -> clap::Command {
+        Command::new("create")
+            .about("Create a database schema from a Exograph model")
+            .arg(model_file_arg())
+            .arg(output_arg())
+    }
 
-        let mut buffer: Box<dyn Write> = open_file_for_output(self.output.as_deref())?;
+    /// Create a database schema from a exograph model
+    fn execute(&self, matches: &clap::ArgMatches) -> Result<()> {
+        let model: PathBuf = get_required(matches, "model")?;
+        let output: Option<PathBuf> = get(matches, "output");
+
+        let postgres_subsystem = util::create_postgres_system(&model)?;
+
+        let mut buffer: Box<dyn Write> = open_file_for_output(output.as_deref())?;
 
         // Creating the schema from the model is the same as migrating from an empty database.
         for (statement, _) in migration_statements(

--- a/crates/cli/src/commands/schema/migrate.rs
+++ b/crates/cli/src/commands/schema/migrate.rs
@@ -1,25 +1,43 @@
-use std::{io, path::PathBuf, time::SystemTime};
+use std::{io, path::PathBuf};
 
 use crate::{
-    commands::command::Command,
+    commands::command::{
+        database_arg, get, get_required, model_file_arg, output_arg, CommandDefinition,
+    },
     util::{open_database, open_file_for_output},
 };
 
 use super::{migration_helper::migration_statements, util};
 use anyhow::Result;
+use clap::{Arg, Command};
 use exo_sql::schema::spec::SchemaSpec;
 
-/// Perform a database migration for a exograph model
-pub struct MigrateCommand {
-    pub model: PathBuf,
-    pub database: Option<String>,
-    pub output: Option<PathBuf>,
-    pub allow_destructive_changes: bool,
-}
+pub(super) struct MigrateCommandDefinition {}
 
-impl Command for MigrateCommand {
-    fn run(&self, _system_start_time: Option<SystemTime>) -> Result<()> {
-        let mut buffer: Box<dyn io::Write> = open_file_for_output(self.output.as_deref())?;
+impl CommandDefinition for MigrateCommandDefinition {
+    fn command(&self) -> clap::Command {
+        Command::new("migrate")
+        .about("Produces a SQL migration script for a Exograph model and the specified database")
+        .arg(model_file_arg())
+        .arg(database_arg())
+        .arg(output_arg())
+        .arg(
+            Arg::new("allow-destructive-changes")
+                .help("By default, destructive changes in the model file are commented out. If specified, this option will uncomment such changes.")
+                .long("allow-destructive-changes")
+                .required(false)
+                .num_args(0),
+        )
+    }
+
+    /// Perform a database migration for a exograph model
+    fn execute(&self, matches: &clap::ArgMatches) -> Result<()> {
+        let model: PathBuf = get_required(matches, "model")?;
+        let database: Option<String> = get(matches, "database");
+        let output: Option<PathBuf> = get(matches, "output");
+        let allow_destructive_changes: bool = matches.get_flag("allow-destructive-changes");
+
+        let mut buffer: Box<dyn io::Write> = open_file_for_output(output.as_deref())?;
 
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_io()
@@ -27,7 +45,7 @@ impl Command for MigrateCommand {
             .unwrap();
 
         rt.block_on(async {
-            let database = open_database(self.database.as_deref())?;
+            let database = open_database(database.as_deref())?;
             let client = database.get_client().await?;
 
             let old_schema = SchemaSpec::from_db(&client).await?;
@@ -36,7 +54,7 @@ impl Command for MigrateCommand {
                 eprintln!("{issue}");
             }
 
-            let new_postgres_subsystem = util::create_postgres_system(&self.model)?;
+            let new_postgres_subsystem = util::create_postgres_system(&model)?;
 
             let new_schema =
                 SchemaSpec::from_model(new_postgres_subsystem.tables.into_iter().collect());
@@ -44,7 +62,7 @@ impl Command for MigrateCommand {
             let statements = migration_statements(&old_schema.value, &new_schema);
 
             for (statement, is_destructive) in statements {
-                if is_destructive && !self.allow_destructive_changes {
+                if is_destructive && !allow_destructive_changes {
                     write!(buffer, "-- ")?;
                 }
                 writeln!(buffer, "{statement}")?;

--- a/crates/cli/src/commands/schema/mod.rs
+++ b/crates/cli/src/commands/schema/mod.rs
@@ -1,6 +1,26 @@
+use self::{
+    create::CreateCommandDefinition, import::ImportCommandDefinition,
+    migrate::MigrateCommandDefinition, verify::VerifyCommandDefinition,
+};
+
+use super::command::SubcommandDefinition;
+
 pub(crate) mod create;
 pub(crate) mod import;
 pub(crate) mod migrate;
 pub(crate) mod migration_helper;
 pub(crate) mod util;
 pub(crate) mod verify;
+
+pub fn command_definition() -> SubcommandDefinition {
+    SubcommandDefinition::new(
+        "schema",
+        "Create, migrate, verify, and import  database schema",
+        vec![
+            Box::new(CreateCommandDefinition {}),
+            Box::new(MigrateCommandDefinition {}),
+            Box::new(VerifyCommandDefinition {}),
+            Box::new(ImportCommandDefinition {}),
+        ],
+    )
+}

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -1,17 +1,41 @@
-use std::{path::PathBuf, time::SystemTime};
+use std::path::PathBuf;
 
-use super::command::Command;
+use super::command::{get, get_required, CommandDefinition};
 use anyhow::Result;
+use clap::{Arg, ArgMatches, Command};
 
-/// Perform integration tests
-pub struct TestCommand {
-    pub dir: PathBuf,
-    pub pattern: Option<String>, // glob pattern indicating tests to be executed
-    pub run_introspection_tests: bool,
-}
+pub struct TestCommandDefinition {}
 
-impl Command for TestCommand {
-    fn run(&self, _system_start_time: Option<SystemTime>) -> Result<()> {
-        testing::run(&self.dir, &self.pattern, self.run_introspection_tests)
+impl CommandDefinition for TestCommandDefinition {
+    fn command(&self) -> Command {
+        Command::new("test")
+            .about("Perform integration tests")
+            .arg(
+                Arg::new("dir")
+                    .help("The directory containing integration tests.")
+                    .value_parser(clap::value_parser!(PathBuf))
+                    .required(true)
+                    .index(1),
+            )
+            .arg(
+                Arg::new("pattern")
+                    .help("Glob pattern to choose which tests to run.")
+                    .required(false)
+                    .index(2),
+            )
+            .arg(
+                Arg::new("run-introspection-tests")
+                    .help("When specified, run standard introspection tests on the tests' model files")
+                    .required(false)
+                    .long("run-introspection-tests").num_args(0)
+            )
+    }
+
+    fn execute(&self, matches: &ArgMatches) -> Result<()> {
+        let dir: PathBuf = get_required(matches, "dir")?;
+        let pattern: Option<String> = get(matches, "pattern"); // glob pattern indicating tests to be executed
+        let run_introspection_tests = matches.contains_id("run-introspection-tests");
+
+        testing::run(&dir, &pattern, run_introspection_tests)
     }
 }

--- a/crates/cli/src/util/watcher.rs
+++ b/crates/cli/src/util/watcher.rs
@@ -63,7 +63,7 @@ where
     // - if the return value is an Ok(None), this mean that we have encountered some error, but it is not necessarily
     //   unrecoverable (the watcher should not exit)
     let build_and_start_server = &|| async {
-        let build_result = build(&absolute_path, None, false);
+        let build_result = build(&absolute_path, false);
 
         match build_result {
             Ok(()) => {


### PR DESCRIPTION
So far, structure for all commands and code to extract argument was defined in the main.rs file. That made is hard to find the correspondance between the command and the code that executes it.

This commit introduces the `CommandDefinition` trait that has a method to return the structure and another to execute the command. This encapsulates both aspects into a single place.