### PR TITLE
Improve live reloading experience of playground

### DIFF
--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -19,7 +19,9 @@ use crate::{
     commands::{
         command::{default_model_file, ensure_exo_project_dir},
         schema::{migration::Migration, verify::VerificationErrors},
-        util::{wait_for_enter, EXO_CORS_DOMAINS, EXO_INTROSPECTION},
+        util::{
+            wait_for_enter, EXO_CORS_DOMAINS, EXO_INTROSPECTION, EXO_INTROSPECTION_LIVE_UPDATE,
+        },
     },
     util::watcher,
 };
@@ -47,6 +49,8 @@ impl CommandDefinition for DevCommandDefinition {
         );
         // In the serve mode, which is meant for development, always enable introspection and use relaxed CORS
         std::env::set_var(EXO_INTROSPECTION, "true");
+        std::env::set_var(EXO_INTROSPECTION_LIVE_UPDATE, "true");
+
         std::env::set_var(EXO_CORS_DOMAINS, "*");
 
         const MIGRATE: &str = "Attempt migration";

--- a/crates/cli/src/commands/util.rs
+++ b/crates/cli/src/commands/util.rs
@@ -12,6 +12,8 @@ use std::io::stdin;
 use rand::Rng;
 
 pub const EXO_INTROSPECTION: &str = "EXO_INTROSPECTION";
+pub const EXO_INTROSPECTION_LIVE_UPDATE: &str = "EXO_INTROSPECTION_LIVE_UPDATE";
+
 pub const EXO_CORS_DOMAINS: &str = "EXO_CORS_DOMAINS";
 pub const EXO_SERVER_PORT: &str = "EXO_SERVER_PORT";
 

--- a/crates/cli/src/commands/yolo.rs
+++ b/crates/cli/src/commands/yolo.rs
@@ -15,8 +15,8 @@ use colored::Colorize;
 use std::{path::PathBuf, sync::atomic::Ordering};
 
 use crate::commands::util::{
-    EXO_CORS_DOMAINS, EXO_INTROSPECTION, EXO_JWT_SECRET, EXO_POSTGRES_PASSWORD, EXO_POSTGRES_URL,
-    EXO_POSTGRES_USER,
+    EXO_CORS_DOMAINS, EXO_INTROSPECTION, EXO_INTROSPECTION_LIVE_UPDATE, EXO_JWT_SECRET,
+    EXO_POSTGRES_PASSWORD, EXO_POSTGRES_URL, EXO_POSTGRES_USER,
 };
 use crate::{
     commands::{
@@ -80,6 +80,8 @@ async fn run_server(
     std::env::remove_var(EXO_POSTGRES_USER);
     std::env::remove_var(EXO_POSTGRES_PASSWORD);
     std::env::set_var(EXO_INTROSPECTION, "true");
+    std::env::set_var(EXO_INTROSPECTION_LIVE_UPDATE, "true");
+
     std::env::set_var(EXO_JWT_SECRET, jwt_secret);
     std::env::set_var(EXO_CORS_DOMAINS, "*");
 

--- a/crates/resolver/src/graphiql.rs
+++ b/crates/resolver/src/graphiql.rs
@@ -10,11 +10,17 @@
 use include_dir::{include_dir, Dir};
 use std::path::Path;
 
-use crate::root_resolver::{get_endpoint_http_path, get_playground_http_path};
+use crate::{
+    root_resolver::{get_endpoint_http_path, get_playground_http_path},
+    system_loader::EXO_INTROSPECTION_LIVE_UPDATE,
+};
 
 static GRAPHIQL_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../../graphiql/build");
 
 pub fn get_asset_bytes<P: AsRef<Path>>(file_name: P) -> Option<Vec<u8>> {
+    let enable_introspection_live_update =
+        std::env::var(EXO_INTROSPECTION_LIVE_UPDATE).unwrap_or_else(|_| "false".to_string());
+
     GRAPHIQL_DIR.get_file(file_name.as_ref()).map(|file| {
         if file_name.as_ref() == Path::new("index.html") {
             let str = file
@@ -22,6 +28,10 @@ pub fn get_asset_bytes<P: AsRef<Path>>(file_name: P) -> Option<Vec<u8>> {
                 .expect("index.html for playground should be utf8");
             let str = str.replace("%%PLAYGROUND_URL%%", &get_playground_http_path());
             let str = str.replace("%%ENDPOINT_URL%%", &get_endpoint_http_path());
+            let str = str.replace(
+                "%%ENABLE_INTROSPECTION_LIVE_UPDATE%%",
+                &enable_introspection_live_update,
+            );
             str.as_bytes().to_owned()
         } else {
             file.contents().to_owned()

--- a/crates/resolver/src/system_loader.rs
+++ b/crates/resolver/src/system_loader.rs
@@ -35,6 +35,8 @@ pub type StaticLoaders = Vec<Box<dyn SubsystemLoader>>;
 pub struct SystemLoader;
 
 pub const EXO_INTROSPECTION: &str = "EXO_INTROSPECTION";
+pub const EXO_INTROSPECTION_LIVE_UPDATE: &str = "EXO_INTROSPECTION_LIVE_UPDATE";
+
 const EXO_MAX_SELECTION_DEPTH: &str = "EXO_MAX_SELECTION_DEPTH";
 
 impl SystemLoader {
@@ -167,7 +169,7 @@ pub fn allow_introspection() -> Result<bool, SystemLoadingError> {
 }
 
 /// Returns the maximum depth of a selection set for normal queries and introspection queries. We
-/// hard-code the introspection query depth to 15 to accomodate the query invoked by GraphQL
+/// hard-code the introspection query depth to 15 to accommodate the query invoked by GraphQL
 /// Playground
 pub fn query_depth_limits() -> Result<(usize, usize), SystemLoadingError> {
     const DEFAULT_QUERY_DEPTH: usize = 5;

--- a/graphiql/public/index.html
+++ b/graphiql/public/index.html
@@ -12,6 +12,7 @@
     <title>Exograph GraphiQL</title>
     <script>
       window.exoGraphQLEndpoint = "%%ENDPOINT_URL%%";
+      window.enableSchemaLiveUpdate = %%ENABLE_INTROSPECTION_LIVE_UPDATE%%;
     </script>
   </head>
   <body>

--- a/graphiql/src/App.tsx
+++ b/graphiql/src/App.tsx
@@ -7,10 +7,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-import { useState, useEffect, useRef, useCallback } from 'react'
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import GraphiQL from "graphiql";
 import { createGraphiQLFetcher } from "@graphiql/toolkit";
 import { useTheme } from "@graphiql/react";
+import { GraphQLSchema } from "graphql";
+import { fetchSchema, SchemaError } from "./schema";
 
 import "graphiql/graphiql.min.css";
 
@@ -31,8 +33,8 @@ export const useBrowserTheme = () => {
     return () => mql.removeEventListener("change", setCurrentTheme);
   }, [currentTheme, mql]);
 
-  return theme
-}
+  return theme;
+};
 
 function Logo() {
   const graphiqlTheme = useTheme().theme;
@@ -40,29 +42,127 @@ function Logo() {
 
   // Currently, switching mode in GraphiQL doesn't update the logo, but this will get fixed
   // when https://github.com/graphql/graphiql/pull/2971 is merged.
-  const logo = graphiqlTheme === "dark" || browserTheme === "dark" ? "logo-dark.svg" : "logo-light.svg";
+  const logo =
+    graphiqlTheme === "dark" || browserTheme === "dark"
+      ? "logo-dark.svg"
+      : "logo-light.svg";
 
   return (
     <a href="https://exograph.dev" target="_blank" rel="noreferrer">
       <img src={logo} className="logo" alt="Exograph" />
     </a>
   );
-};
+}
 
 const fetcher = createGraphiQLFetcher({
   url: (window as any).exoGraphQLEndpoint,
 });
 
-const App = () => (
-  <GraphiQL
-    fetcher={fetcher}
-    defaultEditorToolsVisibility={true}
-    isHeadersEditorEnabled={true}
-  >
-    <GraphiQL.Logo>
-      <Logo />
-    </GraphiQL.Logo>
-  </GraphiQL>
-);
+const enableSchemaLiveUpdate = (window as any).enableSchemaLiveUpdate;
+
+function App() {
+  const [schema, setSchema] = useState<GraphQLSchema | SchemaError | null>(
+    null
+  );
+
+  async function fetchAndSetSchema() {
+    let schema = await fetchSchema(fetcher);
+    setSchema(schema);
+    if (enableSchemaLiveUpdate && schema !== "NetworkError") {
+      // Schedule another fetch in 2 seconds only if there was no network error while fetching the schema
+      setTimeout(fetchAndSetSchema, 2000);
+    }
+  }
+
+  if (schema === null) {
+    fetchAndSetSchema();
+  }
+
+  let overlay = null;
+  let core = null;
+
+  if (schema === null) {
+    overlay = null; // Loading, but let's not show any overlay (we could consider showing with a delay to avoid a flash of the overlay)
+    core = <Core schema={null} />;
+  } else if (typeof schema == "string") {
+    core = <Core schema={null} />;
+    if (schema === "EmptySchema") {
+      overlay = <EmptySchema />;
+    } else if (schema === "InvalidSchema") {
+      overlay = <InvalidSchema />;
+    } else {
+      overlay = <NetworkError />;
+    }
+  } else {
+    overlay = null;
+    core = <Core schema={schema} />;
+  }
+
+  return (
+    <>
+      {overlay && <Overlay>{overlay}</Overlay>}
+      {core}
+    </>
+  );
+}
+
+function Core(props: { schema: GraphQLSchema | null }) {
+  return (
+    <GraphiQL
+      fetcher={fetcher}
+      defaultEditorToolsVisibility={true}
+      isHeadersEditorEnabled={true}
+      schema={props.schema}
+    >
+      <GraphiQL.Logo>
+        <Logo />
+      </GraphiQL.Logo>
+    </GraphiQL>
+  );
+}
+
+function ErrorMessage(props: {
+  title: string;
+  message?: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="error-message">
+      <div className="error-title">{props.title}</div>
+      {props.message && <div className="error-message">{props.message}</div>}
+      {props.children}
+    </div>
+  );
+}
+
+function InvalidSchema() {
+  return <ErrorMessage title="Invalid schema" />;
+}
+
+function EmptySchema() {
+  return (
+    <ErrorMessage
+      title="Schema contains no queries"
+      message="Please check the model to ensure that at least one query is defined."
+    />
+  );
+}
+
+function NetworkError() {
+  return (
+    <ErrorMessage
+      title="Network error"
+      message="Please ensure that the server is running."
+    >
+      <button className="reload-btn" onClick={() => window.location.reload()}>
+        Reload
+      </button>
+    </ErrorMessage>
+  );
+}
+
+function Overlay(props: { children: React.ReactNode }) {
+  return <div className="overlay">{props.children}</div>;
+}
 
 export default App;

--- a/graphiql/src/index.css
+++ b/graphiql/src/index.css
@@ -21,4 +21,44 @@ body {
 
 .logo {
   width: 125px
-} 
+}
+
+.overlay {
+  position: fixed;
+  display: block;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.3);
+  cursor: not-allowed;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.error-message {
+  font-size: 2rem;
+  font-family: Roboto, sans-serif;
+  text-align: center;
+}
+
+.error-message .error-title {
+  color: rgb(112, 27, 27);
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+.error-message .error-message {
+  font-size: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.reload-btn {
+  background-color: #fff;
+  border: 1px solid #000;
+  border-radius: 5px;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  font-family: inherit;
+  cursor: pointer;
+}

--- a/graphiql/src/schema.ts
+++ b/graphiql/src/schema.ts
@@ -1,0 +1,44 @@
+import {
+  Fetcher,
+  fetcherReturnToPromise,
+} from "@graphiql/toolkit";
+import {
+  getIntrospectionQuery,
+  buildClientSchema,
+  IntrospectionQuery,
+  GraphQLSchema,
+} from "graphql";
+
+export type SchemaError = "EmptySchema" | "InvalidSchema" | "NetworkError";
+
+export async function fetchSchema(
+  fetcher: Fetcher
+): Promise<GraphQLSchema | SchemaError> {
+  const source = getIntrospectionQuery();
+  try {
+    const executionResult = await fetcher({ query: source });
+    const fetcherResult = await fetcherReturnToPromise(executionResult);
+
+    if (fetcherResult?.data && "__schema" in fetcherResult.data) {
+      return buildClientSchema(fetcherResult.data as IntrospectionQuery);
+    } else {
+      if (typeof fetcherResult === "string") {
+        return "InvalidSchema";
+      } else {
+        // When we have no queries (which GraphQL spec doesn't allow, but can happen in an Exograph model), we get this error message.
+        // We use this to print an informative message to the user.
+        const noQueryMessage = (fetcherResult as any).errors?.find((error: any) => {
+          return error.message === "No such operation 'Query'";
+        });
+
+        if (noQueryMessage) {
+          return "EmptySchema";
+        } else {
+          return "InvalidSchema"
+        }
+      }
+    }
+  } catch (e) {
+    return "NetworkError";
+  }
+}


### PR DESCRIPTION
If `EXO_INTROSPECTION_LIVE_UPDATE` is enabled (automatically set to true in yolo and dev mode), refetch the schema every 2 seconds.

Also, take care of error situations such as a query-less model (for example, due to an empty exo file).

In the future, we can use websocket to have the server notify the client of a schema change (instead of polling), but this sets the foundation for that.

Fixes #299