### PR TITLE
Don't add mutations to the system when access is false

### DIFF
--- a/crates/postgres-subsystem/postgres-model-builder/Cargo.toml
+++ b/crates/postgres-subsystem/postgres-model-builder/Cargo.toml
@@ -19,7 +19,7 @@ postgres-model = { path = "../postgres-model" }
 exo-sql = { path = "../../../libs/exo-sql" }
 
 [dev-dependencies]
-insta.workspace = true
+insta = { workspace = true, features = ["yaml"] }
 builder = { path = "../../builder" }
 
 

--- a/crates/postgres-subsystem/postgres-model-builder/src/delete_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/delete_mutation_builder.rs
@@ -11,6 +11,7 @@
 //! the create mutations (`delete<Type>`, and `delete<Type>s`)
 
 use core_plugin_interface::core_model::{
+    access::AccessPredicateExpression,
     mapped_arena::MappedArena,
     types::{BaseOperationReturnType, OperationReturnType},
 };
@@ -46,8 +47,10 @@ impl Builder for DeleteMutationBuilder {
         building: &mut SystemContextBuilding,
     ) {
         // Since there are no special input types for deletion, no expansion is needed
-
         for (entity_type_id, entity_type) in building.entity_types.iter() {
+            if let AccessPredicateExpression::BooleanLiteral(false) = entity_type.access.delete {
+                continue;
+            }
             for mutation in self.build_mutations(entity_type_id, entity_type, building) {
                 building.mutations.add(&mutation.name.to_owned(), mutation);
             }

--- a/integration-tests/default-access/tests/default-access-mutations.exotest
+++ b/integration-tests/default-access/tests/default-access-mutations.exotest
@@ -9,11 +9,16 @@ stages:
       {
         "errors": [
           {
-            "message": "Not authorized"
+            "message": "Field 'createConcert' is not valid for type 'Mutation'",
+            "locations": [
+               {
+                 "line": 2,
+                 "column": 3
+               }
+             ]
           }
         ]
       }
-  
   - operation: |
       mutation {
         updateConcert(id: 1, data: {title: "Foo"}) {
@@ -24,7 +29,13 @@ stages:
       {
         "errors": [
           {
-            "message": "Not authorized"
+            "message": "Field 'updateConcert' is not valid for type 'Mutation'",
+            "locations": [
+               {
+                 "line": 2,
+                 "column": 3
+               }
+             ]
           }
         ]
       }
@@ -39,7 +50,13 @@ stages:
       {
         "errors": [
           {
-            "message": "Not authorized"
+            "message": "Field 'deleteConcert' is not valid for type 'Mutation'",
+            "locations": [
+               {
+                 "line": 2,
+                 "column": 3
+               }
+             ]
           }
         ]
       }


### PR DESCRIPTION
For create, update and delete, don't add the relevant mutations (and related types, if any) to the system when building if the access constraint is set to false for the mutation. See #685. Removing queries is more trickier since they are also used in relations. If they are just removed then creating `postgres_model::types::EntityType` will fail since it requires valid indices for its query fields (`pk_query` etc).