### PR TITLE
Cache context values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,6 +1291,7 @@ dependencies = [
  "core-model",
  "core-plugin-interface",
  "core-plugin-shared",
+ "elsa",
  "exo-sql",
  "futures",
  "insta",
@@ -2468,6 +2469,15 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "elsa"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e0aca8dce8856e420195bd13b6a64de3334235ccc9214e824b86b12bf26283"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]

--- a/crates/core-subsystem/core-resolver/Cargo.toml
+++ b/crates/core-subsystem/core-resolver/Cargo.toml
@@ -20,6 +20,7 @@ serde.workspace = true
 thiserror.workspace = true
 cookie = "0.16"
 tokio.workspace = true
+elsa = "1.8.1"
 
 tracing.workspace = true
 


### PR DESCRIPTION
This ensures that don't compute the same context value multiple times. Furthermore, this ties the context value lifetime to the request context, which we will need for using context values as default (where arguments are tied to the request context, but before this PR, context values weren't).