### PR TITLE
Allow parenthetical sub-expressions in access control

### DIFF
--- a/crates/builder/grammar/grammar.js
+++ b/crates/builder/grammar/grammar.js
@@ -133,7 +133,7 @@ module.exports = grammar({
       $.literal_str,
       $.literal_boolean
     ),
-    parenthetical: $ => seq("(", $.expression, ")"),
+    parenthetical: $ => seq("(", field("expression", $.expression), ")"),
     selection: $ => choice(
       $.selection_select,
       $.term

--- a/crates/builder/src/parser/converter.rs
+++ b/crates/builder/src/parser/converter.rs
@@ -503,17 +503,17 @@ fn convert_expression(node: Node, source: &[u8], source_span: Span) -> AstExpr<U
         ),
         "literal_boolean" => {
             let value = first_child.child(0).unwrap().utf8_text(source).unwrap();
-            if value == "true" {
-                AstExpr::BooleanLiteral(true, source_span)
-            } else {
-                AstExpr::BooleanLiteral(false, source_span)
-            }
+            AstExpr::BooleanLiteral(value == "true", source_span)
         }
         "logical_op" => AstExpr::LogicalOp(convert_logical_op(first_child, source, source_span)),
         "relational_op" => {
             AstExpr::RelationalOp(convert_relational_op(first_child, source, source_span))
         }
         "selection" => AstExpr::FieldSelection(convert_selection(first_child, source, source_span)),
+        "parenthetical" => {
+            let expression = first_child.child_by_field_name("expression").unwrap();
+            convert_expression(expression, source, source_span)
+        }
         o => panic!("unsupported expression kind: {o}"),
     }
 }

--- a/crates/builder/src/typechecker/field.rs
+++ b/crates/builder/src/typechecker/field.rs
@@ -75,7 +75,7 @@ impl TypecheckFrom<AstField<Untyped>> for AstField<Typed> {
                                 .to_string(),
                         code: Some("C000".to_string()),
                         spans: vec![SpanLabel {
-                            span: *expr.span(),
+                            span: expr.span(),
                             style: SpanStyle::Primary,
                             label: Some(format!("should be of type {types_allowed}")),
                         }],
@@ -94,7 +94,7 @@ impl TypecheckFrom<AstField<Untyped>> for AstField<Typed> {
                         message: "Non-literal specified in default value field.".to_string(),
                         code: Some("C000".to_string()),
                         spans: vec![SpanLabel {
-                            span: *expr.span(),
+                            span: expr.span(),
                             style: SpanStyle::Primary,
                             label: Some("should be string, boolean, or a number".to_string()),
                         }],

--- a/crates/builder/src/typechecker/relational_op.rs
+++ b/crates/builder/src/typechecker/relational_op.rs
@@ -66,13 +66,13 @@ impl TypecheckFrom<RelationalOp<Untyped>> for RelationalOp<Typed> {
                     if left_typ.is_complete() && right_typ.is_complete() {
                         let mut spans = vec![];
                         spans.push(SpanLabel {
-                            span: *left.span(),
+                            span: left.span(),
                             style: SpanStyle::Primary,
                             label: Some(format!("got {left_typ}")),
                         });
 
                         spans.push(SpanLabel {
-                            span: *right.span(),
+                            span: right.span(),
                             style: SpanStyle::Primary,
                             label: Some(format!("got {right_typ}")),
                         });

--- a/integration-tests/access-expressions/docs.exo
+++ b/integration-tests/access-expressions/docs.exo
@@ -32,5 +32,14 @@ module DocumentModule {
     @pk id: Int = autoIncrement()
     name: String
     membership: Membership?
+    notes: Set<AdminNote>?
+  }
+
+  // Only admins can see their own notes (or all notes if they are super admin)
+  @access("SUPER_ADMIN" in AuthContext.roles || ("ADMIN" in AuthContext.roles && self.user.id == AuthContext.id))
+  type AdminNote {
+    @pk id: Int = autoIncrement()
+    content: String
+    user: User
   }
 }

--- a/integration-tests/access-expressions/init-docs.gql
+++ b/integration-tests/access-expressions/init-docs.gql
@@ -24,15 +24,17 @@ operation: |
         adminDoc4: createAdminDoc(data: {content: "adminDoc4"}) {
             id
         }
-        users: createUsers(data: [{name: "u1"}, {name: "u2"}]) {
+        users: createUsers(data: [{name: "u1"}, {name: "u2"}, {name: "a1"}, {name: "a2"}]) {
             id
         }
         memberships: createMemberships(data: [{kind: "k1", user: {id: 1}}, {kind: "k1", user: {id: 2}}]) {
+            id
+        }
+        adminNotes: createAdminNotes(data: [{content: "n1_user3", user: {id: 3}}, {content: "n2_user4", user: {id: 4}}]) {
             id
         }                       
     }  
 auth: |
     {
-        "sub": 1,
-        "roles": ["ADMIN"]
+        "roles": ["ADMIN", "SUPER_ADMIN"]
     }

--- a/integration-tests/access-expressions/notes-admin-auth.exotest
+++ b/integration-tests/access-expressions/notes-admin-auth.exotest
@@ -1,0 +1,116 @@
+stages:
+  # Admin gets their notes (admin user 3)
+  - operation: |
+      query {
+        adminNotes {
+          id
+          content
+        }
+      }
+    auth: |
+        {
+            "sub": 3,
+            "roles": ["ADMIN"]
+        }   
+    response: |
+        {
+          "data": {
+            "adminNotes": [
+              {
+                "id": 1,
+                "content": "n1_user3"
+              }
+            ]
+          }
+        }
+  # Admin gets their notes (admin user 4)        
+  - operation: |
+      query {
+        adminNotes {
+          id
+          content
+        }
+      }
+    auth: |
+        {
+            "sub": 4,
+            "roles": ["ADMIN"]
+        }   
+    response: |
+        {
+          "data": {
+            "adminNotes": [
+              {
+                "id": 2,
+                "content": "n2_user4"
+              }
+            ]
+          }
+        }
+  # Admin gets their notes (user 1 has no notes)
+  - operation: |
+      query {
+        adminNotes {
+          id
+          content
+        }
+      }
+    auth: |
+        {
+            "sub": 1,
+            "roles": ["ADMIN"]
+        }   
+    response: |
+        {
+          "data": {
+            "adminNotes": [
+            ]
+          }
+        }
+  # Super admin gets all notes
+  - operation: |
+      query {
+        adminNotes {
+          id
+          content
+        }
+      }
+    auth: |
+        {
+            "roles": ["SUPER_ADMIN"]
+        }   
+    response: |
+        {
+          "data": {
+            "adminNotes": [
+              {
+                "id": 1,
+                "content": "n1_user3"
+              },
+              {
+                "id": 2,
+                "content": "n2_user4"
+              }
+            ]
+          }
+        }
+  # Normal user gets an authorization error
+  - operation: |
+      query {
+        adminNotes {
+          id
+          content
+        }
+      }
+    auth: |
+        {
+            "roles": ["USER"]
+        }   
+    response: |
+        {
+          "errors": [
+            {
+              "message": "Not authorized"
+            }
+          ]
+        }


### PR DESCRIPTION
This allows for more complex access control expressions, such as:
```exo
(user.role == "admin" || user.role == "editor") && user.id == doc.owner
```
and

```exo
(self.user.id == AuthContext.id && self.user.role == "admin") || self.user.role == "superadmin"
```

During this change, also noticed that the access control expressions involving `&&` led such as `user.role == "admin" && AuthContext.id == doc.owner` let to a panic, so fixed that.