### PR TITLE
Fix a dependency between testing and resolver

### DIFF
--- a/crates/testing/.gitignore
+++ b/crates/testing/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/crates/testing/build.rs
+++ b/crates/testing/build.rs
@@ -1,0 +1,16 @@
+fn main() {
+    println!("cargo:rerun-if-changed=package.json");
+    println!("cargo:rerun-if-changed=package-lock.json");
+
+    if !std::process::Command::new("npm")
+        .arg("ci")
+        .current_dir(".")
+        .spawn()
+        .unwrap()
+        .wait()
+        .unwrap()
+        .success()
+    {
+        panic!("Failed to install graphql dependencies");
+    }
+}

--- a/crates/testing/package-lock.json
+++ b/crates/testing/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "testing",
+  "version": "0.1.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "testing",
+      "version": "0.1.0",
+      "dependencies": {
+        "graphql": "16.6.0"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    }
+  },
+  "dependencies": {
+    "graphql": {
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw=="
+    }
+  }
+}

--- a/crates/testing/package.json
+++ b/crates/testing/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "testing",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "graphql": "16.6.0"
+  }
+}

--- a/crates/testing/src/exotest/introspection_tests.rs
+++ b/crates/testing/src/exotest/introspection_tests.rs
@@ -12,8 +12,7 @@ use crate::exotest::{
 use super::common::TestResult;
 
 const INTROSPECTION_ASSERT_JS: &str = include_str!("introspection_tests.js");
-const GRAPHQL_NODE_MODULE: Dir<'static> =
-    include_dir!("$CARGO_MANIFEST_DIR/../../graphiql/node_modules/graphql");
+const GRAPHQL_NODE_MODULE: Dir<'static> = include_dir!("$CARGO_MANIFEST_DIR/node_modules/graphql");
 
 pub(crate) fn run_introspection_test(model_path: &Path) -> Result<TestResult> {
     let log_prefix =

--- a/docker/Dockerfile.template
+++ b/docker/Dockerfile.template
@@ -27,9 +27,13 @@ COPY ./Cargo.lock ./Cargo.lock
 
 COPY ./graphiql/package.json ./graphiql/package.json
 COPY ./graphiql/package-lock.json ./graphiql/package-lock.json
+COPY ./crates/testing/package.json ./crates/testing/package.json
+COPY ./crates/testing/package-lock.json ./crates/testing/package-lock.json
 
 ### Compile the depdencies and remove artifacts related to the non-dependency parts (so that when we use real code, they get rebuilt)
-RUN CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse  cargo build --all ${BUILD_FLAG}
+RUN cd graphiql && npm ci
+RUN cd crates/testing && npm ci
+RUN CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse cargo build --all ${BUILD_FLAG}
 
 %%RM_DEPS%% 
 ## Build the actual image
@@ -38,8 +42,7 @@ ADD crates crates/
 ADD libs libs/
 ADD graphiql graphiql/
 
-
-### Build the binaries (first the graphiql app and then the rest)
+### Build the binaries
 RUN CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse cargo build --all ${BUILD_FLAG}
 
 # Create an image to include the compiled binaries


### PR DESCRIPTION
This was a source of intermittent build failures (we have experienced it in CI a few times as well as during Docker build on certain machines). The `testing` subproject relied on the `graphql` node package in `graphiql` being installed, but those dependencies are fetched only when `resolver` is build (see its build.rs). If it happens that `testing` gets built before `resolver` (which can happen since `testing` doesn't (and need not) have `resolver` as a dependency), the build would fail.

This commit fixes the issue by making the `testing` subproject bring its own `graphql` node package.