### PR TITLE
Remove explicit cargo check from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,20 +26,8 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --all-targets -- -D warnings
-  check:
-    runs-on: ubuntu-latest
+        args: --all-targets --all-features -- -D warnings --no-deps
 
-    steps:
-    - uses: actions/checkout@v3
-    - name: Install deps
-      run: sudo apt-get install -y protobuf-compiler
-    - name: Run cargo check
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: --all-targets
-        
   test:
     runs-on: ubuntu-latest
   


### PR DESCRIPTION
cargo clippy [already performs cargo check](https://github.com/rust-lang/rust-clippy/blob/b4075e87bb0456035e1facd9c6da9c788f669fad/lintcheck/src/main.rs#L364) so there's no need to run it twice.

Also pass `--all-features` and `--no-deps` to `cargo clippy` to ensure that all features are checked and that only our code is checked.