### PR TITLE
Do not exit yolo/dev mode on ts/js errors

### DIFF
--- a/crates/builder/src/lib.rs
+++ b/crates/builder/src/lib.rs
@@ -141,6 +141,11 @@ fn emit_diagnostics(err: &ParserError, codemap: &CodeMap) {
         ParserError::ModelBuildingError(ModelBuildingError::Diagnosis(diagnostics)) => {
             emitter.emit(diagnostics);
         }
+        ParserError::ModelBuildingError(ModelBuildingError::ExternalResourceParsing(e)) => {
+            // This is an error in a JavaScript/TypeScript file, so we
+            // have emit it directly to stderr (can't use the emitter, which is tied to exo sources)
+            eprintln!("{}", e)
+        }
         _ => {}
     }
 }

--- a/crates/core-subsystem/core-model-builder/src/error.rs
+++ b/crates/core-subsystem/core-model-builder/src/error.rs
@@ -22,6 +22,9 @@ pub enum ModelBuildingError {
     #[error("{0}")]
     Generic(String),
 
+    #[error("{0}")]
+    ExternalResourceParsing(String),
+
     #[error("Unable to serialize model {0}")]
     Serialize(#[source] ModelSerializationError),
 

--- a/crates/deno-subsystem/deno-model-builder/src/system_builder.rs
+++ b/crates/deno-subsystem/deno-model-builder/src/system_builder.rs
@@ -190,10 +190,9 @@ fn process_script(
                 modules.insert(specifier, ResolvedModule::Redirect(to.clone()))
             }
             ModuleEntryRef::Err(e) => {
-                return Err(ModelBuildingError::Generic(format!(
-                    "Error in Deno graph: {:?}",
-                    e
-                )))
+                return Err(ModelBuildingError::ExternalResourceParsing(
+                    e.to_string_with_range(),
+                ))
             }
         };
     }


### PR DESCRIPTION
During building the dependency graph for Deno, we may encounter ts/js errors. We used the `Generic` error, which is currently treated as an unrecoverable error, which led to exiting the yolo/dev watch loop.

In this commit, we introduce an `ExternalResourceParsing` variant, which emits the given error message but does not exit.

Also, pass a diagnostic error message to the `ExternalResourceParsing` variant so we can show the user a helpful message.