### PR TITLE
Print only relative directory paths being watched

### DIFF
--- a/crates/cli/src/commands/yolo.rs
+++ b/crates/cli/src/commands/yolo.rs
@@ -9,6 +9,7 @@
 
 use anyhow::{anyhow, Result};
 use clap::{ArgMatches, Command};
+use colored::Colorize;
 use std::{io::Write, path::PathBuf, sync::atomic::Ordering};
 
 use crate::util::watcher;
@@ -66,8 +67,8 @@ fn run(model: &PathBuf, port: Option<u32>) -> Result<()> {
             std::env::set_var("EXO_JWT_SECRET", &jwt_secret);
             std::env::set_var("EXO_CORS_DOMAINS", "*");
 
-            println!("JWT secret is {}", &jwt_secret);
-            println!("Postgres URL is {}", &db.url());
+            println!("JWT secret is {}", &jwt_secret.cyan());
+            println!("Postgres URL is {}", &db.url().cyan());
 
             // generate migrations for current database
             println!("Generating migrations...");

--- a/crates/cli/src/util/watcher.rs
+++ b/crates/cli/src/util/watcher.rs
@@ -28,10 +28,7 @@ pub async fn start_watcher<'a, F>(
 where
     F: Fn() -> BoxFuture<'a, Result<()>>,
 {
-    let absolute_path = model_path
-        .canonicalize()
-        .map_err(|e| anyhow!("Could not find {}: {}", model_path.to_string_lossy(), e))?;
-    let parent_dir = absolute_path.parent().ok_or_else(|| {
+    let parent_dir = model_path.parent().ok_or_else(|| {
         anyhow!(
             "Could not get parent directory of {}",
             model_path.to_string_lossy()
@@ -40,9 +37,8 @@ where
 
     // start watcher
     println!(
-        "{} {}",
-        "Watching:".blue().bold(),
-        &parent_dir.display().to_string().cyan().bold()
+        "Watching the {} directory for changes...",
+        &parent_dir.display().to_string().cyan().bold(),
     );
 
     let (watcher_tx, mut watcher_rx) = tokio::sync::mpsc::channel(1);


### PR DESCRIPTION
So instead of:
```
Watching: /home/ramnivas/open-source/foo2/src
```

It will print:
```
Watching the src directory for changes...
```

Also add colors to the output for the JWT token and Postgres URL in the yolo command.