### PR TITLE
Async cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,6 +1105,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-recursion",
+ "async-trait",
  "builder",
  "clap 4.2.7",
  "colored",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,6 +787,7 @@ dependencies = [
  "core-model-builder",
  "core-plugin-interface",
  "core-plugin-shared",
+ "futures",
  "insta",
  "regex",
  "serde",
@@ -1879,6 +1880,7 @@ name = "deno-model-builder"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bincode",
  "core-plugin-interface",
  "deno",
@@ -5466,6 +5468,7 @@ dependencies = [
  "lazy_static",
  "postgres-model",
  "serde",
+ "tokio",
  "typed-generational-arena",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6835,6 +6835,7 @@ dependencies = [
  "core-plugin-shared",
  "serde",
  "subsystem-model-util",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -13,6 +13,7 @@ regex.workspace = true
 serde.workspace = true
 codemap.workspace = true
 codemap-diagnostic.workspace = true
+futures.workspace = true
 
 wildmatch.workspace = true
 thiserror.workspace = true

--- a/crates/builder/src/typechecker/mod.rs
+++ b/crates/builder/src/typechecker/mod.rs
@@ -91,7 +91,7 @@ fn populate_type_env(env: &mut MappedArena<Type>) {
 }
 
 fn populate_annotation_env(
-    subsystem_builders: &[Box<dyn SubsystemBuilder>],
+    subsystem_builders: &[Box<dyn SubsystemBuilder + Send + Sync>],
     env: &mut HashMap<String, AnnotationSpec>,
 ) {
     let mut annotations = vec![
@@ -241,7 +241,7 @@ fn populate_annotation_env(
 }
 
 pub fn build(
-    subsystem_builders: &[Box<dyn SubsystemBuilder>],
+    subsystem_builders: &[Box<dyn SubsystemBuilder + Send + Sync>],
     ast_system: AstSystem<Untyped>,
 ) -> Result<TypecheckedSystem, ParserError> {
     let mut types_arena: MappedArena<Type> = MappedArena::default();

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 [dependencies]
 colored.workspace = true
 tokio.workspace = true
+async-trait.workspace = true
 async-recursion.workspace = true
 anyhow.workspace = true
 heck.workspace = true

--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use anyhow::{anyhow, Result};
+use async_trait::async_trait;
 use builder::error::ParserError;
 use clap::{ArgMatches, Command};
 
@@ -28,13 +29,14 @@ use super::command::CommandDefinition;
 
 pub struct BuildCommandDefinition {}
 
+#[async_trait]
 impl CommandDefinition for BuildCommandDefinition {
     fn command(&self) -> clap::Command {
         Command::new("build").about("Build exograph server binary")
     }
 
     /// Build exograph server binary
-    fn execute(&self, _matches: &ArgMatches) -> Result<()> {
+    async fn execute(&self, _matches: &ArgMatches) -> Result<()> {
         build(true)?;
 
         Ok(())

--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -37,7 +37,7 @@ impl CommandDefinition for BuildCommandDefinition {
 
     /// Build exograph server binary
     async fn execute(&self, _matches: &ArgMatches) -> Result<()> {
-        build(true)?;
+        build(true).await?;
 
         Ok(())
     }
@@ -61,14 +61,16 @@ impl Display for BuildError {
 }
 
 /// Use statically linked builder to avoid dynamic loading for the CLI
-pub(crate) fn build_system_with_static_builders(model: &Path) -> Result<Vec<u8>, ParserError> {
-    let static_builders: Vec<Box<dyn SubsystemBuilder>> = vec![
+pub(crate) async fn build_system_with_static_builders(
+    model: &Path,
+) -> Result<Vec<u8>, ParserError> {
+    let static_builders: Vec<Box<dyn SubsystemBuilder + Send + Sync>> = vec![
         Box::new(postgres_model_builder::PostgresSubsystemBuilder {}),
         Box::new(deno_model_builder::DenoSubsystemBuilder {}),
         Box::new(wasm_model_builder::WasmSubsystemBuilder {}),
     ];
 
-    builder::build_system(model, static_builders)
+    builder::build_system(model, static_builders).await
 }
 
 /// Build exo_ir file
@@ -79,12 +81,13 @@ pub(crate) fn build_system_with_static_builders(model: &Path) -> Result<Vec<u8>,
 /// * `print_message` - if true, it will print a message indicating the time it took to build the model. We need this
 ///                        to avoid printing the message when building the model through `exo serve`, where we don't want to print the message
 ///                        upon detecting changes
-pub(crate) fn build(print_message: bool) -> Result<(), BuildError> {
+pub(crate) async fn build(print_message: bool) -> Result<(), BuildError> {
     ensure_exo_project_dir(&PathBuf::from("."))?;
 
     let model: PathBuf = default_model_file();
-    let serialized_system =
-        build_system_with_static_builders(&model).map_err(BuildError::ParserError)?;
+    let serialized_system = build_system_with_static_builders(&model)
+        .await
+        .map_err(BuildError::ParserError)?;
 
     let exo_ir_file_name = PathBuf::from("target/index.exo_ir");
     create_dir_all("target").map_err(|e| {

--- a/crates/cli/src/commands/deploy/aws_lambda.rs
+++ b/crates/cli/src/commands/deploy/aws_lambda.rs
@@ -14,6 +14,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Ok, Result};
+use async_trait::async_trait;
 use clap::{Arg, Command};
 use colored::Colorize;
 
@@ -32,6 +33,7 @@ use crate::commands::{
 /// TODO: Revisit once we have a proper release process.
 pub(super) struct AwsLambdaCommandDefinition {}
 
+#[async_trait]
 impl CommandDefinition for AwsLambdaCommandDefinition {
     fn command(&self) -> clap::Command {
         Command::new("aws-lambda")
@@ -46,7 +48,7 @@ impl CommandDefinition for AwsLambdaCommandDefinition {
             )
     }
 
-    fn execute(&self, matches: &clap::ArgMatches) -> Result<()> {
+    async fn execute(&self, matches: &clap::ArgMatches) -> Result<()> {
         let app_name: String = get_required(matches, "app-name")?;
 
         build(false)?;

--- a/crates/cli/src/commands/deploy/aws_lambda.rs
+++ b/crates/cli/src/commands/deploy/aws_lambda.rs
@@ -51,7 +51,7 @@ impl CommandDefinition for AwsLambdaCommandDefinition {
     async fn execute(&self, matches: &clap::ArgMatches) -> Result<()> {
         let app_name: String = get_required(matches, "app-name")?;
 
-        build(false)?;
+        build(false).await?;
 
         let aws_lambda_dir = PathBuf::from("target/aws-lambda");
         create_dir_all(aws_lambda_dir)?;

--- a/crates/cli/src/commands/deploy/fly.rs
+++ b/crates/cli/src/commands/deploy/fly.rs
@@ -14,6 +14,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
+use async_trait::async_trait;
 use clap::{Arg, ArgAction, Command};
 use colored::Colorize;
 use heck::ToSnakeCase;
@@ -25,6 +26,7 @@ use crate::commands::{
 
 pub(super) struct FlyCommandDefinition {}
 
+#[async_trait]
 impl CommandDefinition for FlyCommandDefinition {
     fn command(&self) -> clap::Command {
         Command::new("fly")
@@ -75,7 +77,7 @@ impl CommandDefinition for FlyCommandDefinition {
     ///
     /// To avoid clobbering existing files, this command will create a `fly` directory in the same
     /// directory as the model file, and put the `fly.toml` and `Dockerfile` in there.
-    fn execute(&self, matches: &clap::ArgMatches) -> Result<()> {
+    async fn execute(&self, matches: &clap::ArgMatches) -> Result<()> {
         let app_name: String = get_required(matches, "app-name")?;
         let version: String = get_required(matches, "version")?;
         let envs: Option<Vec<String>> = matches.get_many("env").map(|env| env.cloned().collect());

--- a/crates/cli/src/commands/deploy/fly.rs
+++ b/crates/cli/src/commands/deploy/fly.rs
@@ -86,7 +86,7 @@ impl CommandDefinition for FlyCommandDefinition {
 
         let image_tag = format!("{}:{}", app_name, version);
 
-        build(false)?;
+        build(false).await?;
 
         let fly_dir = PathBuf::from("target/fly");
 

--- a/crates/cli/src/commands/new.rs
+++ b/crates/cli/src/commands/new.rs
@@ -12,6 +12,7 @@ use std::io::Write;
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
+use async_trait::async_trait;
 use clap::{ArgMatches, Command};
 
 use super::command::{get_required, new_project_arg, CommandDefinition};
@@ -23,6 +24,7 @@ static GITIGNORE_TEMPLATE: &[u8] = include_bytes!("templates/exo-new/gitignore")
 
 pub struct NewCommandDefinition {}
 
+#[async_trait]
 impl CommandDefinition for NewCommandDefinition {
     fn command(&self) -> Command {
         Command::new("new")
@@ -30,7 +32,7 @@ impl CommandDefinition for NewCommandDefinition {
             .arg(new_project_arg())
     }
 
-    fn execute(&self, matches: &ArgMatches) -> Result<()> {
+    async fn execute(&self, matches: &ArgMatches) -> Result<()> {
         let path: PathBuf = get_required(matches, "path")?;
 
         if path.exists() {

--- a/crates/cli/src/commands/schema/create.rs
+++ b/crates/cli/src/commands/schema/create.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use anyhow::Result;
+use async_trait::async_trait;
 use clap::Command;
 use std::{io::Write, path::PathBuf};
 
@@ -24,6 +25,7 @@ use super::{migration::Migration, util};
 
 pub(super) struct CreateCommandDefinition {}
 
+#[async_trait]
 impl CommandDefinition for CreateCommandDefinition {
     fn command(&self) -> clap::Command {
         Command::new("create")
@@ -32,7 +34,7 @@ impl CommandDefinition for CreateCommandDefinition {
     }
 
     /// Create a database schema from a exograph model
-    fn execute(&self, matches: &clap::ArgMatches) -> Result<()> {
+    async fn execute(&self, matches: &clap::ArgMatches) -> Result<()> {
         ensure_exo_project_dir(&PathBuf::from("."))?;
 
         let model: PathBuf = default_model_file();

--- a/crates/cli/src/commands/schema/create.rs
+++ b/crates/cli/src/commands/schema/create.rs
@@ -40,7 +40,7 @@ impl CommandDefinition for CreateCommandDefinition {
         let model: PathBuf = default_model_file();
         let output: Option<PathBuf> = get(matches, "output");
 
-        let postgres_subsystem = util::create_postgres_system(model)?;
+        let postgres_subsystem = util::create_postgres_system(model).await?;
 
         let mut buffer: Box<dyn Write> = open_file_for_output(output.as_deref())?;
 

--- a/crates/cli/src/commands/schema/util.rs
+++ b/crates/cli/src/commands/schema/util.rs
@@ -17,21 +17,21 @@ use postgres_model::subsystem::PostgresSubsystem;
 
 use crate::commands::build::build_system_with_static_builders;
 
-pub(crate) fn create_postgres_system(
+pub(crate) async fn create_postgres_system(
     model_file: impl AsRef<Path>,
 ) -> Result<PostgresSubsystem, ParserError> {
-    let serialized_system = build_system_with_static_builders(model_file.as_ref())?;
+    let serialized_system = build_system_with_static_builders(model_file.as_ref()).await?;
     let system = SerializableSystem::deserialize(serialized_system)?;
 
     deserialize_postgres_subsystem(system)
 }
 
 #[cfg(test)]
-pub(crate) fn create_postgres_system_from_str(
+pub(crate) async fn create_postgres_system_from_str(
     model_str: &str,
     file_name: String,
 ) -> Result<PostgresSubsystem, ParserError> {
-    let serialized_system = builder::build_system_from_str(model_str, file_name)?;
+    let serialized_system = builder::build_system_from_str(model_str, file_name).await?;
     let system = SerializableSystem::deserialize(serialized_system)?;
 
     deserialize_postgres_subsystem(system)

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -11,10 +11,12 @@ use std::path::PathBuf;
 
 use super::command::{get, get_required, CommandDefinition};
 use anyhow::{anyhow, Result};
+use async_trait::async_trait;
 use clap::{Arg, ArgMatches, Command};
 
 pub struct TestCommandDefinition {}
 
+#[async_trait]
 impl CommandDefinition for TestCommandDefinition {
     fn command(&self) -> Command {
         Command::new("test")
@@ -35,7 +37,7 @@ impl CommandDefinition for TestCommandDefinition {
             )
     }
 
-    fn execute(&self, matches: &ArgMatches) -> Result<()> {
+    async fn execute(&self, matches: &ArgMatches) -> Result<()> {
         let dir: PathBuf = get_required(matches, "dir")?;
         let pattern: Option<String> = get(matches, "pattern"); // glob pattern indicating tests to be executed
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -41,7 +41,8 @@ lazy_static::lazy_static! {
 
 pub static EXIT_ON_SIGINT: AtomicBool = AtomicBool::new(true);
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     // register a sigint handler
     ctrlc::set_handler(move || {
         // set SIGINT event when receiving signal
@@ -76,5 +77,5 @@ fn main() -> Result<()> {
 
     let matches = command.get_matches();
 
-    subcommand_definition.execute(&matches)
+    subcommand_definition.execute(&matches).await
 }

--- a/crates/cli/src/util/watcher.rs
+++ b/crates/cli/src/util/watcher.rs
@@ -66,7 +66,7 @@ where
     // - if the return value is an Ok(None), this mean that we have encountered some error, but it is not necessarily
     //   unrecoverable (the watcher should not exit)
     let build_and_start_server = &|| async {
-        let build_result = build(false);
+        let build_result = build(false).await;
 
         match build_result {
             Ok(()) => {

--- a/crates/core-subsystem/core-plugin-interface/src/interface.rs
+++ b/crates/core-subsystem/core-plugin-interface/src/interface.rs
@@ -18,11 +18,13 @@ use crate::core_model_builder::{
 };
 use crate::core_resolver::plugin::SubsystemResolver;
 use crate::error::ModelSerializationError;
+use async_trait::async_trait;
 use core_model_builder::typechecker::typ::TypecheckedSystem;
 use thiserror::Error;
 
 use crate::build_info::SubsystemCheckError;
 
+#[async_trait]
 pub trait SubsystemBuilder {
     /// Unique string to identify the subsystem by. Should be shared with the corresponding
     /// [SubsystemLoader].
@@ -75,7 +77,7 @@ pub trait SubsystemBuilder {
     /// - `Ok(Some(SubsystemBuild { .. }))`: The subsystem was built successfully.
     /// - `Ok(None)`: There were no user-declared modules (no build is required).
     /// - `Err(ModelBuildingError { .. })`: The subsystem was not built successfully.
-    fn build(
+    async fn build(
         &self,
         typechecked_system: &TypecheckedSystem,
         base_system: &BaseModelSystem,
@@ -163,7 +165,7 @@ fn load_subsystem_library<T: ?Sized>(
 /// Loads a subsystem builder from a dynamic library.
 pub fn load_subsystem_builder(
     library_path: &Path,
-) -> Result<Box<dyn SubsystemBuilder>, LibraryLoadingError> {
+) -> Result<Box<dyn SubsystemBuilder + Send + Sync>, LibraryLoadingError> {
     load_subsystem_library(library_path, "__exograph_subsystem_builder")
 }
 

--- a/crates/core-subsystem/core-resolver/src/validation/document_validator.rs
+++ b/crates/core-subsystem/core-resolver/src/validation/document_validator.rs
@@ -117,9 +117,9 @@ mod tests {
         serializable_system::SerializableSystem, system_serializer::SystemSerializer,
     };
 
-    #[test]
-    fn argument_valid() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn argument_valid() {
+        let schema = create_test_schema().await;
 
         let validator = DocumentValidator::new(&schema, None, None, 10, 10);
 
@@ -139,9 +139,9 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
-    #[test]
-    fn with_operation_name_valid() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn with_operation_name_valid() {
+        let schema = create_test_schema().await;
 
         let validator = DocumentValidator::new(&schema, None, None, 10, 10);
 
@@ -161,9 +161,9 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
-    #[test]
-    fn stray_argument_invalid() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn stray_argument_invalid() {
+        let schema = create_test_schema().await;
 
         let validator = DocumentValidator::new(&schema, None, None, 10, 10);
 
@@ -183,9 +183,9 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
-    #[test]
-    fn unspecified_required_argument_invalid() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn unspecified_required_argument_invalid() {
+        let schema = create_test_schema().await;
 
         let validator = DocumentValidator::new(&schema, None, None, 10, 10);
 
@@ -205,9 +205,9 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
-    #[test]
-    fn variable_resolution_valid() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn variable_resolution_valid() {
+        let schema = create_test_schema().await;
 
         let variables = create_variables(
             r#"
@@ -235,9 +235,9 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
-    #[test]
-    fn variable_resolution_invalid() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn variable_resolution_invalid() {
+        let schema = create_test_schema().await;
 
         let variables = create_variables(r#"{ "concert_id": 2 }"#);
         let validator = DocumentValidator::new(&schema, None, Some(variables), 10, 10);
@@ -258,9 +258,9 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
-    #[test]
-    fn invalid_subfield() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn invalid_subfield() {
+        let schema = create_test_schema().await;
 
         let validator = DocumentValidator::new(&schema, None, None, 10, 10);
 
@@ -277,9 +277,9 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
-    #[test]
-    fn aliases_valid() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn aliases_valid() {
+        let schema = create_test_schema().await;
 
         let validator = DocumentValidator::new(&schema, None, None, 10, 10);
 
@@ -295,9 +295,9 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
-    #[test]
-    fn mergeable_leaf_fields() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn mergeable_leaf_fields() {
+        let schema = create_test_schema().await;
 
         let validator = DocumentValidator::new(&schema, None, None, 10, 10);
 
@@ -316,9 +316,9 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
-    #[test]
-    fn mergeable_leaf_fields_with_alias() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn mergeable_leaf_fields_with_alias() {
+        let schema = create_test_schema().await;
 
         let validator = DocumentValidator::new(&schema, None, None, 10, 10);
 
@@ -337,9 +337,9 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
-    #[test]
-    fn unmergeable_leaf_fields_all_aliases() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn unmergeable_leaf_fields_all_aliases() {
+        let schema = create_test_schema().await;
 
         let validator = DocumentValidator::new(&schema, None, None, 10, 10);
 
@@ -356,9 +356,9 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
-    #[test]
-    fn unmergeable_leaf_fields_mixed_aliases() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn unmergeable_leaf_fields_mixed_aliases() {
+        let schema = create_test_schema().await;
 
         let validator = DocumentValidator::new(&schema, None, None, 10, 10);
 
@@ -375,9 +375,9 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
-    #[test]
-    fn mergeable_non_leaf_fields() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn mergeable_non_leaf_fields() {
+        let schema = create_test_schema().await;
 
         let validator = DocumentValidator::new(&schema, None, None, 10, 10);
 
@@ -404,9 +404,9 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
-    #[test]
-    fn unmergeable_non_leaf_fields() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn unmergeable_non_leaf_fields() {
+        let schema = create_test_schema().await;
 
         let validator = DocumentValidator::new(&schema, None, None, 10, 10);
 
@@ -429,9 +429,9 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
-    #[test]
-    fn mergeable_non_leaf_fields_with_alias() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn mergeable_non_leaf_fields_with_alias() {
+        let schema = create_test_schema().await;
 
         let validator = DocumentValidator::new(&schema, None, None, 10, 10);
 
@@ -458,9 +458,9 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
-    #[test]
-    fn multi_operations_valid() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn multi_operations_valid() {
+        let schema = create_test_schema().await;
 
         let query = r#"
             query concert1 {
@@ -487,9 +487,9 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
-    #[test]
-    fn multi_operations_no_operation_name_invalid() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn multi_operations_no_operation_name_invalid() {
+        let schema = create_test_schema().await;
 
         let query = r#"
             query concert1 {
@@ -512,9 +512,9 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
-    #[test]
-    fn multi_operations_mismatched_operation_name_invalid() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn multi_operations_mismatched_operation_name_invalid() {
+        let schema = create_test_schema().await;
 
         let query = r#"
             query concert1 {
@@ -537,9 +537,9 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
-    #[test]
-    fn fragment_recursion_direct() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn fragment_recursion_direct() {
+        let schema = create_test_schema().await;
 
         let query = r#"
             query {
@@ -558,9 +558,9 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
-    #[test]
-    fn fragment_recursion_indirect() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn fragment_recursion_indirect() {
+        let schema = create_test_schema().await;
 
         let query = r#"
             query {
@@ -583,9 +583,9 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
-    #[test]
-    fn query_depth_limit_direct() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn query_depth_limit_direct() {
+        let schema = create_test_schema().await;
 
         let query = r#"
             query {
@@ -613,9 +613,9 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
-    #[test]
-    fn query_depth_limit_through_fragment() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn query_depth_limit_through_fragment() {
+        let schema = create_test_schema().await;
 
         let query = r#"
             query {
@@ -645,9 +645,9 @@ mod tests {
         insta::assert_debug_snapshot!(validator.validate(create_query_document(query)));
     }
 
-    #[test]
-    fn introspection_query_depth_limit_direct() {
-        let schema = create_test_schema();
+    #[tokio::test]
+    async fn introspection_query_depth_limit_direct() {
+        let schema = create_test_schema().await;
 
         let query = r#"
             query {
@@ -673,7 +673,7 @@ mod tests {
         serde_json::from_str(variables).unwrap()
     }
 
-    fn create_test_schema() -> Schema {
+    async fn create_test_schema() -> Schema {
         let test_exo = r#"
             @postgres
             module LogModule {
@@ -691,7 +691,8 @@ mod tests {
                 }
             }
         "#;
-        let postgres_subsystem = create_postgres_system_from_str(test_exo, "test.exo".to_string());
+        let postgres_subsystem =
+            create_postgres_system_from_str(test_exo, "test.exo".to_string()).await;
 
         Schema::new(
             postgres_subsystem.schema_types(),
@@ -716,11 +717,13 @@ mod tests {
     /// for now and will make these test live outside of the core being tested. A more dramatic
     /// solution would be to create a "test" subsystem that can be used for testing
     /// purposes--something to consider in the future.
-    pub fn create_postgres_system_from_str(
+    pub async fn create_postgres_system_from_str(
         model_str: &str,
         file_name: String,
     ) -> Box<dyn core_plugin_interface::core_resolver::plugin::SubsystemResolver> {
-        let serialized_system = builder::build_system_from_str(model_str, file_name).unwrap();
+        let serialized_system = builder::build_system_from_str(model_str, file_name)
+            .await
+            .unwrap();
         let system = SerializableSystem::deserialize(serialized_system).unwrap();
 
         let subsystem_id = "postgres";

--- a/crates/deno-subsystem/deno-model-builder/Cargo.toml
+++ b/crates/deno-subsystem/deno-model-builder/Cargo.toml
@@ -13,6 +13,7 @@ deno-model = { path = "../deno-model" }
 deno_emit = "0.16.0"
 url = "2.3.1"
 tokio.workspace = true
+async-trait.workspace = true
 anyhow.workspace = true
 
 # we use a patched version of Deno that exposes the CLI internals as a library

--- a/crates/deno-subsystem/deno-model-builder/src/plugin.rs
+++ b/crates/deno-subsystem/deno-model-builder/src/plugin.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use async_trait::async_trait;
+
 use core_plugin_interface::{
     core_model_builder::{
         builder::system_builder::BaseModelSystem,
@@ -26,6 +28,7 @@ use crate::system_builder::ModelDenoSystemWithInterceptors;
 
 pub struct DenoSubsystemBuilder {}
 
+#[async_trait]
 impl SubsystemBuilder for DenoSubsystemBuilder {
     fn id(&self) -> &'static str {
         "deno"
@@ -43,7 +46,7 @@ impl SubsystemBuilder for DenoSubsystemBuilder {
         )]
     }
 
-    fn build(
+    async fn build(
         &self,
         typechecked_system: &TypecheckedSystem,
         base_system: &BaseModelSystem,

--- a/crates/deno-subsystem/deno-model-builder/src/plugin.rs
+++ b/crates/deno-subsystem/deno-model-builder/src/plugin.rs
@@ -51,7 +51,7 @@ impl SubsystemBuilder for DenoSubsystemBuilder {
         typechecked_system: &TypecheckedSystem,
         base_system: &BaseModelSystem,
     ) -> Result<Option<SubsystemBuild>, ModelBuildingError> {
-        let subsystem = crate::system_builder::build(typechecked_system, base_system)?;
+        let subsystem = crate::system_builder::build(typechecked_system, base_system).await?;
 
         let Some(ModelDenoSystemWithInterceptors {
             underlying: subsystem,

--- a/crates/deno-subsystem/deno-model-builder/src/system_builder.rs
+++ b/crates/deno-subsystem/deno-model-builder/src/system_builder.rs
@@ -35,7 +35,7 @@ pub struct ModelDenoSystemWithInterceptors {
     pub interceptors: Vec<(AstExpr<Typed>, SerializableSlabIndex<Interceptor>)>,
 }
 
-pub fn build(
+pub async fn build(
     typechecked_system: &TypecheckedSystem,
     base_system: &BaseModelSystem,
 ) -> Result<Option<ModelDenoSystemWithInterceptors>, ModelBuildingError> {
@@ -47,7 +47,8 @@ pub fn build(
         base_system,
         module_selection_closure,
         process_script,
-    )?;
+    )
+    .await?;
 
     let underlying_module_system = module_system.underlying;
 

--- a/crates/postgres-subsystem/postgres-model-builder/Cargo.toml
+++ b/crates/postgres-subsystem/postgres-model-builder/Cargo.toml
@@ -12,6 +12,7 @@ codemap-diagnostic.workspace = true
 codemap.workspace = true
 lazy_static.workspace = true
 typed-generational-arena.workspace = true
+tokio.workspace = true
 
 core-plugin-interface = { path = "../../core-subsystem/core-plugin-interface" }
 postgres-model = { path = "../postgres-model" }

--- a/crates/postgres-subsystem/postgres-model-builder/src/plugin.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/plugin.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use core_plugin_interface::{
+    async_trait::async_trait,
     core_model_builder::{
         builder::system_builder::BaseModelSystem,
         error::ModelBuildingError,
@@ -23,6 +24,7 @@ use core_plugin_interface::{
 
 pub struct PostgresSubsystemBuilder {}
 
+#[async_trait]
 impl SubsystemBuilder for PostgresSubsystemBuilder {
     fn id(&self) -> &'static str {
         "postgres"
@@ -186,7 +188,7 @@ impl SubsystemBuilder for PostgresSubsystemBuilder {
         ]
     }
 
-    fn build(
+    async fn build(
         &self,
         typechecked_system: &TypecheckedSystem,
         base_system: &BaseModelSystem,

--- a/crates/postgres-subsystem/postgres-model-builder/src/system_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/system_builder.rs
@@ -150,8 +150,8 @@ mod tests {
 
     use super::*;
 
-    #[test]
-    fn optional_fields() {
+    #[tokio::test]
+    async fn optional_fields() {
         let src = r#"
             @postgres
             module ConcertModule {
@@ -173,7 +173,7 @@ mod tests {
             }
         "#;
 
-        let system = create_system(src);
+        let system = create_system(src).await;
         let get_table = |n| get_table_from_arena(n, &system.tables);
 
         let concerts = get_table("concerts");
@@ -204,8 +204,8 @@ mod tests {
         assert!(venues_address.is_nullable);
     }
 
-    #[test]
-    fn one_to_one() {
+    #[tokio::test]
+    async fn one_to_one() {
         let src = r#"
         @postgres
         module UserModule {
@@ -221,7 +221,7 @@ mod tests {
         }
         "#;
 
-        let system = create_system(src);
+        let system = create_system(src).await;
         let get_table = |n| get_table_from_arena(n, &system.tables);
 
         let users = get_table("users");
@@ -237,8 +237,8 @@ mod tests {
         assert!(!users_membership.is_nullable);
     }
 
-    #[test]
-    fn type_hint_annotations() {
+    #[tokio::test]
+    async fn type_hint_annotations() {
         let src = r#"
             @postgres
             module LogModule {
@@ -259,7 +259,7 @@ mod tests {
             }
         "#;
 
-        let system = create_system(src);
+        let system = create_system(src).await;
         let get_table = |n| get_table_from_arena(n, &system.tables);
 
         let logs = get_table("logs");
@@ -372,7 +372,9 @@ mod tests {
         panic!("No such column {name}")
     }
 
-    fn create_system(src: &str) -> PostgresSubsystem {
-        crate::test_utils::create_postgres_system_from_str(src, "test.exo".to_string()).unwrap()
+    async fn create_system(src: &str) -> PostgresSubsystem {
+        crate::test_utils::create_postgres_system_from_str(src, "test.exo".to_string())
+            .await
+            .unwrap()
     }
 }

--- a/crates/postgres-subsystem/postgres-model-builder/src/test_utils.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/test_utils.rs
@@ -16,11 +16,13 @@ use core_plugin_interface::{
 use postgres_model::subsystem::PostgresSubsystem;
 
 #[cfg(test)]
-pub(crate) fn create_postgres_system_from_str(
+pub(crate) async fn create_postgres_system_from_str(
     model_str: &str,
     file_name: String,
 ) -> Result<PostgresSubsystem, ModelSerializationError> {
-    let serialized_system = builder::build_system_from_str(model_str, file_name).unwrap();
+    let serialized_system = builder::build_system_from_str(model_str, file_name)
+        .await
+        .unwrap();
     let system = SerializableSystem::deserialize(serialized_system)?;
 
     deserialize_postgres_subsystem(system)

--- a/crates/postgres-subsystem/postgres-resolver/src/access_solver.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/access_solver.rs
@@ -273,7 +273,7 @@ mod tests {
         }
     }
 
-    fn test_system() -> TestSystem {
+    async fn test_system() -> TestSystem {
         let postgres_subsystem = crate::test_utils::create_postgres_system_from_str(
             r#"
                 context AccessContext {
@@ -301,7 +301,9 @@ mod tests {
             "#,
             "test.exo".to_string(),
         )
+        .await
         .unwrap();
+
         let (table_id, table) = postgres_subsystem
             .tables
             .iter()
@@ -585,7 +587,7 @@ mod tests {
     #[tokio::test]
     async fn basic_eq() {
         test_relational_op(
-            &test_system(),
+            &test_system().await,
             AccessRelationalOp::Eq,
             |_, _| AbstractPredicate::True,
             |_, _| AbstractPredicate::False,
@@ -599,7 +601,7 @@ mod tests {
     #[tokio::test]
     async fn basic_neq() {
         test_relational_op(
-            &test_system(),
+            &test_system().await,
             AccessRelationalOp::Neq,
             |_, _| AbstractPredicate::False,
             |_, _| AbstractPredicate::True,
@@ -613,7 +615,7 @@ mod tests {
     #[tokio::test]
     async fn basic_lt() {
         test_relational_op(
-            &test_system(),
+            &test_system().await,
             AccessRelationalOp::Lt,
             AbstractPredicate::Lt,
             AbstractPredicate::Lt,
@@ -627,7 +629,7 @@ mod tests {
     #[tokio::test]
     async fn basic_lte() {
         test_relational_op(
-            &test_system(),
+            &test_system().await,
             AccessRelationalOp::Lte,
             AbstractPredicate::Lte,
             AbstractPredicate::Lte,
@@ -641,7 +643,7 @@ mod tests {
     #[tokio::test]
     async fn basic_gt() {
         test_relational_op(
-            &test_system(),
+            &test_system().await,
             AccessRelationalOp::Gt,
             AbstractPredicate::Gt,
             AbstractPredicate::Gt,
@@ -655,7 +657,7 @@ mod tests {
     #[tokio::test]
     async fn basic_gte() {
         test_relational_op(
-            &test_system(),
+            &test_system().await,
             AccessRelationalOp::Gte,
             AbstractPredicate::Gte,
             AbstractPredicate::Gte,
@@ -814,7 +816,7 @@ mod tests {
     #[tokio::test]
     async fn basic_and() {
         test_logical_op(
-            &test_system(),
+            &test_system().await,
             AccessLogicalExpression::And,
             AbstractPredicate::True,
             AbstractPredicate::False,
@@ -829,7 +831,7 @@ mod tests {
     #[tokio::test]
     async fn basic_or() {
         test_logical_op(
-            &test_system(),
+            &test_system().await,
             AccessLogicalExpression::Or,
             AbstractPredicate::True,
             AbstractPredicate::False,
@@ -843,7 +845,7 @@ mod tests {
 
     #[tokio::test]
     async fn basic_not() {
-        let test_system = test_system();
+        let test_system = test_system().await;
         let TestSystem {
             system,
             dept1_id_column_path: dept1_id_column_id,
@@ -919,7 +921,7 @@ mod tests {
             system,
             test_system_resolver,
             ..
-        } = test_system();
+        } = test_system().await;
 
         let test_ae = AccessPredicateExpression::RelationalOp(AccessRelationalOp::Eq(
             context_selection_expr("AccessContext", "role"),
@@ -941,7 +943,7 @@ mod tests {
     async fn context_and_dynamic() {
         // Scenario: AuthContext.role == "ROLE_ADMIN" || self.published
 
-        let test_system = test_system();
+        let test_system = test_system().await;
         let TestSystem {
             system,
             published_column_path,
@@ -983,7 +985,7 @@ mod tests {
     async fn context_compared_with_dynamic() {
         // Scenario: AuthContext.user_id == self.owner_id
 
-        let test_system = test_system();
+        let test_system = test_system().await;
         let TestSystem {
             system,
             owner_id_column_path,
@@ -1023,7 +1025,7 @@ mod tests {
     async fn varied_rule_for_roles() {
         // Scenario: AuthContext.role == "ROLE_ADMIN" || (AuthContext.role == "ROLE_USER" && self.published == true)
 
-        let test_system = test_system();
+        let test_system = test_system().await;
         let TestSystem {
             system,
             published_column_path,
@@ -1098,7 +1100,7 @@ mod tests {
 
     #[tokio::test]
     async fn top_level_boolean_literal() {
-        let test_system = test_system();
+        let test_system = test_system().await;
         let TestSystem {
             test_system_resolver,
             ..
@@ -1122,7 +1124,7 @@ mod tests {
     async fn top_level_boolean_column() {
         // Scenario: self.published
 
-        let test_system = test_system();
+        let test_system = test_system().await;
         let TestSystem {
             system,
             published_column_path: published_column_id,
@@ -1147,7 +1149,7 @@ mod tests {
     async fn top_level_boolean_context() {
         // Scenario: AuthContext.is_admin
 
-        let test_system = test_system();
+        let test_system = test_system().await;
         let TestSystem {
             system,
             test_system_resolver,

--- a/crates/postgres-subsystem/postgres-resolver/src/test_utils.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/test_utils.rs
@@ -17,11 +17,13 @@ use core_plugin_interface::{
 use postgres_model::subsystem::PostgresSubsystem;
 
 #[cfg(test)]
-pub(crate) fn create_postgres_system_from_str(
+pub(crate) async fn create_postgres_system_from_str(
     model_str: &str,
     file_name: String,
 ) -> Result<PostgresSubsystem, ModelSerializationError> {
-    let serialized_system = builder::build_system_from_str(model_str, file_name).unwrap();
+    let serialized_system = builder::build_system_from_str(model_str, file_name)
+        .await
+        .unwrap();
     let system = SerializableSystem::deserialize(serialized_system)?;
 
     deserialize_postgres_subsystem(system)

--- a/crates/server-aws-lambda/tests/common.rs
+++ b/crates/server-aws-lambda/tests/common.rs
@@ -23,7 +23,9 @@ pub async fn test_query(json_input: Value, exo_model: &str, expected: Value) {
         std::env::set_var("EXO_POSTGRES_URL", "postgres://a@dummy-value");
     }
 
-    let model_system = builder::build_system_from_str(exo_model, "index.exo".to_string()).unwrap();
+    let model_system = builder::build_system_from_str(exo_model, "index.exo".to_string())
+        .await
+        .unwrap();
     let system_resolver =
         Arc::new(create_system_resolver_from_serialized_bytes(model_system, vec![]).unwrap());
 

--- a/crates/subsystem-util/subsystem-model-builder-util/Cargo.toml
+++ b/crates/subsystem-util/subsystem-model-builder-util/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 serde.workspace = true
+tokio.workspace = true
 codemap-diagnostic.workspace = true
 codemap.workspace = true
 

--- a/crates/subsystem-util/subsystem-model-builder-util/src/builder/system_builder.rs
+++ b/crates/subsystem-util/subsystem-model-builder-util/src/builder/system_builder.rs
@@ -74,7 +74,7 @@ pub struct ModuleSubsystemWithInterceptors {
 ///                               annotation (e.g. `"deno"` for `@deno`).
 /// `process_script` - A closure that will process a script at the provided [`Path`] into a runnable form for usage
 ///                    during subsystem resolution at runtime.
-pub fn build_with_selection(
+pub async fn build_with_selection(
     typechecked_system: &TypecheckedSystem,
     base_system: &BaseModelSystem,
     module_selection_closure: impl Fn(&AstModule<Typed>) -> Option<String>,
@@ -90,7 +90,8 @@ pub fn build_with_selection(
         base_system,
         module_selection_closure,
         process_script,
-    )?;
+    )
+    .await?;
 
     let resolved_env = ResolvedTypeEnv {
         contexts: &base_system.contexts,

--- a/crates/wasm-subsystem/wasm-model-builder/src/plugin.rs
+++ b/crates/wasm-subsystem/wasm-model-builder/src/plugin.rs
@@ -50,7 +50,7 @@ impl SubsystemBuilder for WasmSubsystemBuilder {
         typechecked_system: &TypecheckedSystem,
         base_system: &BaseModelSystem,
     ) -> Result<Option<SubsystemBuild>, ModelBuildingError> {
-        let subsystem = crate::system_builder::build(typechecked_system, base_system)?;
+        let subsystem = crate::system_builder::build(typechecked_system, base_system).await?;
 
         let Some(ModelWasmSystemWithInterceptors {
             underlying: subsystem,

--- a/crates/wasm-subsystem/wasm-model-builder/src/plugin.rs
+++ b/crates/wasm-subsystem/wasm-model-builder/src/plugin.rs
@@ -11,6 +11,7 @@ use std::vec;
 
 use crate::system_builder::ModelWasmSystemWithInterceptors;
 use core_plugin_interface::{
+    async_trait::async_trait,
     core_model_builder::{
         builder::system_builder::BaseModelSystem,
         error::ModelBuildingError,
@@ -26,6 +27,7 @@ use core_plugin_interface::{
 };
 pub struct WasmSubsystemBuilder {}
 
+#[async_trait]
 impl SubsystemBuilder for WasmSubsystemBuilder {
     fn id(&self) -> &'static str {
         "wasm"
@@ -43,7 +45,7 @@ impl SubsystemBuilder for WasmSubsystemBuilder {
         )]
     }
 
-    fn build(
+    async fn build(
         &self,
         typechecked_system: &TypecheckedSystem,
         base_system: &BaseModelSystem,

--- a/crates/wasm-subsystem/wasm-model-builder/src/system_builder.rs
+++ b/crates/wasm-subsystem/wasm-model-builder/src/system_builder.rs
@@ -28,7 +28,7 @@ pub struct ModelWasmSystemWithInterceptors {
     pub interceptors: Vec<(AstExpr<Typed>, SerializableSlabIndex<Interceptor>)>,
 }
 
-pub fn build(
+pub async fn build(
     typechecked_system: &TypecheckedSystem,
     base_system: &BaseModelSystem,
 ) -> Result<Option<ModelWasmSystemWithInterceptors>, ModelBuildingError> {
@@ -40,7 +40,8 @@ pub fn build(
         base_system,
         module_selection_closure,
         process_script,
-    )?;
+    )
+    .await?;
 
     let underlying_module_system = module_system.underlying;
 


### PR DESCRIPTION
Earlier, several places created a tokio runtime and used `block_on`. This created issues such as creating runtime within runtime and executing functions without having a runtime. Specifically, `exo yolo` was broken due to runtime-in-runtime.

This PR makes the whole cli a `#[tokio::main]` process obviating the need to create more runtimes and free-ing ourselves from ensuring the execution of a task in a runtime context.

We still have `block_on` in `process_script` that creates a Deno bundle for the reasons mentioned in the comment.
