### PR TITLE
Fix shared memory leak in local postgres instances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2505,6 +2505,7 @@ dependencies = [
  "deadpool-postgres",
  "lazy_static",
  "maybe-owned",
+ "nix 0.26.2",
  "once_cell",
  "openssl",
  "postgres-openssl",
@@ -3999,6 +4000,15 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
@@ -4145,6 +4155,8 @@ dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
  "static_assertions",
 ]
 

--- a/crates/cli/src/commands/yolo.rs
+++ b/crates/cli/src/commands/yolo.rs
@@ -37,7 +37,7 @@ fn run(model: &PathBuf, port: Option<u32>) -> Result<()> {
         .unwrap();
 
     // make sure we do not exit on SIGINT
-    // we spawn containers that need to be cleaned up through drop(),
+    // we spawn processes/containers that need to be cleaned up through drop(),
     // which does not run on a normal SIGINT exit
     crate::EXIT_ON_SIGINT.store(false, Ordering::SeqCst);
 
@@ -99,7 +99,7 @@ fn run(model: &PathBuf, port: Option<u32>) -> Result<()> {
                 let result = std::io::stdin().read_line(&mut input).map(|_| input.trim());
 
                 match result {
-                    // rebuild docker
+                    // rebuild 
                     Ok("r") => {
                         run(model, port)?;
                     }

--- a/libs/exo-sql/Cargo.toml
+++ b/libs/exo-sql/Cargo.toml
@@ -31,6 +31,7 @@ which = "4.4.0"
 rand.workspace = true
 tempfile.workspace = true
 urlencoding = "2.1.2"
+nix = "0.26.2"
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/libs/exo-sql/src/testing/docker.rs
+++ b/libs/exo-sql/src/testing/docker.rs
@@ -91,6 +91,7 @@ impl EphemeralDatabaseServer for DockerPostgresDatabaseServer {
         launch_process(
             "docker",
             &["exec", &self.container_name, "createdb", "-U", "exo", name],
+            true,
         )?;
 
         Ok(Box::new(DockerPostgresDatabase {
@@ -104,7 +105,7 @@ impl EphemeralDatabaseServer for DockerPostgresDatabaseServer {
 impl Drop for DockerPostgresDatabaseServer {
     fn drop(&mut self) {
         // kill docker, will get removed automatically on exit due to --rm provided when starting
-        launch_process("docker", &["kill", &self.container_name]).unwrap();
+        launch_process("docker", &["kill", &self.container_name], false).unwrap();
     }
 }
 
@@ -126,6 +127,7 @@ impl Drop for DockerPostgresDatabase {
                 "exo",
                 &self.name,
             ],
+            false,
         )
         .unwrap();
     }


### PR DESCRIPTION
Gracefully shut down local postgres instances to let the postgres process clean up its shared memory. This avoids exhausting the shared memory after running `exo yolo` or `exo test` multiple times.