### PR TITLE
Make naming of env vars constants consistent

### DIFF
--- a/crates/cli/src/commands/deploy/fly.rs
+++ b/crates/cli/src/commands/deploy/fly.rs
@@ -22,6 +22,7 @@ use heck::ToSnakeCase;
 use crate::commands::{
     build::build,
     command::{get, get_required, CommandDefinition},
+    util::EXO_POSTGRES_URL,
 };
 
 pub(super) struct FlyCommandDefinition {}
@@ -189,11 +190,11 @@ static DOCKERFILE: &str = include_str!("../templates/Dockerfile.fly");
 
 fn create_dockerfile(fly_dir: &Path, use_fly_db: bool) -> Result<()> {
     let extra_env = if use_fly_db {
-        "EXO_POSTGRES_URL=${DATABASE_URL}"
+        format!("{EXO_POSTGRES_URL}=${{DATABASE_URL}}")
     } else {
-        ""
+        "".into()
     };
-    let dockerfile_content = DOCKERFILE.replace("<<<EXTRA_ENV>>>", extra_env);
+    let dockerfile_content = DOCKERFILE.replace("<<<EXTRA_ENV>>>", &extra_env);
 
     let mut dockerfile = File::create(fly_dir.join("Dockerfile"))?;
     dockerfile.write_all(dockerfile_content.as_bytes())?;

--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -19,7 +19,7 @@ use crate::{
     commands::{
         command::{default_model_file, ensure_exo_project_dir},
         schema::{migration::Migration, verify::VerificationErrors},
-        util::wait_for_enter,
+        util::{wait_for_enter, EXO_CORS_DOMAINS, EXO_INTROSPECTION},
     },
     util::watcher,
 };
@@ -46,8 +46,8 @@ impl CommandDefinition for DevCommandDefinition {
             "Starting server in development mode...".purple().bold()
         );
         // In the serve mode, which is meant for development, always enable introspection and use relaxed CORS
-        std::env::set_var("EXO_INTROSPECTION", "true");
-        std::env::set_var("EXO_CORS_DOMAINS", "*");
+        std::env::set_var(EXO_INTROSPECTION, "true");
+        std::env::set_var(EXO_CORS_DOMAINS, "*");
 
         const MIGRATE: &str = "Attempt migration";
         const CONTINUE: &str = "Continue with old schema";

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -14,6 +14,8 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use clap::{Arg, ArgMatches, Command};
 
+const EXO_RUN_INTROSPECTION_TESTS: &str = "EXO_RUN_INTROSPECTION_TESTS";
+
 pub struct TestCommandDefinition {}
 
 #[async_trait]
@@ -41,12 +43,12 @@ impl CommandDefinition for TestCommandDefinition {
         let dir: PathBuf = get_required(matches, "dir")?;
         let pattern: Option<String> = get(matches, "pattern"); // glob pattern indicating tests to be executed
 
-        let run_introspection_tests: bool = match std::env::var("EXO_RUN_INTROSPECTION_TESTS") {
+        let run_introspection_tests: bool = match std::env::var(EXO_RUN_INTROSPECTION_TESTS) {
             Ok(e) => match e.to_lowercase().as_str() {
                 "true" | "1" => Ok(true), // The standard convention for boolean env vars is to accept "1" as true, as well
                 "false" => Ok(false),
                 _ => Err(anyhow!(
-                    "EXO_RUN_INTROSPECTION_TESTS env var must be set to a boolean or 1",
+                    "{EXO_RUN_INTROSPECTION_TESTS} env var must be set to a boolean or 1",
                 )),
             },
             Err(_) => Ok(false),

--- a/crates/cli/src/commands/util.rs
+++ b/crates/cli/src/commands/util.rs
@@ -11,6 +11,15 @@ use std::io::stdin;
 
 use rand::Rng;
 
+pub const EXO_INTROSPECTION: &str = "EXO_INTROSPECTION";
+pub const EXO_CORS_DOMAINS: &str = "EXO_CORS_DOMAINS";
+pub const EXO_SERVER_PORT: &str = "EXO_SERVER_PORT";
+
+pub const EXO_POSTGRES_URL: &str = "EXO_POSTGRES_URL";
+pub const EXO_POSTGRES_USER: &str = "EXO_POSTGRES_USER";
+pub const EXO_POSTGRES_PASSWORD: &str = "EXO_POSTGRES_PASSWORD";
+pub const EXO_JWT_SECRET: &str = "EXO_JWT_SECRET";
+
 pub(super) fn generate_random_string() -> String {
     rand::thread_rng()
         .sample_iter(&rand::distributions::Alphanumeric)

--- a/crates/cli/src/commands/yolo.rs
+++ b/crates/cli/src/commands/yolo.rs
@@ -14,6 +14,10 @@ use clap::{ArgMatches, Command};
 use colored::Colorize;
 use std::{path::PathBuf, sync::atomic::Ordering};
 
+use crate::commands::util::{
+    EXO_CORS_DOMAINS, EXO_INTROSPECTION, EXO_JWT_SECRET, EXO_POSTGRES_PASSWORD, EXO_POSTGRES_URL,
+    EXO_POSTGRES_USER,
+};
 use crate::{
     commands::{
         schema::migration::{self, Migration},
@@ -72,12 +76,12 @@ async fn run_server(
     db: &(dyn EphemeralDatabase + Send + Sync),
 ) -> Result<()> {
     // set envs for server
-    std::env::set_var("EXO_POSTGRES_URL", db.url());
-    std::env::remove_var("EXO_POSTGRES_USER");
-    std::env::remove_var("EXO_POSTGRES_PASSWORD");
-    std::env::set_var("EXO_INTROSPECTION", "true");
-    std::env::set_var("EXO_JWT_SECRET", jwt_secret);
-    std::env::set_var("EXO_CORS_DOMAINS", "*");
+    std::env::set_var(EXO_POSTGRES_URL, db.url());
+    std::env::remove_var(EXO_POSTGRES_USER);
+    std::env::remove_var(EXO_POSTGRES_PASSWORD);
+    std::env::set_var(EXO_INTROSPECTION, "true");
+    std::env::set_var(EXO_JWT_SECRET, jwt_secret);
+    std::env::set_var(EXO_CORS_DOMAINS, "*");
 
     println!("JWT secret is {}", &jwt_secret.cyan());
     println!("Postgres URL is {}", &db.url().cyan());
@@ -111,7 +115,7 @@ async fn run_server(
                 println!("Pausing for manual repair");
                 println!(
                     "You can get the migrations by running: {}{}{}",
-                    "EXO_POSTGRES_URL=".cyan(),
+                    format!("{EXO_POSTGRES_URL}=").cyan(),
                     db.url().cyan(),
                     " exo schema migration".cyan()
                 );

--- a/crates/cli/src/util/watcher.rs
+++ b/crates/cli/src/util/watcher.rs
@@ -16,7 +16,10 @@ use core_model_builder::error::ModelBuildingError;
 use futures::{future::BoxFuture, FutureExt};
 use notify_debouncer_mini::notify::RecursiveMode;
 
-use crate::commands::build::{build, BuildError};
+use crate::commands::{
+    build::{build, BuildError},
+    util::EXO_SERVER_PORT,
+};
 
 /// Starts a watcher that will rebuild and serve model files with every change.
 /// Takes a callback that will be called before the start of each server.
@@ -79,7 +82,7 @@ where
                 command.kill_on_drop(true);
 
                 if let Some(port) = server_port {
-                    command.env("EXO_SERVER_PORT", port.to_string());
+                    command.env(EXO_SERVER_PORT, port.to_string());
                 }
 
                 let child = command

--- a/crates/core-subsystem/core-resolver/src/context/provider/jwt.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/jwt.rs
@@ -31,7 +31,7 @@ pub struct JwtAuthenticator {
     secret: String, // Shared secret for HS algorithms, public key for RSA/ES
 }
 
-const JWT_SECRET_PARAM: &str = "EXO_JWT_SECRET";
+const EXO_JWT_SECRET: &str = "EXO_JWT_SECRET";
 
 // we spawn many resolvers concurrently in integration tests
 thread_local! {
@@ -45,7 +45,7 @@ impl JwtAuthenticator {
                 local_jwt_secret
                     .borrow()
                     .clone()
-                    .or_else(|| env::var(JWT_SECRET_PARAM).ok())
+                    .or_else(|| env::var(EXO_JWT_SECRET).ok())
             })
             .map(Self::new)
     }
@@ -106,7 +106,7 @@ impl JwtAuthenticator {
                     JwtAuthenticationError::Unknown => ContextParsingError::Malformed,
                 })?
         } else {
-            warn!("{JWT_SECRET_PARAM} is not set, not parsing JWT tokens");
+            warn!("{EXO_JWT_SECRET} is not set, not parsing JWT tokens");
             serde_json::Value::Null
         };
 

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -21,4 +21,6 @@ pub use root_resolver::get_endpoint_http_path;
 pub use root_resolver::get_playground_http_path;
 pub use root_resolver::{create_system_resolver, create_system_resolver_or_exit};
 pub use root_resolver::{resolve, resolve_in_memory};
-pub use system_loader::{allow_introspection, LOCAL_ALLOW_INTROSPECTION, LOCAL_ENVIRONMENT};
+pub use system_loader::{
+    allow_introspection, EXO_INTROSPECTION, LOCAL_ALLOW_INTROSPECTION, LOCAL_ENVIRONMENT,
+};

--- a/crates/resolver/src/root_resolver.rs
+++ b/crates/resolver/src/root_resolver.rs
@@ -26,6 +26,9 @@ pub use core_resolver::OperationsPayload;
 use core_resolver::{context::RequestContext, QueryResponseBody};
 use futures::Stream;
 
+const EXO_PLAYGROUND_HTTP_PATH: &str = "EXO_PLAYGROUND_HTTP_PATH";
+const EXO_ENDPOINT_HTTP_PATH: &str = "EXO_ENDPOINT_HTTP_PATH";
+
 #[instrument(
     name = "resolver::resolve_in_memory"
     skip(system_resolver, request_context)
@@ -150,11 +153,11 @@ pub async fn resolve<'a, E: 'static>(
 }
 
 pub fn get_playground_http_path() -> String {
-    std::env::var("EXO_PLAYGROUND_HTTP_PATH").unwrap_or_else(|_| "/playground".to_string())
+    std::env::var(EXO_PLAYGROUND_HTTP_PATH).unwrap_or_else(|_| "/playground".to_string())
 }
 
 pub fn get_endpoint_http_path() -> String {
-    std::env::var("EXO_ENDPOINT_HTTP_PATH").unwrap_or_else(|_| "/graphql".to_string())
+    std::env::var(EXO_ENDPOINT_HTTP_PATH).unwrap_or_else(|_| "/graphql".to_string())
 }
 
 pub async fn create_system_resolver(

--- a/crates/resolver/src/system_loader.rs
+++ b/crates/resolver/src/system_loader.rs
@@ -34,6 +34,9 @@ pub type StaticLoaders = Vec<Box<dyn SubsystemLoader>>;
 
 pub struct SystemLoader;
 
+pub const EXO_INTROSPECTION: &str = "EXO_INTROSPECTION";
+const EXO_MAX_SELECTION_DEPTH: &str = "EXO_MAX_SELECTION_DEPTH";
+
 impl SystemLoader {
     pub async fn load(
         read: impl std::io::Read,
@@ -151,12 +154,12 @@ pub fn allow_introspection() -> Result<bool, SystemLoadingError> {
     LOCAL_ALLOW_INTROSPECTION.with(|f| {
         f.borrow()
             .map(Ok)
-            .unwrap_or_else(|| match std::env::var("EXO_INTROSPECTION").ok() {
+            .unwrap_or_else(|| match std::env::var(EXO_INTROSPECTION).ok() {
                 Some(e) => match e.parse::<bool>() {
                     Ok(v) => Ok(v),
-                    Err(_) => Err(SystemLoadingError::Config(
-                        "EXO_INTROSPECTION env var must be set to either true or false".into(),
-                    )),
+                    Err(_) => Err(SystemLoadingError::Config(format!(
+                        "{EXO_INTROSPECTION} env var must be set to either true or false"
+                    ))),
                 },
                 None => Ok(false),
             })
@@ -174,15 +177,15 @@ pub fn query_depth_limits() -> Result<(usize, usize), SystemLoadingError> {
         .with(|f| {
             f.borrow()
                 .as_ref()
-                .and_then(|env| env.get("EXO_MAX_SELECTION_DEPTH").cloned())
+                .and_then(|env| env.get(EXO_MAX_SELECTION_DEPTH).cloned())
         })
-        .or_else(|| std::env::var("EXO_MAX_SELECTION_DEPTH").ok())
+        .or_else(|| std::env::var(EXO_MAX_SELECTION_DEPTH).ok())
     {
         Some(e) => match e.parse::<usize>() {
             Ok(v) => Ok(v),
-            Err(_) => Err(SystemLoadingError::Config(
-                "EXO_MAX_SELECTION_DEPTH env var must be set to a positive integer".into(),
-            )),
+            Err(_) => Err(SystemLoadingError::Config(format!(
+                "{EXO_MAX_SELECTION_DEPTH} env var must be set to a positive integer"
+            ))),
         },
         None => Ok(DEFAULT_QUERY_DEPTH),
     }?;

--- a/crates/server-actix/src/main.rs
+++ b/crates/server-actix/src/main.rs
@@ -21,6 +21,9 @@ use std::path::Path;
 use std::time;
 use std::{env, process::exit};
 
+const EXO_CORS_DOMAINS: &str = "EXO_CORS_DOMAINS";
+const EXO_SERVER_PORT: &str = "EXO_SERVER_PORT";
+
 /// Run the server in production mode with a compiled exo_ir file
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
@@ -28,7 +31,7 @@ async fn main() -> std::io::Result<()> {
 
     let system_resolver = web::Data::new(server_common::init().await);
 
-    let server_port = env::var("EXO_SERVER_PORT")
+    let server_port = env::var(EXO_SERVER_PORT)
         .map(|port_str| {
             port_str
                 .parse::<u32>()
@@ -133,7 +136,7 @@ async fn playground(req: HttpRequest, resolver: web::Data<SystemResolver>) -> im
 }
 
 fn cors_from_env() -> Cors {
-    match env::var("EXO_CORS_DOMAINS").ok() {
+    match env::var(EXO_CORS_DOMAINS).ok() {
         Some(domains) => {
             let domains_list = domains.split(',');
 

--- a/crates/server-common/src/logging_tracing.rs
+++ b/crates/server-common/src/logging_tracing.rs
@@ -39,6 +39,7 @@ use opentelemetry_otlp::WithExportConfig;
 use std::str::FromStr;
 use tracing_subscriber::{filter::LevelFilter, prelude::*, EnvFilter};
 
+const EXO_LOG: &str = "EXO_LOG";
 /// Initialize the tracing subscriber.
 ///
 /// Creates a `tracing_subscriber::fmt` layer by default and adds a `tracing_opentelemetry`
@@ -50,7 +51,7 @@ pub(super) fn init() {
         create_otlp_tracer().map(|t| tracing_opentelemetry::layer().with_tracer(t));
     let filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::WARN.into())
-        .with_env_var("EXO_LOG")
+        .with_env_var(EXO_LOG)
         .from_env_lossy();
 
     tracing_subscriber::registry()

--- a/libs/exo-sql/src/sql/database_client.rs
+++ b/libs/exo-sql/src/sql/database_client.rs
@@ -16,11 +16,11 @@ use tokio_postgres::{config::SslMode, Config};
 
 use crate::database_error::DatabaseError;
 
-const URL_PARAM: &str = "EXO_POSTGRES_URL";
-const USER_PARAM: &str = "EXO_POSTGRES_USER";
-const PASSWORD_PARAM: &str = "EXO_POSTGRES_PASSWORD";
-const CONNECTION_POOL_SIZE_PARAM: &str = "EXO_CONNECTION_POOL_SIZE";
-const CHECK_CONNECTION_ON_STARTUP: &str = "EXO_CHECK_CONNECTION_ON_STARTUP";
+const EXO_POSTGRES_URL: &str = "EXO_POSTGRES_URL";
+const EXO_POSTGRES_USER: &str = "EXO_POSTGRES_USER";
+const EXO_POSTGRES_PASSWORD: &str = "EXO_POSTGRES_PASSWORD";
+const EXO_CONNECTION_POOL_SIZE: &str = "EXO_CONNECTION_POOL_SIZE";
+const EXO_CHECK_CONNECTION_ON_STARTUP: &str = "EXO_CHECK_CONNECTION_ON_STARTUP";
 
 // we spawn many resolvers concurrently in integration tests
 thread_local! {
@@ -43,18 +43,18 @@ impl<'a> DatabaseClient {
     pub async fn from_env(pool_size_override: Option<usize>) -> Result<Self, DatabaseError> {
         let url = LOCAL_URL
             .with(|f| f.borrow().clone())
-            .or_else(|| env::var(URL_PARAM).ok())
+            .or_else(|| env::var(EXO_POSTGRES_URL).ok())
             .ok_or(DatabaseError::Config(format!(
-                "Env {URL_PARAM} must be provided"
+                "Env {EXO_POSTGRES_URL} must be provided"
             )))?;
 
-        let user = env::var(USER_PARAM).ok();
-        let password = env::var(PASSWORD_PARAM).ok();
+        let user = env::var(EXO_POSTGRES_USER).ok();
+        let password = env::var(EXO_POSTGRES_PASSWORD).ok();
         let pool_size = pool_size_override.unwrap_or_else(|| {
             LOCAL_CONNECTION_POOL_SIZE
                 .with(|f| *f.borrow())
                 .or_else(|| {
-                    env::var(CONNECTION_POOL_SIZE_PARAM)
+                    env::var(EXO_CONNECTION_POOL_SIZE)
                         .ok()
                         .map(|pool_str| pool_str.parse::<usize>().unwrap())
                 })
@@ -64,7 +64,7 @@ impl<'a> DatabaseClient {
         let check_connection = LOCAL_CHECK_CONNECTION_ON_STARTUP
             .with(|f| *f.borrow())
             .or_else(|| {
-                env::var(CHECK_CONNECTION_ON_STARTUP)
+                env::var(EXO_CHECK_CONNECTION_ON_STARTUP)
                     .ok()
                     .map(|check| check.parse::<bool>().expect("Should be true or false"))
             })


### PR DESCRIPTION
Some of the declarations of env vars had the "EXO_" prefix, some had the "_PARAM" suffix. This commit makes them all consistent. In the process, it also introduces constants for all `EXO_*` envs.

There is some duplication (between cli and other crates), which is not easily avoidable since cli doesn't depend on, for example, the server_common crate.

We leave the "OTEL_" prefix for OpenTelemetry env vars as locally defined string literals since all of them are used in a single place.