### PR TITLE
Build server-aws-lambda only on Linux platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6427,7 +6427,6 @@ dependencies = [
  "core-resolver",
  "futures",
  "lambda_runtime",
- "openssl",
  "opentelemetry 0.17.0",
  "opentelemetry-jaeger",
  "resolver",

--- a/crates/server-aws-lambda/Cargo.toml
+++ b/crates/server-aws-lambda/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.1.0"
 edition = "2021"
 repository = "https://github.com/exograph/exograph"
 
-[target.'cfg(linux)'.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 async-trait.workspace = true
 lambda_runtime = "0.6.1"
 futures.workspace = true
@@ -26,7 +26,7 @@ resolver = { path = "../resolver" }
 core-resolver = { path = "../core-subsystem/core-resolver" }
 server-common = { path = "../server-common" }
 
-[target.'cfg(linux)'.dev-dependencies]
+[target.'cfg(target_os = "linux")'.dev-dependencies]
 builder = { path = "../builder" }
 
 [features]

--- a/crates/server-aws-lambda/Cargo.toml
+++ b/crates/server-aws-lambda/Cargo.toml
@@ -1,14 +1,23 @@
+# This crate is intended to be built only on Linux platforms.
+#
+# Once https://github.com/rust-lang/cargo/issues/5220 is resolved,
+# we will be able to include this crate in the workspace only for the linux target.
+# Until then, we need to scope dependencies to the linux target as well as mark
+# each source file as `#![cfg(target_os = "linux")]`.
+
 [package]
 name = "server-aws-lambda"
 version = "0.1.0"
 edition = "2021"
 repository = "https://github.com/exograph/exograph"
 
-[dependencies]
+[target.'cfg(linux)'.dependencies]
 async-trait.workspace = true
 lambda_runtime = "0.6.1"
 futures.workspace = true
-opentelemetry = { version = "0.17", default-features = false, features = ["trace"] }
+opentelemetry = { version = "0.17", default-features = false, features = [
+  "trace",
+] }
 opentelemetry-jaeger = "0.16"
 serde_json = { workspace = true, features = ["preserve_order"] }
 tokio = { workspace = true, features = ["full"] }
@@ -17,17 +26,18 @@ resolver = { path = "../resolver" }
 core-resolver = { path = "../core-subsystem/core-resolver" }
 server-common = { path = "../server-common" }
 
-[target.'cfg(target_os = "windows")'.dependencies]
-openssl = { version = "0.10.50", features = ["vendored"] }
-
-[dev-dependencies]
+[target.'cfg(linux)'.dev-dependencies]
 builder = { path = "../builder" }
 
 [features]
 static-postgres-resolver = ["server-common/static-postgres-resolver"]
 static-deno-resolver = ["server-common/static-deno-resolver"]
 static-wasm-resolver = ["server-common/static-wasm-resolver"]
-default = ["static-postgres-resolver", "static-deno-resolver", "static-wasm-resolver"]
+default = [
+  "static-postgres-resolver",
+  "static-deno-resolver",
+  "static-wasm-resolver",
+]
 
 [[bin]]
 name = "bootstrap"

--- a/crates/server-aws-lambda/src/lib.rs
+++ b/crates/server-aws-lambda/src/lib.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#![cfg(target_os = "linux")]
+
 mod request;
 
 use core_resolver::{

--- a/crates/server-aws-lambda/src/main.rs
+++ b/crates/server-aws-lambda/src/main.rs
@@ -7,17 +7,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use lambda_runtime::Error;
-use lambda_runtime::LambdaEvent;
-
-use serde_json::Value;
-use server_aws_lambda::resolve;
-
-use std::sync::Arc;
-
 /// Run the server in production mode with a compiled exo_ir file
+#[cfg(target_os = "linux")]
 #[tokio::main]
 async fn main() -> Result<(), Error> {
+    use lambda_runtime::Error;
+    use lambda_runtime::LambdaEvent;
+
+    use serde_json::Value;
+    use server_aws_lambda::resolve;
+
+    use std::sync::Arc;
+
     let system_resolver = Arc::new(server_common::init());
 
     let module = lambda_runtime::service_fn(|event: LambdaEvent<Value>| async {
@@ -27,4 +28,9 @@ async fn main() -> Result<(), Error> {
     lambda_runtime::run(module).await?;
 
     Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    panic!("This binary is only intended to run on Linux.")
 }

--- a/crates/server-aws-lambda/src/main.rs
+++ b/crates/server-aws-lambda/src/main.rs
@@ -9,9 +9,11 @@
 
 /// Run the server in production mode with a compiled exo_ir file
 #[cfg(target_os = "linux")]
+use lambda_runtime::Error;
+
+#[cfg(target_os = "linux")]
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    use lambda_runtime::Error;
     use lambda_runtime::LambdaEvent;
 
     use serde_json::Value;

--- a/crates/server-aws-lambda/src/request.rs
+++ b/crates/server-aws-lambda/src/request.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#![cfg(target_os = "linux")]
+
 use core_resolver::context::Request;
 use lambda_runtime::LambdaEvent;
 use serde_json::Value;

--- a/crates/server-aws-lambda/tests/basic_query.rs
+++ b/crates/server-aws-lambda/tests/basic_query.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#![cfg(target_os = "linux")]
+
 use serde_json::json;
 
 mod common;

--- a/crates/server-aws-lambda/tests/common.rs
+++ b/crates/server-aws-lambda/tests/common.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#![cfg(target_os = "linux")]
+
 use std::sync::Arc;
 
 use resolver::create_system_resolver_from_serialized_bytes;


### PR DESCRIPTION
Since, we don't need to build the server-aws-lambda crate on Mac/Windows platforms, to save build times (for Mac platforms) and to avoid build/test issues (for Windows platforms), we build the server-aws-lambda crate only on Linux platforms.

Ideally, we could have included the server-aws-lambda crate in the workspace only on Linux platforms, but until https://github.com/rust-lang/cargo/issues/5220 is fixed, we can't do that.