### PR TITLE
Produce context.d.ts file in <project-root>/generated

### DIFF
--- a/crates/core-subsystem/core-model-builder/src/ast/ast_types.rs
+++ b/crates/core-subsystem/core-model-builder/src/ast/ast_types.rs
@@ -83,7 +83,7 @@ pub struct AstModule<T: NodeTypedness> {
     pub types: Vec<AstModel<T>>,
     pub methods: Vec<AstMethod<T>>,
     pub interceptors: Vec<AstInterceptor<T>>,
-    pub base_exofile: PathBuf,
+    pub base_exofile: PathBuf, // The exo file in which this module is defined. Used to resolve relative imports and js/ts/wasm sources
     #[serde(skip_serializing)]
     #[serde(skip_deserializing)]
     #[serde(default = "default_span")]

--- a/crates/subsystem-util/subsystem-model-builder-util/src/builder/resolved_builder.rs
+++ b/crates/subsystem-util/subsystem-model-builder-util/src/builder/resolved_builder.rs
@@ -256,17 +256,20 @@ fn resolve_module(
         &Path,
     ) -> Result<Vec<u8>, ModelBuildingError>,
 ) -> Result<(), ModelBuildingError> {
+    // Extract the source path from the annotation
+    // `@deno("util/auth.ts")` -> `util/auth.ts`
     let module_relative_path = match module.annotations.get(&annotation_name).unwrap() {
         AstAnnotationParams::Single(AstExpr::StringLiteral(s, _), _) => s,
         _ => panic!(),
     }
     .clone();
 
-    let mut module_fs_path = module.base_exofile.clone();
-    module_fs_path.pop();
-    module_fs_path.push(&module_relative_path);
+    // The source path is relative to the module's base exofile
+    let mut source_path = module.base_exofile.clone();
+    source_path.pop();
+    source_path.push(&module_relative_path);
 
-    let bundled_script = process_script(module, base_system, &module_fs_path)?;
+    let bundled_script = process_script(module, base_system, &source_path)?;
 
     fn extract_intercept_annot<'a>(
         annotations: &'a AnnotationMap,


### PR DESCRIPTION
This file is shared by all modules, so it needs to be in a common location. By putting in "generated" (which we add to .gitignore), we are free to regenerate as needed to ensure that those types are in sync with context types in the exo files.

This also fixes the infinite watch look due to regenerated context.d.ts files.