### PR TITLE
Add an optional 'retries' field to exotest files

### DIFF
--- a/crates/testing/src/exotest/loader.rs
+++ b/crates/testing/src/exotest/loader.rs
@@ -45,6 +45,7 @@ pub struct ProjectTests {
 #[derive(Debug, Clone)]
 pub struct ParsedTestfile {
     testfile_path: PathBuf,
+    pub retries: usize,
     pub init_operations: Vec<TestfileOperation>,
     pub extra_envs: HashMap<String, String>, // extra envvars to set for the entire testfile
     pub test_operation_stages: Vec<TestfileOperation>,
@@ -91,6 +92,8 @@ pub struct TestfileStage {
 #[derive(Deserialize, Debug)]
 pub struct TestfileCommon {
     pub exofile: Option<String>,
+    #[serde(default)]
+    pub retries: usize,
     pub envs: Option<HashMap<String, String>>,
 }
 
@@ -297,8 +300,11 @@ Error as a multistage test: {}
         })
         .collect::<Result<Vec<_>>>()?;
 
+    assert!(common.retries <= 5, "The maximum number of retries is 5");
+
     Ok(ParsedTestfile {
         testfile_path: testfile_path.to_path_buf(),
+        retries: common.retries,
         extra_envs: common.envs.unwrap_or_default(),
         init_operations: init_ops,
         test_operation_stages: test_operation_sequence,

--- a/integration-tests/blobs-uuids/tests/mutation-populate-with-blob.exotest
+++ b/integration-tests/blobs-uuids/tests/mutation-populate-with-blob.exotest
@@ -1,3 +1,4 @@
+retries: 3
 deno: |
     import { v4 } from "https://deno.land/std@0.140.0/uuid/mod.ts";
 operation: |

--- a/integration-tests/services/basic/tests/network-access.exotest
+++ b/integration-tests/services/basic/tests/network-access.exotest
@@ -1,3 +1,4 @@
+retries: 3
 operation: |
     query {
       todo1: todo(id: 1) {


### PR DESCRIPTION
If set the test will be retried this many times if it fails until it passes (or panics). If it still doesn't pass, the last failure will be reported for the test.

There is a pause before each retry, starting at one second duration and doubling each time thereafter.

Fixes #843.