### PR TITLE
Install ca-certificates in the docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
     tags:
       - "*"
+  pull_request: # Temporary to test without merging
 
 env:
   REGISTRY: ghcr.io
@@ -82,7 +83,8 @@ jobs:
   build-and-push-docker:
     needs: build-artifacts
     runs-on: ubuntu-20.04
-    if: startsWith(github.ref, 'refs/tags/') # Only build and push Docker images for tags
+    # Temporary to test without merging
+    # if: startsWith(github.ref, 'refs/tags/') # Only build and push Docker images for tags 
 
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
     branches: ["main"]
     tags:
       - "*"
-  pull_request: # Temporary to test without merging
 
 env:
   REGISTRY: ghcr.io
@@ -83,8 +82,7 @@ jobs:
   build-and-push-docker:
     needs: build-artifacts
     runs-on: ubuntu-20.04
-    # Temporary to test without merging
-    # if: startsWith(github.ref, 'refs/tags/') # Only build and push Docker images for tags 
+    if: startsWith(github.ref, 'refs/tags/') # Only build and push Docker images for tags
 
     permissions:
       contents: read

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -1,6 +1,7 @@
-# We must use "debian:bullseye" (and not "debian:buster") as the base runtime image to match the libc version used while building the binaries
-# Create a builder image with exograph release binaries
-FROM debian:bullseye as builder
+# We must use "debian:bullseye*" (and not "debian:buster") as the base runtime image to match the libc version used while building the binaries
+
+## Create a builder image with exograph release binaries
+FROM debian:bullseye-slim as builder
 
 RUN apt-get update && apt-get -y install unzip
 
@@ -9,7 +10,25 @@ COPY exograph-x86_64-unknown-linux-gnu.zip ./exograph-x86_64-unknown-linux-gnu.z
 RUN unzip ./exograph-x86_64-unknown-linux-gnu.zip
 
 
-# Build the runtime image with just the binary we need for the server
-FROM debian:bullseye as exo-server
+## Build the runtime image with just the binary we need for the server
+FROM debian:bullseye-slim as exo-server
+
+### Install ca-certificates and tzdata (needed to establish TLS connections and set the timezone)
+RUN apt-get update \
+  && apt-get install -y ca-certificates tzdata \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/src/exo-server /usr/local/bin/exo-server
+
+ENV TZ=Etc/UTC
+ENV APP_USER=exo
+ENV APP=/usr/src/app
+
+### Create a non-root user to run the server
+RUN groupadd $APP_USER \
+  && useradd -g $APP_USER $APP_USER \
+  && mkdir -p ${APP}
+RUN chown -R $APP_USER:$APP_USER ${APP}
+USER $APP_USER
+
+WORKDIR ${APP}

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -22,13 +22,13 @@ COPY --from=builder /usr/src/exo-server /usr/local/bin/exo-server
 
 ENV TZ=Etc/UTC
 ENV APP_USER=exo
-ENV APP=/usr/src/app
+ENV APP_DIR=/usr/src/app
 
 ### Create a non-root user to run the server
 RUN groupadd $APP_USER \
   && useradd -g $APP_USER $APP_USER \
-  && mkdir -p ${APP}
-RUN chown -R $APP_USER:$APP_USER ${APP}
+  && mkdir -p ${APP_DIR}
+RUN chown -R $APP_USER:$APP_USER ${APP_DIR}
 USER $APP_USER
 
-WORKDIR ${APP}
+WORKDIR ${APP_DIR}


### PR DESCRIPTION
Also improve the Dockerfile by:
- Using bullseye-slim instead of bullseye
- Setting up a non-root user (so that unless user's Dockerfile overrides it, the image will run as a non-root user)
- Seting up the default timezone to UTC