### PR TITLE
Improve the 'exo dev' experience for migration

### DIFF
--- a/crates/cli/src/commands/schema/create.rs
+++ b/crates/cli/src/commands/schema/create.rs
@@ -20,7 +20,7 @@ use crate::{
     util::open_file_for_output,
 };
 
-use super::{migration_helper::migration_statements, util};
+use super::{migration::Migration, util};
 
 pub(super) struct CreateCommandDefinition {}
 
@@ -43,11 +43,11 @@ impl CommandDefinition for CreateCommandDefinition {
         let mut buffer: Box<dyn Write> = open_file_for_output(output.as_deref())?;
 
         // Creating the schema from the model is the same as migrating from an empty database.
-        migration_statements(
+        let migrations = Migration::from_schemas(
             &SchemaSpec::default(),
             &SchemaSpec::from_model(postgres_subsystem.tables.into_iter().collect()),
-        )
-        .write(&mut buffer, true)?;
+        );
+        migrations.write(&mut buffer, true)?;
 
         Ok(())
     }

--- a/crates/cli/src/commands/schema/mod.rs
+++ b/crates/cli/src/commands/schema/mod.rs
@@ -17,7 +17,7 @@ use super::command::SubcommandDefinition;
 pub(crate) mod create;
 pub(crate) mod import;
 pub(crate) mod migrate;
-pub(crate) mod migration_helper;
+pub(crate) mod migration;
 pub(crate) mod util;
 pub(crate) mod verify;
 

--- a/crates/cli/src/util/mod.rs
+++ b/crates/cli/src/util/mod.rs
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0.
 
 use anyhow::{anyhow, Result};
-use exo_sql::{database_error::DatabaseError, Database};
 use std::{
     fs::File,
     io::{self, stdin, stdout, Read, Write},
@@ -36,13 +35,5 @@ pub fn open_file_for_output(output: Option<&Path>) -> Result<Box<dyn Write>> {
         Ok(Box::new(File::create(output)?))
     } else {
         Ok(Box::new(stdout()))
-    }
-}
-
-pub fn open_database(database: Option<&str>) -> Result<Database, DatabaseError> {
-    if let Some(database) = database {
-        Ok(Database::from_db_url(database)?)
-    } else {
-        Ok(Database::from_env(Some(1))?)
     }
 }


### PR DESCRIPTION
Earlier, when there is a model change that requires a mighration, we just alerted the user and let them fix it outside of the 'exo dev' flow.

In this change, we offer a migration option. We warn if there are destructive changes and upon confirmation, carry the migrations.

Also, use the 'inquire' crate for better UI (and partity with 'yolo').