### PR TITLE
Make SubsystemLoader async and add DB startup checks

### DIFF
--- a/crates/cli/src/commands/schema/import.rs
+++ b/crates/cli/src/commands/schema/import.rs
@@ -61,7 +61,7 @@ impl CommandDefinition for ImportCommandDefinition {
 }
 
 async fn import_schema() -> Result<WithIssues<DatabaseSpec>> {
-    let database_client = DatabaseClient::from_env(Some(1))?; // TODO: error handling here
+    let database_client = DatabaseClient::from_env(Some(1)).await?; // TODO: error handling here
     let client = database_client.get_client().await?;
     let database = DatabaseSpec::from_live_database(&client).await?;
     Ok(database)

--- a/crates/cli/src/commands/schema/migration.rs
+++ b/crates/cli/src/commands/schema/migration.rs
@@ -125,7 +125,7 @@ impl Migration {
         db_url: Option<&str>,
         allow_destructive_changes: bool,
     ) -> Result<(), anyhow::Error> {
-        let database = open_database(db_url)?;
+        let database = open_database(db_url).await?;
         let mut client = database.get_client().await?;
         let transaction = client.transaction().await?;
         for MigrationStatement {
@@ -176,7 +176,7 @@ impl MigrationStatement {
 async fn extract_db_schema(
     db_url: Option<&str>,
 ) -> Result<WithIssues<DatabaseSpec>, DatabaseError> {
-    let database = open_database(db_url)?;
+    let database = open_database(db_url).await?;
     let client = database.get_client().await?;
 
     DatabaseSpec::from_live_database(&client).await
@@ -189,7 +189,7 @@ async fn extract_model_schema(model_path: &PathBuf) -> Result<DatabaseSpec, Pars
 }
 
 pub async fn wipe_database(db_url: Option<&str>) -> Result<(), DatabaseError> {
-    let database = open_database(db_url)?;
+    let database = open_database(db_url).await?;
     let client = database.get_client().await?;
     client
         .execute("DROP SCHEMA public CASCADE", &[])
@@ -203,11 +203,11 @@ pub async fn wipe_database(db_url: Option<&str>) -> Result<(), DatabaseError> {
     Ok(())
 }
 
-pub fn open_database(database: Option<&str>) -> Result<DatabaseClient, DatabaseError> {
+pub async fn open_database(database: Option<&str>) -> Result<DatabaseClient, DatabaseError> {
     if let Some(database) = database {
-        Ok(DatabaseClient::from_db_url(database)?)
+        Ok(DatabaseClient::from_db_url(database).await?)
     } else {
-        Ok(DatabaseClient::from_env(Some(1))?)
+        Ok(DatabaseClient::from_env(Some(1)).await?)
     }
 }
 
@@ -693,8 +693,8 @@ mod tests {
                 module RsvpModule {
                     type Rsvp {
                         @pk id: Int = autoIncrement()
-                        @unique("email_event_id") email: String 
-                        @unique("email_event_id") event_id: Int 
+                        @unique("email_event_id") email: String
+                        @unique("email_event_id") event_id: Int
                     }
                 }
             "#,
@@ -745,7 +745,7 @@ mod tests {
                 module RsvpModule {
                     type Rsvp {
                         @pk id: Int = autoIncrement()
-                        @unique("email_event_id") email: String 
+                        @unique("email_event_id") email: String
                         event_id: Int
                     }
                 }
@@ -755,8 +755,8 @@ mod tests {
                 module RsvpModule {
                     type Rsvp {
                         @pk id: Int = autoIncrement()
-                        @unique("email_event_id") email: String 
-                        @unique("email_event_id") event_id: Int 
+                        @unique("email_event_id") email: String
+                        @unique("email_event_id") event_id: Int
                     }
                 }
             "#,
@@ -921,7 +921,7 @@ mod tests {
                         level: String
                         message: String
                     }
-                } 
+                }
             "#,
             vec![
                 (

--- a/crates/core-subsystem/core-plugin-interface/src/interface.rs
+++ b/crates/core-subsystem/core-plugin-interface/src/interface.rs
@@ -84,13 +84,14 @@ pub trait SubsystemBuilder {
     ) -> Result<Option<SubsystemBuild>, ModelBuildingError>;
 }
 
+#[async_trait]
 pub trait SubsystemLoader {
     /// Unique string to identify the subsystem by. Should be shared with the corresponding
     /// [SubsystemBuilder].
     fn id(&self) -> &'static str;
 
     /// Loads and initializes the subsystem, producing a [SubsystemResolver].
-    fn init(
+    async fn init(
         &self,
         serialized_subsystem: Vec<u8>,
     ) -> Result<Box<dyn SubsystemResolver + Send + Sync>, SubsystemLoadingError>;
@@ -172,7 +173,7 @@ pub fn load_subsystem_builder(
 /// Loads a subsystem loader from a dynamic library.
 pub fn load_subsystem_loader(
     library_name: &str,
-) -> Result<Box<dyn SubsystemLoader>, LibraryLoadingError> {
+) -> Result<Box<dyn SubsystemLoader + Send + Sync>, LibraryLoadingError> {
     // search executable directory for library
     // TODO: we should try to load from sources LD_LIBRARY_PATH first
     let mut library_path = current_exe()?;

--- a/crates/core-subsystem/core-resolver/Cargo.toml
+++ b/crates/core-subsystem/core-resolver/Cargo.toml
@@ -20,7 +20,7 @@ jsonwebtoken.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 cookie = "0.16"
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt", "macros"] }
 elsa = "1.8.1"
 
 tracing.workspace = true

--- a/crates/core-subsystem/core-resolver/src/validation/document_validator.rs
+++ b/crates/core-subsystem/core-resolver/src/validation/document_validator.rs
@@ -747,6 +747,10 @@ mod tests {
             "postgres://postgres:postgres@localhost:5432/exo_test",
         );
 
-        loader.init(subsystem).unwrap()
+        env::set_var("EXO_CHECK_CONNECTION_ON_STARTUP", "false");
+        loader
+            .init(subsystem)
+            .await
+            .expect("Failed to initialize postgres subsystem")
     }
 }

--- a/crates/deno-subsystem/deno-resolver/src/plugin.rs
+++ b/crates/deno-subsystem/deno-resolver/src/plugin.rs
@@ -43,12 +43,13 @@ pub type ExoDenoExecutorPool = DenoExecutorPool<
 
 pub struct DenoSubsystemLoader {}
 
+#[async_trait]
 impl SubsystemLoader for DenoSubsystemLoader {
     fn id(&self) -> &'static str {
         "deno"
     }
 
-    fn init<'a>(
+    async fn init(
         &self,
         serialized_subsystem: Vec<u8>,
     ) -> Result<Box<dyn SubsystemResolver + Send + Sync>, SubsystemLoadingError> {

--- a/crates/postgres-subsystem/postgres-resolver/src/plugin/subsystem_loader.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/plugin/subsystem_loader.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use super::PostgresSubsystemResolver;
+use async_trait::async_trait;
 use core_plugin_interface::{
     core_resolver::plugin::SubsystemResolver,
     interface::{SubsystemLoader, SubsystemLoadingError},
@@ -18,18 +19,20 @@ use postgres_model::subsystem::PostgresSubsystem;
 
 pub struct PostgresSubsystemLoader {}
 
+#[async_trait]
 impl SubsystemLoader for PostgresSubsystemLoader {
     fn id(&self) -> &'static str {
         "postgres"
     }
 
-    fn init<'a>(
+    async fn init(
         &self,
         serialized_subsystem: Vec<u8>,
     ) -> Result<Box<dyn SubsystemResolver + Send + Sync>, SubsystemLoadingError> {
         let subsystem = PostgresSubsystem::deserialize(serialized_subsystem)?;
 
         let database_client = DatabaseClient::from_env(None)
+            .await
             .map_err(|e| SubsystemLoadingError::BoxedError(Box::new(e)))?;
         let executor = DatabaseExecutor { database_client };
 

--- a/crates/server-actix/src/main.rs
+++ b/crates/server-actix/src/main.rs
@@ -26,7 +26,7 @@ use std::{env, process::exit};
 async fn main() -> std::io::Result<()> {
     let start_time = time::SystemTime::now();
 
-    let system_resolver = web::Data::new(server_common::init());
+    let system_resolver = web::Data::new(server_common::init().await);
 
     let server_port = env::var("EXO_SERVER_PORT")
         .map(|port_str| {

--- a/crates/server-aws-lambda/src/main.rs
+++ b/crates/server-aws-lambda/src/main.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Error> {
 
     use std::sync::Arc;
 
-    let system_resolver = Arc::new(server_common::init());
+    let system_resolver = Arc::new(server_common::init().await);
 
     let module = lambda_runtime::service_fn(|event: LambdaEvent<Value>| async {
         resolve(event, system_resolver.clone()).await

--- a/crates/server-aws-lambda/tests/common.rs
+++ b/crates/server-aws-lambda/tests/common.rs
@@ -28,8 +28,11 @@ pub async fn test_query(json_input: Value, exo_model: &str, expected: Value) {
     let model_system = builder::build_system_from_str(exo_model, "index.exo".to_string())
         .await
         .unwrap();
-    let system_resolver =
-        Arc::new(create_system_resolver_from_serialized_bytes(model_system, vec![]).unwrap());
+    let system_resolver = Arc::new(
+        create_system_resolver_from_serialized_bytes(model_system, vec![])
+            .await
+            .unwrap(),
+    );
 
     let result = resolve(event, system_resolver).await.unwrap();
 

--- a/crates/server-common/src/lib.rs
+++ b/crates/server-common/src/lib.rs
@@ -26,12 +26,12 @@ mod logging_tracing;
 ///
 /// # Exit codes
 /// - 1 - If the exo_ir file doesn't exist or can't be loaded.
-pub fn init() -> SystemResolver {
+pub async fn init() -> SystemResolver {
     logging_tracing::init();
 
     let exo_ir_file = get_exo_ir_file_name();
 
-    create_system_resolver_or_exit(&exo_ir_file, create_static_loaders())
+    create_system_resolver_or_exit(&exo_ir_file, create_static_loaders()).await
 }
 
 pub fn create_static_loaders() -> Vec<Box<dyn SubsystemLoader>> {

--- a/crates/testing/src/exotest/integration_tests.rs
+++ b/crates/testing/src/exotest/integration_tests.rs
@@ -100,36 +100,35 @@ pub(crate) async fn run_testfile(
         let server = {
             let static_loaders = server_common::create_static_loaders();
 
-            let exo_ir_file = testfile.exo_ir_file_path(project_dir);
-            LOCAL_URL.with(|url| {
-                // set a common timezone for tests for consistency "-c TimeZone=UTC+00"
-                url.borrow_mut().replace(format!(
-                    "{}?options=-c%20TimeZone%3DUTC%2B00",
-                    db_instance.url()
-                ));
+            let exo_ir_file = testfile.exo_ir_file_path(project_dir).display().to_string();
+            LOCAL_URL
+                .with(|url| {
+                    // set a common timezone for tests for consistency "-c TimeZone=UTC+00"
+                    url.borrow_mut().replace(format!(
+                        "{}?options=-c%20TimeZone%3DUTC%2B00",
+                        db_instance.url()
+                    ));
 
-                LOCAL_CONNECTION_POOL_SIZE.with(|pool_size| {
-                    // Otherwise we get a "too many connections" error
-                    pool_size.borrow_mut().replace(1);
+                    LOCAL_CONNECTION_POOL_SIZE.with(|pool_size| {
+                        // Otherwise we get a "too many connections" error
+                        pool_size.borrow_mut().replace(1);
 
-                    LOCAL_JWT_SECRET.with(|jwt| {
-                        jwt.borrow_mut().replace(jwtsecret.clone());
+                        LOCAL_JWT_SECRET.with(|jwt| {
+                            jwt.borrow_mut().replace(jwtsecret.clone());
 
-                        LOCAL_ALLOW_INTROSPECTION.with(|allow| {
-                            allow.borrow_mut().replace(true);
+                            LOCAL_ALLOW_INTROSPECTION.with(|allow| {
+                                allow.borrow_mut().replace(true);
 
-                            LOCAL_ENVIRONMENT.with(|env| {
-                                env.borrow_mut().replace(extra_envs.clone());
+                                LOCAL_ENVIRONMENT.with(|env| {
+                                    env.borrow_mut().replace(extra_envs.clone());
 
-                                create_system_resolver(
-                                    &exo_ir_file.display().to_string(),
-                                    static_loaders,
-                                )
+                                    create_system_resolver(&exo_ir_file, static_loaders)
+                                })
                             })
                         })
                     })
                 })
-            })?
+                .await?
         };
 
         TestfileContext {

--- a/crates/wasm-subsystem/wasm-resolver/src/plugin.rs
+++ b/crates/wasm-subsystem/wasm-resolver/src/plugin.rs
@@ -28,12 +28,13 @@ use wasm_model::{module::ModuleMethod, subsystem::WasmSubsystem};
 
 pub struct WasmSubsystemLoader {}
 
+#[async_trait]
 impl SubsystemLoader for WasmSubsystemLoader {
     fn id(&self) -> &'static str {
         "wasm"
     }
 
-    fn init<'a>(
+    async fn init(
         &self,
         serialized_subsystem: Vec<u8>,
     ) -> Result<Box<dyn SubsystemResolver + Send + Sync>, SubsystemLoadingError> {

--- a/libs/exo-sql/src/lib.rs
+++ b/libs/exo-sql/src/lib.rs
@@ -62,7 +62,9 @@ pub use sql::{
     column::Column,
     database::Database,
     database::TableId,
-    database_client::{DatabaseClient, LOCAL_CONNECTION_POOL_SIZE, LOCAL_URL},
+    database_client::{
+        DatabaseClient, LOCAL_CHECK_CONNECTION_ON_STARTUP, LOCAL_CONNECTION_POOL_SIZE, LOCAL_URL,
+    },
     limit::Limit,
     offset::Offset,
     order::Ordering,


### PR DESCRIPTION
This reinstates the DB connection check which was removed when switching to an async connection pool (see #328).

In order to call get_client() in DatabaseClient to check the connection, the initialization functions have to be async. The client is setup when loading the Postgres subsystem, hence the loader also has to be async.

Some of the tests (such as the introspection tests) initialize the Postgres subsystem without connecting to a real database, so it's necessary to override the default in these cases, making sure the check isn't performed.