### PR TITLE
Fix the instruction to add to .bashrc/.zshrc

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -51,7 +51,7 @@ else
 	*) shell_profile=".bashrc" ;;
 	esac
 	echo "Manually add the directory to your \$HOME/$shell_profile (or similar)"
-	echo "  export PATH=\"$EXOGRAPH_INSTALL/bin:\$PATH\""
+	echo "  export PATH=\"$bin_dir:\$PATH\""
 	echo "Run '$exe --help' to get started"
 fi
 echo


### PR DESCRIPTION
Was printing:
```
Manually add the directory to your $HOME/.zshrc (or similar)
  export PATH="/bin:$PATH"
```

Fixes to print the correct path.