### PR TITLE
Fix issues with yolo mode and migrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,6 +1042,7 @@ name = "cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-recursion",
  "builder",
  "clap 4.2.4",
  "colored",
@@ -1055,6 +1056,7 @@ dependencies = [
  "futures",
  "heck",
  "home",
+ "inquire",
  "lazy_static",
  "notify-debouncer-mini",
  "postgres-model",
@@ -1445,6 +1447,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -3350,6 +3377,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33e7c1ddeb15c9abcbfef6029d8e29f69b52b6d6c891031b88ed91b5065803b"
+dependencies = [
+ "bitflags",
+ "crossterm",
+ "dyn-clone",
+ "lazy_static",
+ "newline-converter",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "insta"
 version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4096,6 +4139,15 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "newline-converter"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f71d09d5c87634207f894c6b31b6a2b2c64ea3bdcf71bd5599fdbbe1600c00f"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "nix"
@@ -5917,6 +5969,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7396,6 +7469,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 [dependencies]
 colored.workspace = true
 tokio.workspace = true
+async-recursion.workspace = true
 anyhow.workspace = true
 heck.workspace = true
 lazy_static.workspace = true
@@ -23,6 +24,7 @@ ctrlc = "3.2"
 tempfile.workspace = true
 zip = "0.6.4"
 home = "0.5.4"
+inquire = "0.6.2"
 
 exo-sql = { path = "../../libs/exo-sql" }
 builder = { path = "../builder" }

--- a/crates/cli/src/commands/schema/create.rs
+++ b/crates/cli/src/commands/schema/create.rs
@@ -38,17 +38,16 @@ impl CommandDefinition for CreateCommandDefinition {
         let model: PathBuf = default_model_file();
         let output: Option<PathBuf> = get(matches, "output");
 
-        let postgres_subsystem = util::create_postgres_system(&model)?;
+        let postgres_subsystem = util::create_postgres_system(model)?;
 
         let mut buffer: Box<dyn Write> = open_file_for_output(output.as_deref())?;
 
         // Creating the schema from the model is the same as migrating from an empty database.
-        for (statement, _) in migration_statements(
+        migration_statements(
             &SchemaSpec::default(),
             &SchemaSpec::from_model(postgres_subsystem.tables.into_iter().collect()),
-        ) {
-            writeln!(buffer, "{statement}\n")?;
-        }
+        )
+        .write(&mut buffer, true)?;
 
         Ok(())
     }

--- a/crates/cli/src/commands/schema/migrate.rs
+++ b/crates/cli/src/commands/schema/migrate.rs
@@ -70,14 +70,8 @@ impl CommandDefinition for MigrateCommandDefinition {
             let new_schema =
                 SchemaSpec::from_model(new_postgres_subsystem.tables.into_iter().collect());
 
-            let statements = migration_statements(&old_schema.value, &new_schema);
-
-            for (statement, is_destructive) in statements {
-                if is_destructive && !allow_destructive_changes {
-                    write!(buffer, "-- ")?;
-                }
-                writeln!(buffer, "{statement}")?;
-            }
+            migration_statements(&old_schema.value, &new_schema)
+                .write(&mut buffer, allow_destructive_changes)?;
 
             Ok(())
         })


### PR DESCRIPTION
When migrations could not be applied and if user chooses to rebuild database, it produced an error (creating runtime from a runtime not allowed).

This PR fixes that issue and:
1. Improve the API around migration functionality
2. Use the "inquire" crate to present options in a nicer way