### PR TITLE
Use an in-memory resolver for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,21 +55,21 @@ jobs:
       - name: Run tests
         run: cargo test --workspace
         
-  # test-integration:
-  #   runs-on: ubuntu-latest
+  test-integration:
+    runs-on: ubuntu-latest
   
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Install deps
-  #       run: sudo apt-get install -y protobuf-compiler
-  #     - name: Install Deno
-  #       uses: denoland/setup-deno@v1
-  #       with:
-  #         deno-version: vx.x.x
-  #     - uses: Swatinem/rust-cache@v2
-  #     - name: Build
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: build
-  #     - name: Run integration tests
-  #       run: EXO_RUN_INTROSPECTION_TESTS=true cargo run --bin exo -- test integration-tests
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install deps
+        run: sudo apt-get install -y protobuf-compiler
+      - name: Install Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: vx.x.x
+      - uses: Swatinem/rust-cache@v2
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+      - name: Run integration tests
+        run: EXO_RUN_INTROSPECTION_TESTS=true cargo run --bin exo -- test integration-tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,17 +470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,12 +922,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "castaway"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
-
-[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,15 +1121,6 @@ checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
  "bytes",
  "memchr",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1513,37 +1487,6 @@ checksum = "bbcf33c2a618cbe41ee43ae6e9f2e48368cd9f9db2896f10167d8d762679f639"
 dependencies = [
  "nix 0.26.2",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "curl"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
-dependencies = [
- "curl-sys",
- "libc",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "socket2",
- "winapi",
-]
-
-[[package]]
-name = "curl-sys"
-version = "0.4.61+curl-8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d05c10f541ae6f3bc5b3d923c20001f47db7d5f0b2bc6ad16490133842db79"
-dependencies = [
- "cc",
- "libc",
- "libnghttp2-sys",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "winapi",
 ]
 
 [[package]]
@@ -2555,12 +2498,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
 name = "exo-deno"
 version = "0.1.0"
 dependencies = [
@@ -2861,21 +2798,6 @@ name = "futures-io"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
-
-[[package]]
-name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
 
 [[package]]
 name = "futures-macro"
@@ -3537,36 +3459,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "isahc"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "334e04b4d781f436dc315cb1e7515bd96826426345d498149e4bde36b67f8ee9"
-dependencies = [
- "async-channel",
- "castaway",
- "crossbeam-utils",
- "curl",
- "curl-sys",
- "encoding_rs",
- "event-listener",
- "futures-lite",
- "http",
- "httpdate",
- "log",
- "mime",
- "once_cell",
- "polling",
- "serde",
- "serde_json",
- "slab",
- "sluice",
- "tracing",
- "tracing-futures",
- "url",
- "waker-fn",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3869,34 +3761,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
-name = "libnghttp2-sys"
-version = "0.1.7+1.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ed28aba195b38d5ff02b9170cbff627e336a20925e43b4945390401c5dc93f"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "libsqlite3-sys"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
 dependencies = [
  "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
-dependencies = [
- "cc",
- "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -4698,12 +4568,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14f2252c834a40ed9bb5422029649578e63aa341ac401f74e719dd1afda8394e"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4961,22 +4825,6 @@ dependencies = [
  "proc-macro2 1.0.56",
  "quote 1.0.26",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "polling"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be1c66a6add46bff50935c313dae30a5030cf8385c5206e8a95e9e9def974aa"
-dependencies = [
- "autocfg",
- "bitflags",
- "cfg-if 1.0.0",
- "concurrent-queue",
- "libc",
- "log",
- "pin-project-lite",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6136,17 +5984,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sluice"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7400c0eff44aa2fcb5e31a5f24ba9716ed90138769e4977a2ba6014ae63eb5"
-dependencies = [
- "async-channel",
- "futures-core",
- "futures-io",
-]
-
-[[package]]
 name = "smallbitvec"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6749,22 +6586,27 @@ dependencies = [
  "async-graphql-parser",
  "async-graphql-value",
  "colored",
+ "core-plugin-interface",
+ "core-resolver",
+ "deno-resolver",
  "exo-deno",
  "exo-sql",
  "include_dir",
  "insta",
- "isahc",
  "jsonwebtoken",
  "md5",
  "num_cpus",
  "postgres",
+ "postgres-resolver",
  "rand",
  "rayon",
  "regex",
+ "resolver",
  "serde",
  "serde_json",
  "serde_yaml",
  "tokio",
+ "unescape",
  "wildmatch",
 ]
 
@@ -7473,6 +7315,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
+name = "unescape"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
+
+[[package]]
 name = "unic-char-property"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7710,12 +7558,6 @@ dependencies = [
  "proc-macro2 1.0.56",
  "quote 1.0.26",
 ]
-
-[[package]]
-name = "waker-fn"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"

--- a/crates/builder/src/builder/interceptor_weaver.rs
+++ b/crates/builder/src/builder/interceptor_weaver.rs
@@ -69,7 +69,7 @@ fn matches(expr: &AstExpr<Typed>, operation_name: &str, operation_kind: Operatio
         AstExpr::FieldSelection(_) => {
             panic!("FieldSelection not supported in interceptor expression")
         }
-        AstExpr::LogicalOp(logical_op) => match dbg!(logical_op) {
+        AstExpr::LogicalOp(logical_op) => match logical_op {
             LogicalOp::Not(expr, _, _) => !matches(expr, operation_name, operation_kind),
             LogicalOp::And(first, second, _, _) => {
                 matches(first, operation_name, operation_kind)

--- a/crates/core-subsystem/core-resolver/src/context/mod.rs
+++ b/crates/core-subsystem/core-resolver/src/context/mod.rs
@@ -10,10 +10,12 @@
 mod error;
 mod overridden_context;
 mod parsed_context;
-mod provider;
+pub mod provider;
 mod request;
 mod request_context;
 mod user_request_context;
+
+pub use provider::jwt::{JwtAuthenticator, LOCAL_JWT_SECRET};
 
 pub use error::ContextParsingError;
 pub use request::Request;

--- a/crates/core-subsystem/core-resolver/src/context/provider/environment.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/environment.rs
@@ -7,15 +7,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::context::{parsed_context::ParsedContext, request::Request, RequestContext};
 
-pub struct EnvironmentContextExtractor;
+pub struct EnvironmentContextExtractor<'a> {
+    pub env: &'a HashMap<String, String>,
+}
 
 #[async_trait]
-impl ParsedContext for EnvironmentContextExtractor {
+impl<'a> ParsedContext for EnvironmentContextExtractor<'a> {
     fn annotation_name(&self) -> &str {
         "env"
     }
@@ -26,6 +30,6 @@ impl ParsedContext for EnvironmentContextExtractor {
         _request_context: &'r RequestContext<'r>,
         _request: &'r (dyn Request + Send + Sync),
     ) -> Option<Value> {
-        std::env::var(key).ok().map(|v| v.into())
+        self.env.get(key).map(|v| v.as_str().into())
     }
 }

--- a/crates/core-subsystem/core-resolver/src/context/user_request_context.rs
+++ b/crates/core-subsystem/core-resolver/src/context/user_request_context.rs
@@ -43,12 +43,14 @@ impl<'a> UserRequestContext<'a> {
     ) -> Result<UserRequestContext<'a>, ContextParsingError> {
         // a list of backend-agnostic contexts to also include
         let generic_contexts: Vec<BoxedParsedContext> = vec![
-            Box::new(EnvironmentContextExtractor),
+            Box::new(EnvironmentContextExtractor {
+                env: &system_resolver.env,
+            }),
             Box::new(QueryExtractor::new(system_resolver)),
             Box::new(HeaderExtractor),
             Box::new(IpExtractor),
             CookieExtractor::parse_context(request)?,
-            JwtAuthenticator::parse_context(request)?,
+            JwtAuthenticator::parse_context(system_resolver.jwt_authenticator.as_ref(), request)?,
         ];
 
         Ok(UserRequestContext {

--- a/crates/core-subsystem/core-resolver/src/system_resolver.rs
+++ b/crates/core-subsystem/core-resolver/src/system_resolver.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::HashMap;
+
 use async_graphql_parser::{
     types::{ExecutableDocument, OperationType},
     Pos,
@@ -21,6 +23,7 @@ use tokio::runtime::Handle;
 use tracing::{error, instrument};
 
 use crate::{
+    context::provider::jwt::JwtAuthenticator,
     context::RequestContext,
     introspection::definition::schema::Schema,
     plugin::{subsystem_resolver::SubsystemResolver, SubsystemResolutionError},
@@ -48,16 +51,21 @@ pub struct SystemResolver {
     query_interception_map: InterceptionMap,
     mutation_interception_map: InterceptionMap,
     schema: Schema,
+    pub jwt_authenticator: Option<JwtAuthenticator>,
+    pub env: HashMap<String, String>,
     normal_query_depth_limit: usize,
     introspection_query_depth_limit: usize,
 }
 
 impl SystemResolver {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         subsystem_resolvers: Vec<Box<dyn SubsystemResolver + Send + Sync>>,
         query_interception_map: InterceptionMap,
         mutation_interception_map: InterceptionMap,
         schema: Schema,
+        jwt_authenticator: Option<JwtAuthenticator>,
+        env: HashMap<String, String>,
         normal_query_depth_limit: usize,
         introspection_query_depth_limit: usize,
     ) -> Self {
@@ -66,6 +74,8 @@ impl SystemResolver {
             query_interception_map,
             mutation_interception_map,
             schema,
+            jwt_authenticator,
+            env,
             normal_query_depth_limit,
             introspection_query_depth_limit,
         }

--- a/crates/postgres-subsystem/postgres-resolver/src/access_solver.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/access_solver.rs
@@ -358,6 +358,8 @@ mod tests {
                 map: HashMap::new(),
             },
             Schema::new(vec![], vec![], vec![]),
+            None,
+            HashMap::new(),
             10,
             10,
         );

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -17,8 +17,8 @@ mod system_loader;
 
 pub mod graphiql;
 pub use root_resolver::create_system_resolver_from_serialized_bytes;
-pub use root_resolver::create_system_resolver_or_exit;
 pub use root_resolver::get_endpoint_http_path;
 pub use root_resolver::get_playground_http_path;
-pub use root_resolver::resolve;
-pub use system_loader::allow_introspection;
+pub use root_resolver::{create_system_resolver, create_system_resolver_or_exit};
+pub use root_resolver::{resolve, resolve_in_memory};
+pub use system_loader::{allow_introspection, LOCAL_ALLOW_INTROSPECTION, LOCAL_ENVIRONMENT};

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 [dependencies]
 anyhow.workspace = true
 colored.workspace = true
-isahc = { version = "1.7", features = ["json", "cookies"] }
 num_cpus = "1.13.1"
 serde.workspace = true
 jsonwebtoken.workspace = true
@@ -25,9 +24,17 @@ async-graphql-value.workspace = true
 md5 = "0.7"
 wildmatch.workspace = true
 include_dir.workspace = true
+unescape = "0.1.0"
 
 exo-sql = { path = "../../libs/exo-sql" }
 exo-deno = { path = "../../libs/exo-deno" }
+
+core-resolver = { path = "../core-subsystem/core-resolver" }
+resolver = { path = "../resolver" }
+postgres-resolver = { path = "../postgres-subsystem/postgres-resolver" }
+deno-resolver = { path = "../deno-subsystem/deno-resolver" }
+
+core-plugin-interface = { path = "../core-subsystem/core-plugin-interface" }
 
 [dev-dependencies]
 insta = { workspace = true, features = ["yaml"] }

--- a/crates/testing/src/exotest/introspection_tests.js
+++ b/crates/testing/src/exotest/introspection_tests.js
@@ -11,16 +11,12 @@ import { buildClientSchema } from "embedded://graphql/utilities/buildClientSchem
 import { getIntrospectionQuery } from "embedded://graphql/utilities/getIntrospectionQuery.mjs"
 import { assertValidSchema } from "embedded://graphql/type/validate.mjs"
 
-export async function assertSchema(endpoint) {
-    let response = await fetch(endpoint, {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json"
-        },
-        body: JSON.stringify({"query": getIntrospectionQuery()})
-    })
+export async function introspectionQuery() {
+    return getIntrospectionQuery();
+}
 
-    const schema = (await response.json())["data"]
+export async function assertSchema(response) {
+    const schema = JSON.parse(response)["data"]
     const clientSchema = buildClientSchema(schema)
 
     assertValidSchema(clientSchema)

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -65,14 +65,7 @@ pub fn run(
 
     // test introspection for all model files
     if run_introspection_tests {
-        println!(
-            "{}",
-            "** Introspection tests enabled, running".blue().bold()
-        );
-
-        for model_path in model_file_deps.keys() {
-            test_results.push(run_introspection_test(model_path));
-        }
+        println!("{}", "** Introspection tests enabled".blue().bold());
     };
 
     println!("{}", "** Running integration tests".blue().bold());
@@ -96,6 +89,10 @@ pub fn run(
 
         pool.spawn(move || match build_exo_ir_file(&model_path) {
             Ok(()) => {
+                if run_introspection_tests {
+                    tx.send(run_introspection_test(&model_path)).unwrap();
+                };
+
                 for file in testfiles.iter() {
                     let result = run_testfile(
                         file,

--- a/libs/exo-deno/src/deno_actor.rs
+++ b/libs/exo-deno/src/deno_actor.rs
@@ -104,7 +104,6 @@ where
         let (deno_call_sender, mut deno_call_receiver) = tokio::sync::mpsc::channel(1);
         let busy = Arc::new(AtomicBool::new(false));
 
-        let deno_call_sender_clone = deno_call_sender.clone();
         let busy_clone = busy.clone();
 
         // start the DenoModule thread
@@ -151,10 +150,7 @@ where
                         final_response_sender,
                     } = match deno_call_receiver.recv().await {
                         Some(call_info) => call_info,
-                        // check if the channel is closed (happens sometimes during shutdown). If so break, otherwise we end up
-                        // printing an error message after the shutdown message
-                        None if deno_call_sender_clone.is_closed() => break,
-                        None => panic!("Could not receive requests in DenoActor thread"),
+                        None => break,
                     };
 
                     busy_clone.store(true, Ordering::Relaxed); // mark DenoActor as busy

--- a/libs/exo-sql/src/lib.rs
+++ b/libs/exo-sql/src/lib.rs
@@ -63,7 +63,7 @@ pub use asql::{
 pub use sql::{
     array_util::{self, ArrayEntry},
     column::Column,
-    database::Database,
+    database::{Database, LOCAL_CONNECTION_POOL_SIZE, LOCAL_URL},
     limit::Limit,
     offset::Offset,
     order::Ordering,


### PR DESCRIPTION
Instead of spawning child processes running a full server, we instead directly invoke the resolver in-memory, which dramatically reduces the OS overhead.

Before:
```
* Test results: PASS. 218 passed out of 218 total in 121 seconds (24 cpus)
```

After:
```
* Test results: PASS. 218 passed out of 218 total in 20 seconds (24 cpus)
```