### PR TITLE
Print errors with only relative paths when building

### DIFF
--- a/crates/builder/src/lib.rs
+++ b/crates/builder/src/lib.rs
@@ -36,10 +36,8 @@ pub fn build_system(
 ) -> Result<Vec<u8>, ParserError> {
     let file_content = fs::read_to_string(model_file.as_ref())?;
     let mut codemap = CodeMap::new();
-    codemap.add_file(
-        model_file.as_ref().to_str().unwrap().to_string(),
-        file_content,
-    );
+
+    codemap.add_file(model_file.as_ref().display().to_string(), file_content);
 
     build_from_ast_system(
         parser::parse_file(&model_file, &mut codemap),

--- a/crates/builder/src/parser/mod.rs
+++ b/crates/builder/src/parser/mod.rs
@@ -63,13 +63,11 @@ fn _parse_file(
         ));
     }
 
-    let input_file_path = input_file_path.canonicalize()?;
-
     let source = fs::read_to_string(input_file.as_ref())?;
-    let mut system = parse_str(&source, codemap, &input_file_path)?;
+    let mut system = parse_str(&source, codemap, input_file_path)?;
 
     // add to already parsed list since we're parsing it currently
-    already_parsed.push(input_file_path);
+    already_parsed.push(input_file_path.to_path_buf());
 
     for import in system.imports.iter() {
         if !already_parsed.contains(import) {
@@ -92,7 +90,7 @@ pub fn parse_str(
 ) -> Result<AstSystem<Untyped>, ParserError> {
     let source_span = codemap
         .add_file(
-            input_file_name.as_ref().to_str().unwrap().to_string(),
+            input_file_name.as_ref().display().to_string(),
             source.to_string(),
         )
         .span;

--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -94,10 +94,7 @@ pub(crate) fn build(print_message: bool) -> Result<(), BuildError> {
 
     if print_message {
         println!("Exograph IR file {} created", exo_ir_file_name.display());
-        println!(
-            "You can start the server with using the 'exo-server {}' command",
-            exo_ir_file_name.display()
-        );
+        println!("You can start the server with using the 'exo-server' command");
     }
 
     Ok(())


### PR DESCRIPTION
We used to print the full path when emitting errors, like:
```
error[C000]: Reference to unknown type: Venue
 --> /home/ramnivas/open-source/foo2/src/index.exo:8:12
  |
8 |     venue: Venue
  |            ^^^^^ unknown type
```

Now, we print only the path relative to the current directory:
```
error[C000]: Reference to unknown type: Venue
 --> src/index.exo:8:12
  |
8 |     venue: Venue
  |            ^^^^^ unknown type
```