### PR TITLE
Use colored crate instead of ansi_term

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,7 +1058,6 @@ checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 name = "cli"
 version = "0.1.0"
 dependencies = [
- "ansi_term",
  "anyhow",
  "builder",
  "clap 4.2.4",
@@ -6715,10 +6714,10 @@ dependencies = [
 name = "testing"
 version = "0.1.0"
 dependencies = [
- "ansi_term",
  "anyhow",
  "async-graphql-parser",
  "async-graphql-value",
+ "colored",
  "exo-deno",
  "exo-sql",
  "include_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ default-members = [
 resolver = "2"
 
 [workspace.dependencies]
-ansi_term = "0.12"
 colored = "2.0"
 anyhow = "1.0"
 async-graphql-parser = "5.0.6"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -9,7 +9,6 @@ name = "exo"
 path = "src/main.rs"
 
 [dependencies]
-ansi_term.workspace = true
 colored.workspace = true
 tokio.workspace = true
 anyhow.workspace = true

--- a/crates/cli/src/commands/deploy/fly.rs
+++ b/crates/cli/src/commands/deploy/fly.rs
@@ -4,9 +4,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use ansi_term::Color;
 use anyhow::{anyhow, Result};
 use clap::{Arg, ArgAction, Command};
+use colored::Colorize;
 use heck::ToSnakeCase;
 
 use crate::commands::{
@@ -108,89 +108,69 @@ impl CommandDefinition for FlyCommandDefinition {
 
         println!(
             "{}",
-            Color::Purple.paint("If you haven't already done so, run `fly auth login` to login.")
+            "If you haven't already done so, run `fly auth login` to login.".purple()
         );
 
         println!(
             "{}",
-            Color::Blue
+            "\nTo deploy the app for the first time, run:"
+                .blue()
                 .italic()
-                .paint("\nTo deploy the app for the first time, run:")
         );
-        println!(
-            "{}",
-            Color::Blue.paint(format!("\tcd {}", fly_dir.display()))
-        );
-        println!(
-            "{}",
-            Color::Blue.paint(format!("\tfly apps create {}", app_name))
-        );
+        println!("{}", format!("\tcd {}", fly_dir.display()).blue());
+        println!("{}", format!("\tfly apps create {}", app_name).blue());
         println!(
             "{}{}",
-            Color::Blue.paint(format!(
-                "\tfly secrets set --app {} EXO_JWT_SECRET=",
-                app_name,
-            )),
-            Color::Yellow.paint("<your-jwt-secret>")
+            format!("\tfly secrets set --app {} EXO_JWT_SECRET=", app_name,).blue(),
+            "<your-jwt-secret>".yellow()
         );
         if use_fly_db {
             println!(
                 "{}",
-                Color::Blue.paint(format!("\tfly postgres create --name {}-db", app_name))
+                format!("\tfly postgres create --name {}-db", app_name).blue()
             );
             println!(
                 "{}",
-                Color::Blue.paint(format!(
-                    "\tfly postgres attach --app {} {}-db",
-                    app_name, app_name
-                ))
+                format!("\tfly postgres attach --app {} {}-db", app_name, app_name).blue()
             );
             println!(
                 "\tIn a separate terminal: {}",
-                Color::Blue.paint(format!("fly proxy 54321:5432 -a {}-db", app_name))
+                format!("fly proxy 54321:5432 -a {}-db", app_name).blue()
             );
             let db_name = &app_name.to_snake_case(); // this is how fly.io names the db
             println!(
                 "{}{}{}",
-                Color::Blue.paint(format!(
+                format!(
                     "\texo schema create ../{} | psql postgres://{db_name}:",
                     model.to_str().unwrap()
-                )),
-                Color::Blue.paint(format!("@localhost:54321/{db_name}")),
-                Color::Yellow.paint("<APP_DATABASE_PASSWORD>"),
+                )
+                .blue(),
+                "<APP_DATABASE_PASSWORD>".yellow(),
+                format!("@localhost:54321/{db_name}").blue(),
             );
         } else {
             println!(
                 "{}{}",
-                Color::Blue.paint(format!(
-                    "\tfly secrets set --app {} EXO_POSTGRES_URL=",
-                    app_name
-                )),
-                Color::Yellow.paint("<your-postgres-url>")
+                format!("\tfly secrets set --app {} EXO_POSTGRES_URL=", app_name).blue(),
+                "<your-postgres-url>".yellow()
             );
             println!(
                 "{}{}",
-                Color::Blue.paint(format!(
-                    "\texo schema create ../{} | psql ",
-                    model.to_str().unwrap()
-                )),
-                Color::Yellow.paint("<your-postgres-url>")
+                format!("\texo schema create ../{} | psql ", model.to_str().unwrap()).blue(),
+                "<your-postgres-url>".yellow()
             );
         }
 
-        println!("{}", Color::Blue.paint("\tfly deploy --local-only"));
+        println!("{}", "\tfly deploy --local-only".blue());
 
         println!(
             "{}",
-            Color::Green
+            "\nTo deploy a new version of an existing app, run:"
+                .green()
                 .italic()
-                .paint("\nTo deploy a new version of an existing app, run:")
         );
-        println!(
-            "{}",
-            Color::Green.paint(format!("\tcd {}", fly_dir.display()))
-        );
-        println!("{}", Color::Green.paint("\tfly deploy --local-only"));
+        println!("{}", format!("\tcd {}", fly_dir.display()).green());
+        println!("{}", "\tfly deploy --local-only".green());
 
         Ok(())
     }

--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Result};
 use clap::{ArgMatches, Command};
+use colored::Colorize;
 use futures::FutureExt;
 use std::{
     io::{stdin, stdout, Write},
@@ -30,9 +31,7 @@ impl CommandDefinition for DevCommandDefinition {
 
         println!(
             "{}",
-            ansi_term::Color::Purple
-                .bold()
-                .paint("Starting server in development mode...")
+            "Starting server in development mode...".purple().bold()
         );
         // In the serve mode, which is meant for development, always enable introspection and use relaxed CORS
         std::env::set_var("EXO_INTROSPECTION", "true");
@@ -41,17 +40,17 @@ impl CommandDefinition for DevCommandDefinition {
         let rt = Runtime::new()?;
 
         rt.block_on(watcher::start_watcher(&model, port, || async {
-            println!("{}", ansi_term::Color::Blue.bold().paint("\nVerifying new model..."));
+            println!("{}", "\nVerifying new model...".blue().bold());
 
             loop {
                 let verification_result = verify(&model, None).await;
 
                 match verification_result {
                     Err(e @ VerificationErrors::ModelNotCompatible(_)) => {
-                        println!("{}", ansi_term::Color::Red.bold().paint("The schema of the current database is not compatible with the current model for the following reasons:"));
-                        println!("{}", ansi_term::Color::Red.bold().paint(e.to_string()));
-                        println!("{}", ansi_term::Color::Blue.bold().paint("Select an option:"));
-                        print!("{}", ansi_term::Color::Blue.bold().paint("[c]ontinue without fixing, (p)ause and fix manually: "));
+                        println!("{}", "The schema of the current database is not compatible with the current model for the following reasons:".red().bold());
+                        println!("{}", e.to_string().red().bold());
+                        println!("{}", "Select an option:".blue().bold());
+                        print!("{}", "[c]ontinue without fixing, (p)ause and fix manually: ".blue().bold());
                         stdout().flush()?;
 
                         let mut input: String = String::new();
@@ -61,13 +60,13 @@ impl CommandDefinition for DevCommandDefinition {
 
                         match result {
                             "p" => {
-                                println!("{}", ansi_term::Color::Blue.bold().paint("Paused. Press enter to re-verify."));
+                                println!("{}", "Paused. Press enter to re-verify.".blue().bold());
 
                                 let mut line = String::new();
                                 stdin().read_line(&mut line)?;
                             }
                             _ => {
-                                println!("{}", ansi_term::Color::Green.bold().paint("Continuing..."));
+                                println!("{}", "Continuing...".green().bold());
                                 break Ok(());
                             }
                         }

--- a/crates/cli/src/util/watcher.rs
+++ b/crates/cli/src/util/watcher.rs
@@ -2,6 +2,7 @@ use std::{path::Path, time::Duration};
 
 use anyhow::{anyhow, Context, Result};
 use builder::error::ParserError;
+use colored::Colorize;
 use core_model_builder::error::ModelBuildingError;
 use futures::{future::BoxFuture, FutureExt};
 use notify_debouncer_mini::notify::RecursiveMode;
@@ -31,10 +32,8 @@ where
     // start watcher
     println!(
         "{} {}",
-        ansi_term::Color::Blue.bold().paint("Watching:"),
-        ansi_term::Color::Cyan
-            .bold()
-            .paint(&parent_dir.display().to_string())
+        "Watching:".blue().bold(),
+        &parent_dir.display().to_string().cyan().bold()
     );
 
     let (watcher_tx, mut watcher_rx) = tokio::sync::mpsc::channel(1);
@@ -68,11 +67,7 @@ where
         match build_result {
             Ok(()) => {
                 if let Err(e) = prestart_callback().await {
-                    println!(
-                        "{} {}",
-                        ansi_term::Color::Red.bold().paint("Error:"),
-                        ansi_term::Color::Red.bold().paint(e.to_string())
-                    );
+                    println!("{} {}", "Error:".red().bold(), e.to_string().red().bold());
                 }
 
                 let mut command = tokio::process::Command::new(&server_binary);

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 anyhow.workspace = true
-ansi_term.workspace = true
+colored.workspace = true
 isahc = { version = "1.7", features = ["json", "cookies"] }
 num_cpus = "1.13.1"
 serde.workspace = true

--- a/crates/testing/src/exotest/common.rs
+++ b/crates/testing/src/exotest/common.rs
@@ -1,7 +1,9 @@
 use anyhow::{bail, Context, Error, Result};
 
+use colored::Colorize;
 use exo_sql::testing::db::EphemeralDatabase;
 use isahc::HttpClient;
+
 use std::{
     collections::HashMap,
     ffi::OsStr,
@@ -107,37 +109,23 @@ impl fmt::Display for TestResult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.result {
             TestResultKind::Success => {
-                writeln!(
-                    f,
-                    "{} {}",
-                    self.log_prefix,
-                    ansi_term::Color::Green.paint("PASS")
-                )
+                writeln!(f, "{} {}", self.log_prefix, "PASS".green())
             }
-            TestResultKind::Fail(e) => writeln!(
-                f,
-                "{} {}\n{:?}",
-                self.log_prefix,
-                ansi_term::Color::Yellow.paint("FAIL"),
-                e
-            ),
+            TestResultKind::Fail(e) => {
+                writeln!(f, "{} {}\n{:?}", self.log_prefix, "FAIL".yellow(), e)
+            }
             TestResultKind::SetupFail(e) => writeln!(
                 f,
                 "{} {}\n{:?}",
                 self.log_prefix,
-                ansi_term::Color::Red.paint("TEST SETUP FAILED"),
+                "TEST SETUP FAILED".red(),
                 e
             ),
         }
         .unwrap();
 
         if !matches!(&self.result, TestResultKind::Success) {
-            write!(
-                f,
-                "{}\n{}\n",
-                ansi_term::Color::Purple.paint(":: Output:"),
-                ansi_term::Color::Fixed(240).paint(&self.output)
-            )
+            write!(f, "{}\n{}\n", ":: Output:".purple(), &self.output)
         } else {
             Ok(())
         }

--- a/crates/testing/src/exotest/integration_tests.rs
+++ b/crates/testing/src/exotest/integration_tests.rs
@@ -1,4 +1,6 @@
 use anyhow::{anyhow, bail, Context, Result};
+use colored::Colorize;
+
 use exo_sql::testing::db::EphemeralDatabaseServer;
 use isahc::{HttpClient, ReadResponseExt, Request};
 use jsonwebtoken::{encode, EncodingKey, Header};
@@ -33,7 +35,7 @@ pub(crate) fn run_testfile(
     testfile: &ParsedTestfile,
     ephemeral_database: &dyn EphemeralDatabaseServer,
 ) -> Result<TestResult> {
-    let log_prefix = ansi_term::Color::Purple.paint(format!("({})\n :: ", testfile.name()));
+    let log_prefix = format!("({})\n :: ", testfile.name()).purple();
 
     // iterate through our tests
     let mut ctx = {

--- a/crates/testing/src/exotest/introspection_tests.rs
+++ b/crates/testing/src/exotest/introspection_tests.rs
@@ -1,4 +1,6 @@
 use anyhow::{anyhow, Result};
+use colored::Colorize;
+
 use exo_deno::{deno_error::DenoError, Arg, DenoModule, DenoModuleSharedState, UserCode};
 use include_dir::{include_dir, Dir};
 use serde_json::Value;
@@ -15,8 +17,7 @@ const INTROSPECTION_ASSERT_JS: &str = include_str!("introspection_tests.js");
 const GRAPHQL_NODE_MODULE: Dir<'static> = include_dir!("$CARGO_MANIFEST_DIR/node_modules/graphql");
 
 pub(crate) fn run_introspection_test(model_path: &Path) -> Result<TestResult> {
-    let log_prefix =
-        ansi_term::Color::Purple.paint(format!("(introspection: {})\n :: ", model_path.display()));
+    let log_prefix = format!("(introspection: {})\n :: ", model_path.display()).purple();
     println!("{log_prefix} Running introspection tests...");
 
     build_exo_ir_file(model_path)?;

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -1,6 +1,8 @@
 mod exotest;
 
 use anyhow::{bail, Context, Result};
+use colored::Colorize;
+
 use exo_sql::testing::db::{EphemeralDatabaseLauncher, EphemeralDatabaseServer};
 use exotest::integration_tests::{build_exo_ir_file, run_testfile};
 use exotest::loader::{load_testfiles_from_dir, ParsedTestfile};
@@ -22,15 +24,13 @@ pub fn run(
 
     println!(
         "{} {} {} {}",
-        ansi_term::Color::Blue
-            .bold()
-            .paint("* Running tests in directory"),
+        "* Running tests in directory".blue().bold(),
         root_directory_str,
         pattern
             .as_ref()
             .map(|p| format!("with pattern '{p}'"))
             .unwrap_or_else(|| "".to_string()),
-        ansi_term::Color::Blue.bold().paint("..."),
+        "...".blue().bold(),
     );
 
     let start_time = std::time::Instant::now();
@@ -58,9 +58,7 @@ pub fn run(
     if run_introspection_tests {
         println!(
             "{}",
-            ansi_term::Color::Blue
-                .bold()
-                .paint("** Introspection tests enabled, running")
+            "** Introspection tests enabled, running".blue().bold()
         );
 
         for model_path in model_file_deps.keys() {
@@ -68,12 +66,7 @@ pub fn run(
         }
     };
 
-    println!(
-        "{}",
-        ansi_term::Color::Blue
-            .bold()
-            .paint("** Running integration tests")
-    );
+    println!("{}", "** Running integration tests".blue().bold());
 
     // Estimate an optimal pool size
     let pool_size = min(number_of_integration_tests, cpus * 2);
@@ -149,11 +142,8 @@ pub fn run(
             }
 
             Err(e) => {
-                println!(
-                    "{}",
-                    ansi_term::Color::Red.paint("A testfile errored while running.")
-                );
-                println!("{}\n", ansi_term::Color::Fixed(240).paint(format!("{e:?}")));
+                println!("{}", "A testfile errored while running.".red());
+                println!("{e:?}\n");
             }
         }
     }
@@ -161,18 +151,16 @@ pub fn run(
     let number_of_tests = test_results.len();
     let success = number_of_succeeded_tests == number_of_tests;
     let status = if success {
-        ansi_term::Color::Green.paint("PASS.")
+        "PASS.".green()
     } else {
-        ansi_term::Color::Red.paint("FAIL.")
+        "FAIL.".red()
     };
 
     println!(
         "{} {} {} out of {} total in {} seconds ({} cpus)",
-        ansi_term::Color::Blue.bold().paint("* Test results:"),
+        "* Test results:".blue().bold(),
         status,
-        ansi_term::Style::new()
-            .bold()
-            .paint(format!("{number_of_succeeded_tests} passed")),
+        format!("{number_of_succeeded_tests} passed").bold(),
         number_of_tests,
         start_time.elapsed().as_secs(),
         cpus,


### PR DESCRIPTION
ansi_term is deemed unmaintained, so replace it with colored. We still have indirect dependencies on ansi_term (through Clap, e.g), but at least no longer directly depend on it.