### PR TITLE
Turn off running doctests

### DIFF
--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -33,3 +33,4 @@ insta.workspace = true
 serde_json.workspace = true
 
 [lib]
+doctest = false

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/exograph/exograph"
 [[bin]]
 name = "exo"
 path = "src/main.rs"
+doctest = false
 
 [dependencies]
 colored.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -7,7 +7,6 @@ repository = "https://github.com/exograph/exograph"
 [[bin]]
 name = "exo"
 path = "src/main.rs"
-doctest = false
 
 [dependencies]
 colored.workspace = true

--- a/crates/core-subsystem/core-model-builder/Cargo.toml
+++ b/crates/core-subsystem/core-model-builder/Cargo.toml
@@ -16,3 +16,4 @@ core-plugin-shared = { path = "../core-plugin-shared" }
 [dev-dependencies]
 
 [lib]
+doctest = false

--- a/crates/core-subsystem/core-model/Cargo.toml
+++ b/crates/core-subsystem/core-model/Cargo.toml
@@ -13,3 +13,4 @@ async-graphql-value.workspace = true
 [dev-dependencies]
 
 [lib]
+doctest = false

--- a/crates/core-subsystem/core-plugin-interface/Cargo.toml
+++ b/crates/core-subsystem/core-plugin-interface/Cargo.toml
@@ -22,3 +22,4 @@ core-plugin-shared = { path = "../core-plugin-shared" }
 [dev-dependencies]
 
 [lib]
+doctest = false

--- a/crates/core-subsystem/core-plugin-shared/Cargo.toml
+++ b/crates/core-subsystem/core-plugin-shared/Cargo.toml
@@ -13,3 +13,4 @@ bytes.workspace = true
 [dev-dependencies]
 
 [lib]
+doctest = false

--- a/crates/core-subsystem/core-resolver/Cargo.toml
+++ b/crates/core-subsystem/core-resolver/Cargo.toml
@@ -36,3 +36,4 @@ builder = { path = "../../builder", features = ["test-context"] }
 core-plugin-interface = { path = "../core-plugin-interface" }
 
 [lib]
+doctest = false

--- a/crates/deno-subsystem/deno-model-builder-dynamic/Cargo.toml
+++ b/crates/deno-subsystem/deno-model-builder-dynamic/Cargo.toml
@@ -12,3 +12,4 @@ deno-model-builder = { path = "../deno-model-builder" }
 
 [lib]
 crate-type = ["cdylib"]
+doctest = false

--- a/crates/deno-subsystem/deno-model-builder/Cargo.toml
+++ b/crates/deno-subsystem/deno-model-builder/Cargo.toml
@@ -26,3 +26,4 @@ deno_graph = "0.44.3"
 
 [lib]
 crate-type = ["lib"]
+doctest = false

--- a/crates/deno-subsystem/deno-model/Cargo.toml
+++ b/crates/deno-subsystem/deno-model/Cargo.toml
@@ -17,3 +17,4 @@ core-plugin-interface = { path = "../../core-subsystem/core-plugin-interface" }
 
 
 [lib]
+doctest = false

--- a/crates/deno-subsystem/deno-resolver-dynamic/Cargo.toml
+++ b/crates/deno-subsystem/deno-resolver-dynamic/Cargo.toml
@@ -12,3 +12,4 @@ deno-resolver = { path = "../deno-resolver" }
 
 [lib]
 crate-type = ["cdylib"]
+doctest = false

--- a/crates/deno-subsystem/deno-resolver/Cargo.toml
+++ b/crates/deno-subsystem/deno-resolver/Cargo.toml
@@ -33,3 +33,4 @@ builder = { path = "../../builder" }
 
 [lib]
 crate-type = ["lib"]
+doctest = false

--- a/crates/introspection-subsystem/introspection-resolver/Cargo.toml
+++ b/crates/introspection-subsystem/introspection-resolver/Cargo.toml
@@ -21,3 +21,4 @@ core-plugin-shared = { path = "../../core-subsystem/core-plugin-shared" }
 [dev-dependencies]
 
 [lib]
+doctest = false

--- a/crates/postgres-subsystem/postgres-model-builder-dynamic/Cargo.toml
+++ b/crates/postgres-subsystem/postgres-model-builder-dynamic/Cargo.toml
@@ -12,3 +12,4 @@ postgres-model-builder = { path = "../postgres-model-builder" }
 
 [lib]
 crate-type = ["cdylib"]
+doctest = false

--- a/crates/postgres-subsystem/postgres-model-builder/Cargo.toml
+++ b/crates/postgres-subsystem/postgres-model-builder/Cargo.toml
@@ -25,3 +25,4 @@ builder = { path = "../../builder" }
 
 [lib]
 crate-type = ["lib"]
+doctest = false

--- a/crates/postgres-subsystem/postgres-model/Cargo.toml
+++ b/crates/postgres-subsystem/postgres-model/Cargo.toml
@@ -18,3 +18,4 @@ core-plugin-interface = { path = "../../core-subsystem/core-plugin-interface" }
 
 
 [lib]
+doctest = false

--- a/crates/postgres-subsystem/postgres-resolver-dynamic/Cargo.toml
+++ b/crates/postgres-subsystem/postgres-resolver-dynamic/Cargo.toml
@@ -12,3 +12,4 @@ postgres-resolver = { path = "../postgres-resolver" }
 
 [lib]
 crate-type = ["cdylib"]
+doctest = false

--- a/crates/postgres-subsystem/postgres-resolver/Cargo.toml
+++ b/crates/postgres-subsystem/postgres-resolver/Cargo.toml
@@ -37,3 +37,4 @@ resolver = { path = "../../resolver" }
 
 [lib]
 crate-type = ["lib"]
+doctest = false

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -32,3 +32,6 @@ builder = { path = "../builder" }
 
 [build-dependencies]
 which = "4.4.0"
+
+[lib]
+doctest = false

--- a/crates/server-actix/Cargo.toml
+++ b/crates/server-actix/Cargo.toml
@@ -37,4 +37,3 @@ default = [
 [[bin]]
 name = "exo-server"
 path = "src/main.rs"
-doctest = false

--- a/crates/server-actix/Cargo.toml
+++ b/crates/server-actix/Cargo.toml
@@ -28,8 +28,13 @@ openssl = { version = "0.10.50", features = ["vendored"] }
 static-postgres-resolver = ["server-common/static-postgres-resolver"]
 static-deno-resolver = ["server-common/static-deno-resolver"]
 static-wasm-resolver = ["server-common/static-wasm-resolver"]
-default = ["static-postgres-resolver", "static-deno-resolver", "static-wasm-resolver"]
+default = [
+  "static-postgres-resolver",
+  "static-deno-resolver",
+  "static-wasm-resolver",
+]
 
 [[bin]]
 name = "exo-server"
 path = "src/main.rs"
+doctest = false

--- a/crates/server-aws-lambda/Cargo.toml
+++ b/crates/server-aws-lambda/Cargo.toml
@@ -38,4 +38,3 @@ default = [
 [[bin]]
 name = "bootstrap"
 path = "src/main.rs"
-doctest = false

--- a/crates/server-aws-lambda/Cargo.toml
+++ b/crates/server-aws-lambda/Cargo.toml
@@ -8,7 +8,9 @@ repository = "https://github.com/exograph/exograph"
 async-trait.workspace = true
 lambda_runtime = "0.6.1"
 futures.workspace = true
-opentelemetry = { version = "0.17", default-features = false, features = ["trace"] }
+opentelemetry = { version = "0.17", default-features = false, features = [
+  "trace",
+] }
 opentelemetry-jaeger = "0.16"
 serde_json = { workspace = true, features = ["preserve_order"] }
 tokio = { workspace = true, features = ["full"] }
@@ -27,8 +29,13 @@ builder = { path = "../builder" }
 static-postgres-resolver = ["server-common/static-postgres-resolver"]
 static-deno-resolver = ["server-common/static-deno-resolver"]
 static-wasm-resolver = ["server-common/static-wasm-resolver"]
-default = ["static-postgres-resolver", "static-deno-resolver", "static-wasm-resolver"]
+default = [
+  "static-postgres-resolver",
+  "static-deno-resolver",
+  "static-wasm-resolver",
+]
 
 [[bin]]
 name = "bootstrap"
 path = "src/main.rs"
+doctest = false

--- a/crates/server-common/Cargo.toml
+++ b/crates/server-common/Cargo.toml
@@ -8,10 +8,18 @@ publish = false
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 tracing-opentelemetry = "=0.18"
-opentelemetry = { version = "=0.18", default-features = false, features = [ "trace", "rt-tokio" ]}
-opentelemetry-otlp = { version = "=0.11", features = ["reqwest-client", "reqwest-rustls", "http-proto", "tls"]}
+opentelemetry = { version = "=0.18", default-features = false, features = [
+  "trace",
+  "rt-tokio",
+] }
+opentelemetry-otlp = { version = "=0.11", features = [
+  "reqwest-client",
+  "reqwest-rustls",
+  "http-proto",
+  "tls",
+] }
 # Tonic isn't used directly but we need these flags to establish a TLS connection
-tonic = { version = "0.8", features = ["tls", "tls-roots"]}
+tonic = { version = "0.8", features = ["tls", "tls-roots"] }
 
 resolver = { path = "../resolver" }
 core-resolver = { path = "../core-subsystem/core-resolver" }
@@ -26,3 +34,4 @@ static-deno-resolver = ["deno-resolver"]
 static-wasm-resolver = ["wasm-resolver"]
 
 [lib]
+doctest = false

--- a/crates/subsystem-util/subsystem-model-builder-util/Cargo.toml
+++ b/crates/subsystem-util/subsystem-model-builder-util/Cargo.toml
@@ -19,3 +19,4 @@ subsystem-model-util = { path = "../subsystem-model-util" }
 builder = { path = "../../builder" }
 
 [lib]
+doctest = false

--- a/crates/subsystem-util/subsystem-model-util/Cargo.toml
+++ b/crates/subsystem-util/subsystem-model-util/Cargo.toml
@@ -16,3 +16,4 @@ core-plugin-shared = { path = "../../core-subsystem/core-plugin-shared" }
 
 
 [lib]
+doctest = false

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -4,13 +4,15 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-[lib]
-
 [features]
 static-postgres-resolver = ["server-common/static-postgres-resolver"]
 static-deno-resolver = ["server-common/static-deno-resolver"]
 static-wasm-resolver = ["server-common/static-wasm-resolver"]
-default = ["static-postgres-resolver", "static-deno-resolver", "static-wasm-resolver"]
+default = [
+  "static-postgres-resolver",
+  "static-deno-resolver",
+  "static-wasm-resolver",
+]
 
 [dependencies]
 anyhow.workspace = true
@@ -48,3 +50,6 @@ insta = { workspace = true, features = ["yaml"] }
 
 [build-dependencies]
 which = "4.4.0"
+
+[lib]
+doctest = false

--- a/crates/wasm-subsystem/wasm-model-builder-dynamic/Cargo.toml
+++ b/crates/wasm-subsystem/wasm-model-builder-dynamic/Cargo.toml
@@ -12,3 +12,4 @@ wasm-model-builder = { path = "../wasm-model-builder" }
 
 [lib]
 crate-type = ["cdylib"]
+doctest = false

--- a/crates/wasm-subsystem/wasm-model-builder/Cargo.toml
+++ b/crates/wasm-subsystem/wasm-model-builder/Cargo.toml
@@ -14,3 +14,4 @@ subsystem-model-builder-util = { path = "../../subsystem-util/subsystem-model-bu
 
 [lib]
 crate-type = ["lib"]
+doctest = false

--- a/crates/wasm-subsystem/wasm-model/Cargo.toml
+++ b/crates/wasm-subsystem/wasm-model/Cargo.toml
@@ -16,3 +16,4 @@ core-plugin-interface = { path = "../../core-subsystem/core-plugin-interface" }
 
 
 [lib]
+doctest = false

--- a/crates/wasm-subsystem/wasm-resolver-dynamic/Cargo.toml
+++ b/crates/wasm-subsystem/wasm-resolver-dynamic/Cargo.toml
@@ -12,3 +12,4 @@ wasm-resolver = { path = "../wasm-resolver" }
 
 [lib]
 crate-type = ["cdylib"]
+doctest = false

--- a/crates/wasm-subsystem/wasm-resolver/Cargo.toml
+++ b/crates/wasm-subsystem/wasm-resolver/Cargo.toml
@@ -24,3 +24,4 @@ wasm-model = { path = "../wasm-model" }
 
 [lib]
 crate-type = ["lib"]
+doctest = false

--- a/libs/exo-deno/Cargo.toml
+++ b/libs/exo-deno/Cargo.toml
@@ -21,6 +21,7 @@ tracing.workspace = true
 include_dir.workspace = true
 
 [lib]
+doctest = false
 
 [features]
 default = []

--- a/libs/exo-sql/Cargo.toml
+++ b/libs/exo-sql/Cargo.toml
@@ -37,3 +37,4 @@ urlencoding = "2.1.2"
 serde_json.workspace = true
 
 [lib]
+doctest = false

--- a/libs/exo-wasm/Cargo.toml
+++ b/libs/exo-wasm/Cargo.toml
@@ -16,3 +16,4 @@ serde_json.workspace = true
 tracing.workspace = true
 
 [lib]
+doctest = false


### PR DESCRIPTION
Currently, none of our code has doctests, so to avoid noise in output while running `cargo test`, we set `doctest = false` in all Cargo.toml.