### PR TITLE
Replace openssl with rustls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,25 +22,21 @@ jobs:
             deps-script: brew install protobuf
             target: x86_64-apple-darwin
             cross_flag: ""
-            vendor_openssl_flag: "--features vendored-openssl"
             bin_extension: ""
           - os: macos-11
             deps-script: brew install protobuf
             target: aarch64-apple-darwin
             cross_flag: "--features cross"
-            vendor_openssl_flag: "--features vendored-openssl"
             bin_extension: ""
           - os: ubuntu-20.04
             deps-script: sudo apt-get install -y protobuf-compiler
             target: x86_64-unknown-linux-gnu
             cross_flag: ""
-            vendor_openssl_flag: "--features vendored-openssl"
             bin_extension: ""
           - os: windows-2019
             deps-script: choco install protoc
             target: x86_64-pc-windows-msvc
             cross_flag: ""
-            vendor_openssl_flag: "--features vendored-openssl"
             bin_extension: ".exe"
 
     runs-on: ${{ matrix.os }}
@@ -59,7 +55,7 @@ jobs:
           key: ${{ matrix.target }}
       - name: Build
         run: |
-          cargo build -p cli -p server-actix --target ${{ matrix.target }} --release ${{ matrix.cross_flag }} ${{ matrix.vendor_openssl_flag }}
+          cargo build -p cli -p server-actix --target ${{ matrix.target }} --release ${{ matrix.cross_flag }} 
           mkdir -p dist
           cp target/${{matrix.target}}/release/exo${{matrix.bin_extension}} dist/
           cp target/${{matrix.target}}/release/exo-server${{matrix.bin_extension}} dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,22 +55,18 @@ jobs:
           deps-script: sudo apt-get install -y protobuf-compiler
           target: x86_64-unknown-linux-gnu
           cross_flag: ""
-          vendor_openssl_flag: ""
         - os: macos-11
           deps-script: brew install protobuf
           target: x86_64-apple-darwin
           cross_flag: ""
-          vendor_openssl_flag: ""
         - os: macos-11
           deps-script: brew install protobuf
           target: aarch64-apple-darwin
           cross_flag: "--features cross"
-          vendor_openssl_flag: "--features vendored-openssl"
         - os: windows-2019
           deps-script: choco install protoc
           target: x86_64-pc-windows-msvc
           cross_flag: ""
-          vendor_openssl_flag: "--features vendored-openssl"
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -96,12 +92,12 @@ jobs:
           key: ${{ matrix.target }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build
-        run: cargo build --target ${{ matrix.target }} ${{ matrix.cross_flag }} ${{ matrix.vendor_openssl_flag }}
+        run: cargo build --target ${{ matrix.target }} ${{ matrix.cross_flag }} 
       - name: Run tests
         if: ${{ matrix.cross_flag == '' }}
         env:
           RUST_BACKTRACE: 1
-        run: cargo test --workspace --target ${{ matrix.target }} ${{ matrix.cross_flag }} ${{ matrix.vendor_openssl_flag }}
+        run: cargo test --workspace --target ${{ matrix.target }} ${{ matrix.cross_flag }} 
       - name: Run integration tests
         if: ${{ matrix.cross_flag == '' }}
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,7 +1122,6 @@ dependencies = [
  "inquire",
  "lazy_static",
  "notify-debouncer-mini",
- "openssl",
  "postgres-model",
  "postgres-model-builder",
  "rand",
@@ -2036,7 +2035,7 @@ dependencies = [
  "libc",
  "log",
  "mio",
- "rustls",
+ "rustls 0.20.8",
  "rustls-pemfile",
  "serde",
  "socket2",
@@ -2255,12 +2254,12 @@ source = "git+https://github.com/exograph/deno.git?branch=patched#61c8ed12473250
 dependencies = [
  "deno_core",
  "once_cell",
- "rustls",
+ "rustls 0.20.8",
  "rustls-native-certs",
  "rustls-pemfile",
  "serde",
- "webpki",
- "webpki-roots",
+ "webpki 0.22.0",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -2320,7 +2319,7 @@ dependencies = [
  "hyper",
  "serde",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-tungstenite",
 ]
 
@@ -2698,17 +2697,19 @@ dependencies = [
  "lazy_static",
  "maybe-owned",
  "once_cell",
- "openssl",
- "postgres-openssl",
  "postgres_array",
  "rand",
  "regex",
+ "rustls 0.21.1",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror",
  "tokio",
  "tokio-postgres",
+ "tokio-postgres-rustls",
  "tracing",
  "typed-generational-arena",
  "url",
@@ -3335,8 +3336,10 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5825a38a94c3aff23ea7f60572726829ef055ca02fc64899c3e2e7db2ce4f03f"
 dependencies = [
- "native-tls",
+ "rustls 0.19.1",
  "unicase",
+ "webpki 0.21.4",
+ "webpki-roots 0.21.1",
 ]
 
 [[package]]
@@ -3389,9 +3392,9 @@ checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
- "rustls",
+ "rustls 0.20.8",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -4287,24 +4290,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4575,58 +4560,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "openssl"
-version = "0.10.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
-dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.27",
- "syn 2.0.15",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-src"
-version = "111.25.3+1.1.1t"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924757a6a226bf60da5f7dd0311a34d2b52283dd82ddeb103208ddc66362f80c"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -5160,19 +5097,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "postgres-openssl"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de0ea6504e07ca78355a6fb88ad0f36cafe9e696cbc6717f16a207f3a60be72"
-dependencies = [
- "futures",
- "openssl",
- "tokio",
- "tokio-openssl",
- "tokio-postgres",
-]
-
-[[package]]
 name = "postgres-protocol"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5611,14 +5535,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.20.8",
  "rustls-native-certs",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-socks",
  "tokio-util",
  "tower-service",
@@ -5627,7 +5551,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.22.6",
  "winreg",
 ]
 
@@ -5830,14 +5754,39 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64 0.13.1",
+ "log",
+ "ring",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
 version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
- "sct",
- "webpki",
+ "sct 0.7.0",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct 0.7.0",
 ]
 
 [[package]]
@@ -5859,6 +5808,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -5902,6 +5861,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sct"
@@ -6098,7 +6067,6 @@ dependencies = [
  "async-trait",
  "core-resolver",
  "futures",
- "openssl",
  "resolver",
  "serde_json",
  "server-common",
@@ -7208,18 +7176,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-openssl"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08f9ffb7809f1b20c1b398d92acf4cc719874b3b2b2d9ea2f09b4a80350878a"
-dependencies = [
- "futures-util",
- "openssl",
- "openssl-sys",
- "tokio",
-]
-
-[[package]]
 name = "tokio-postgres"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7244,14 +7200,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-postgres-rustls"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5831152cb0d3f79ef5523b357319ba154795d64c7078b2daa95a803b54057f"
+dependencies = [
+ "futures",
+ "ring",
+ "rustls 0.21.1",
+ "tokio",
+ "tokio-postgres",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.8",
  "tokio",
- "webpki",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.1",
+ "tokio",
 ]
 
 [[package]]
@@ -7285,12 +7265,12 @@ checksum = "e80b39df6afcc12cdf752398ade96a6b9e99c903dfdc36e53ad10b9c366bca72"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
+ "rustls 0.20.8",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tungstenite",
- "webpki",
- "webpki-roots",
+ "webpki 0.22.0",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -7358,7 +7338,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-pemfile",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-stream",
  "tokio-util",
  "tower",
@@ -7707,12 +7687,12 @@ dependencies = [
  "httparse",
  "log",
  "rand",
- "rustls",
+ "rustls 0.20.8",
  "sha-1 0.9.8",
  "thiserror",
  "url",
  "utf-8",
- "webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -8537,6 +8517,16 @@ dependencies = [
 
 [[package]]
 name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
@@ -8547,11 +8537,20 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
- "webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -9,8 +9,6 @@ name = "exo"
 path = "src/main.rs"
 
 [features]
-cross = ["vendored-openssl"]
-vendored-openssl = ["openssl", "openssl/vendored"]
 
 [dependencies]
 colored.workspace = true
@@ -41,7 +39,6 @@ core-plugin-interface = { path = "../core-subsystem/core-plugin-interface" }
 postgres-model-builder = { path = "../postgres-subsystem/postgres-model-builder" }
 deno-model-builder = { path = "../deno-subsystem/deno-model-builder" }
 wasm-model-builder = { path = "../wasm-subsystem/wasm-model-builder" }
-openssl = { version = "0.10.50", optional = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 rexpect = "0.5.0"

--- a/crates/server-actix/Cargo.toml
+++ b/crates/server-actix/Cargo.toml
@@ -14,7 +14,6 @@ default = [
 static-postgres-resolver = ["server-common/static-postgres-resolver"]
 static-deno-resolver = ["server-common/static-deno-resolver"]
 static-wasm-resolver = ["server-common/static-wasm-resolver"]
-vendored-openssl = ["openssl", "openssl/vendored"]
 
 [dependencies]
 async-trait.workspace = true
@@ -33,7 +32,6 @@ resolver = { path = "../resolver" }
 core-resolver = { path = "../core-subsystem/core-resolver" }
 server-common = { path = "../server-common" }
 
-openssl = { version = "0.10.50", optional = true }
 
 [[bin]]
 name = "exo-server"

--- a/libs/exo-deno/Cargo.toml
+++ b/libs/exo-deno/Cargo.toml
@@ -19,7 +19,7 @@ deno_runtime = { git = "https://github.com/exograph/deno.git", branch = "patched
 deno_core.workspace = true
 deno_ast = { version = "0.24.0", features = ["transpiling"], optional = true }
 tokio.workspace = true
-http_req = "0.9.0"
+http_req  = {version="0.9.1", default-features = false, features = ["rust-tls"]}
 futures.workspace = true
 lazy_static.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/libs/exo-sql/Cargo.toml
+++ b/libs/exo-sql/Cargo.toml
@@ -6,14 +6,16 @@ publish = false
 
 [dependencies]
 bytes.workspace = true
-openssl = "0.10.50"
 tokio-postgres = { workspace = true, features = [
   "runtime",
   "with-chrono-0_4",
   "with-serde_json-1",
   "with-uuid-1",
 ] }
-postgres-openssl = "0.5.0"
+rustls = "0.21.1"
+tokio-postgres-rustls = "0.10.0"
+rustls-native-certs = "0.6.2"
+rustls-pemfile = "1.0.2"
 postgres_array = "0.11.0"
 deadpool-postgres = "0.10"
 chrono.workspace = true

--- a/libs/exo-sql/src/database_error.rs
+++ b/libs/exo-sql/src/database_error.rs
@@ -23,8 +23,11 @@ pub enum DatabaseError {
     #[error("Delegate: {0}")]
     Delegate(#[from] tokio_postgres::Error),
 
+    #[error("Unable to load native certificates: {0}")]
+    NativeCerts(#[from] std::io::Error),
+
     #[error("SSL: {0}")]
-    Ssl(#[from] openssl::error::ErrorStack),
+    Ssl(#[from] rustls::Error),
 
     #[error("Pool: {0}")]
     Pool(#[from] deadpool_postgres::PoolError),


### PR DESCRIPTION
We had two dependencies on openssl: Postgres and http-req.

For Postgres, we now use a combination of rustls, tokio-postgres-rustls, rustls-native-certs, and rustls-pemfile crates to provide the same functionality.

This commit drops the support for "enabling ssl but ignoring certificate validation" (through the EXO_SSL_VERIFY env variable). This was possible with OpenSSL, but rustls does not support it (and so far we haven't come across a use case for it).

  Tested with:
  - local Postgres without SSL
  - Neon (with sslmode=true)
  - Yugabyte (with sslrootcert=./root.crt") to test custom root certs

For http-req, we use the rustls feature to replace openssl with rustls. This usage was only during "exo test" (and verified that it works fine).

Fixes #798