### PR TITLE
Fix "cargo deny" warnings

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cli"
+publish = false
 version.workspace = true
 edition.workspace = true
 repository = "https://github.com/exograph/exograph"

--- a/crates/server-actix/Cargo.toml
+++ b/crates/server-actix/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "server-actix"
+publish = false
 version.workspace = true
 edition.workspace = true
 repository = "https://github.com/exograph/exograph"

--- a/crates/server-aws-lambda/Cargo.toml
+++ b/crates/server-aws-lambda/Cargo.toml
@@ -7,6 +7,7 @@
 
 [package]
 name = "server-aws-lambda"
+publish = false
 version.workspace = true
 edition.workspace = true
 repository = "https://github.com/exograph/exograph"


### PR DESCRIPTION
We had marked server-actix, server-aws-lambda, and cli as published, so cargo deno didn't apply `licenses.private.ignored = true`. This change marks those crates as unpublished.