### PR TITLE
Bump Deno commit to one that doesn't include submodules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1742,7 +1742,7 @@ dependencies = [
 [[package]]
 name = "deno"
 version = "1.31.2"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "async-trait",
  "atty",
@@ -1924,7 +1924,7 @@ dependencies = [
 [[package]]
 name = "deno_broadcast_channel"
 version = "0.86.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1935,7 +1935,7 @@ dependencies = [
 [[package]]
 name = "deno_cache"
 version = "0.24.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1948,7 +1948,7 @@ dependencies = [
 [[package]]
 name = "deno_console"
 version = "0.92.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "deno_core",
 ]
@@ -1956,7 +1956,7 @@ dependencies = [
 [[package]]
 name = "deno_core"
 version = "0.174.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "deno_crypto"
 version = "0.106.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "aes 0.8.2",
  "aes-gcm",
@@ -2049,7 +2049,7 @@ dependencies = [
 [[package]]
 name = "deno_fetch"
 version = "0.116.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "bytes",
  "data-url",
@@ -2067,7 +2067,7 @@ dependencies = [
 [[package]]
 name = "deno_ffi"
 version = "0.79.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "deno_core",
  "dlopen",
@@ -2083,7 +2083,7 @@ dependencies = [
 [[package]]
 name = "deno_flash"
 version = "0.28.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "deno_core",
  "deno_tls",
@@ -2103,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "deno_fs"
 version = "0.2.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "deno_core",
  "deno_crypto",
@@ -2142,7 +2142,7 @@ dependencies = [
 [[package]]
 name = "deno_http"
 version = "0.87.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "async-compression",
  "base64 0.13.1",
@@ -2167,7 +2167,7 @@ dependencies = [
 [[package]]
 name = "deno_io"
 version = "0.2.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "deno_core",
  "nix 0.24.2",
@@ -2196,7 +2196,7 @@ dependencies = [
 [[package]]
 name = "deno_lockfile"
 version = "0.8.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "anyhow",
  "ring",
@@ -2207,7 +2207,7 @@ dependencies = [
 [[package]]
 name = "deno_napi"
 version = "0.22.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "deno_core",
  "libloading",
@@ -2216,7 +2216,7 @@ dependencies = [
 [[package]]
 name = "deno_net"
 version = "0.84.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "deno_core",
  "deno_tls",
@@ -2231,7 +2231,7 @@ dependencies = [
 [[package]]
 name = "deno_node"
 version = "0.29.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "deno_core",
  "digest 0.10.6",
@@ -2256,7 +2256,7 @@ dependencies = [
 [[package]]
 name = "deno_ops"
 version = "0.52.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "once_cell",
  "pmutil",
@@ -2270,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "deno_runtime"
 version = "0.100.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "atty",
  "console_static_text",
@@ -2340,7 +2340,7 @@ dependencies = [
 [[package]]
 name = "deno_tls"
 version = "0.79.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "deno_core",
  "once_cell",
@@ -2355,7 +2355,7 @@ dependencies = [
 [[package]]
 name = "deno_url"
 version = "0.92.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "deno_core",
  "serde",
@@ -2366,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "deno_web"
 version = "0.123.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -2381,7 +2381,7 @@ dependencies = [
 [[package]]
 name = "deno_webgpu"
 version = "0.93.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "deno_core",
  "serde",
@@ -2393,7 +2393,7 @@ dependencies = [
 [[package]]
 name = "deno_webidl"
 version = "0.92.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "deno_core",
 ]
@@ -2401,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "deno_websocket"
 version = "0.97.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "deno_core",
  "deno_tls",
@@ -2416,7 +2416,7 @@ dependencies = [
 [[package]]
 name = "deno_webstorage"
 version = "0.87.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "deno_core",
  "deno_web",
@@ -4509,7 +4509,7 @@ dependencies = [
 [[package]]
 name = "napi_sym"
 version = "0.22.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "proc-macro2 1.0.56",
  "quote 1.0.27",
@@ -6377,7 +6377,7 @@ dependencies = [
 [[package]]
 name = "serde_v8"
 version = "0.85.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched#aa212e2c0ba6be8cc3ccede2ba0523b12d70f34a"
+source = "git+https://github.com/exograph/deno.git?branch=patched#d621ba4ee8b8e9615f88365aec5e26f959e9ccae"
 dependencies = [
  "bytes",
  "derive_more",
@@ -8086,7 +8086,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand",
  "static_assertions",
 ]


### PR DESCRIPTION
Bump Deno commit to one that doesn't include submodules
Should help reduce disk space utilization
