### PR TITLE
Fix aliasing of subselect elements

### DIFF
--- a/integration-tests/ownership-access-check/tests/query/all-documents-admin.exotest
+++ b/integration-tests/ownership-access-check/tests/query/all-documents-admin.exotest
@@ -1,6 +1,6 @@
 operation: |
   query {
-    documents { 
+    documents {
       id
       content
       user {

--- a/integration-tests/ownership-access-check/tests/query/all-documents-admin.exotest
+++ b/integration-tests/ownership-access-check/tests/query/all-documents-admin.exotest
@@ -1,0 +1,54 @@
+operation: |
+  query {
+    documents { 
+      id
+      content
+      user {
+        id
+        name
+      }
+    }
+  }
+auth: |
+  {
+    "role": "ADMIN"
+  }
+response: |
+  {
+    "data": {
+      "documents": [
+        {
+          "id": 1,
+          "content": "content1",
+          "user": {
+            "id": 2,
+            "name": "u2"
+          }
+        },
+        {
+          "id": 2,
+          "content": "content2",
+          "user": {
+            "id": 2,
+            "name": "u2"
+          }
+        },
+        {
+          "id": 3,
+          "content": "content3",
+          "user": {
+            "id": 1,
+            "name": "u1"
+          }
+        },
+        {
+          "id": 4,
+          "content": "content4",
+          "user": {
+            "id": 3,
+            "name": "u3"
+          }
+        }
+      ]
+    }
+  }

--- a/integration-tests/ownership-access-check/tests/query/all-documents-admin.exotest
+++ b/integration-tests/ownership-access-check/tests/query/all-documents-admin.exotest
@@ -1,6 +1,6 @@
 operation: |
   query {
-    documents {
+    documents @unordered {
       id
       content
       user {

--- a/integration-tests/ownership-access-check/tests/query/all-documents.exotest
+++ b/integration-tests/ownership-access-check/tests/query/all-documents.exotest
@@ -1,0 +1,40 @@
+# Query with a user that can only see his own documents (user 2 owns documents 1 and 2)
+operation: |
+  query {
+    documents { 
+      id
+      content
+      user {
+        id
+        name
+      }
+    }
+  }
+auth: |
+  {
+    "sub": 2,
+    "role": "USER"
+  }
+response: |
+  {
+    "data": {
+      "documents": [
+        {
+          "id": 1,
+          "content": "content1",
+          "user": {
+            "id": 2,
+            "name": "u2"
+          }
+        },
+        {
+          "id": 2,
+          "content": "content2",
+          "user": {
+            "id": 2,
+            "name": "u2"
+          }
+        }
+      ]
+    }
+  }

--- a/integration-tests/ownership-access-check/tests/query/all-documents.exotest
+++ b/integration-tests/ownership-access-check/tests/query/all-documents.exotest
@@ -1,7 +1,7 @@
 # Query with a user that can only see his own documents (user 2 owns documents 1 and 2)
 operation: |
   query {
-    documents { 
+    documents {
       id
       content
       user {

--- a/integration-tests/ownership-access-check/tests/query/all-documents.exotest
+++ b/integration-tests/ownership-access-check/tests/query/all-documents.exotest
@@ -1,7 +1,7 @@
 # Query with a user that can only see his own documents (user 2 owns documents 1 and 2)
 operation: |
   query {
-    documents {
+    documents @unordered {
       id
       content
       user {

--- a/integration-tests/ownership-access-check/tests/query/all-users-admin-with-predicate.exotest
+++ b/integration-tests/ownership-access-check/tests/query/all-users-admin-with-predicate.exotest
@@ -8,14 +8,14 @@ operation: |
         content
       }
     }
-    all_users_with_docs: users(orderBy: {id: ASC}) { 
+    all_users_with_docs: users(orderBy: {id: ASC}) {
       id
       name
       documents(where: {id: {gt: 0}}, orderBy: {id: ASC}) {
         id
         content
       }
-    }    
+    }
   }
 auth: |
   {

--- a/integration-tests/ownership-access-check/tests/query/all-users-admin-with-predicate.exotest
+++ b/integration-tests/ownership-access-check/tests/query/all-users-admin-with-predicate.exotest
@@ -16,6 +16,22 @@ operation: |
         content
       }
     }
+    users_with_doc_1_no_order_by: users(where: {documents: {id: {eq: 1}}}) @unordered {
+      id
+      name
+      documents @unordered{
+        id
+        content
+      }
+    }
+    all_users_with_docs_no_order_by: users @unordered {
+      id
+      name
+      documents(where: {id: {gt: 0}}) @unordered {
+        id
+        content
+      }
+    }    
   }
 auth: |
   {
@@ -85,6 +101,68 @@ response: |
             }
           ]
         }
-      ]
+      ],
+      "all_users_with_docs_no_order_by": [
+        {
+          "id": 1,
+          "name": "u1",
+          "documents": [
+            {
+              "id": 3,
+              "content": "content3"
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "name": "u2",
+          "documents": [
+            {
+              "id": 1,
+              "content": "content1"
+            },
+            {
+              "id": 2,
+              "content": "content2"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "name": "u3",
+          "documents": [
+            {
+              "id": 4,
+              "content": "content4"
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "name": "u4",
+          "documents": []
+        },
+        {
+          "id": 5,
+          "name": "u5",
+          "documents": []
+        }
+      ],
+      "users_with_doc_1_no_order_by": [
+        {
+          "id": 2,
+          "name": "u2",
+          "documents": [
+            {
+              "id": 1,
+              "content": "content1"
+            },
+            {
+              "id": 2,
+              "content": "content2"
+            }
+          ]
+        }
+      ]      
     }
   }

--- a/integration-tests/ownership-access-check/tests/query/all-users-admin-with-predicate.exotest
+++ b/integration-tests/ownership-access-check/tests/query/all-users-admin-with-predicate.exotest
@@ -1,0 +1,90 @@
+operation: |
+  query {
+    users_with_doc_1: users(where: {documents: {id: {eq: 1}}}, orderBy: {id: ASC}) {
+      id
+      name
+      documents(orderBy: {id: ASC}) {
+        id
+        content
+      }
+    }
+    all_users_with_docs: users(orderBy: {id: ASC}) { 
+      id
+      name
+      documents(where: {id: {gt: 0}}, orderBy: {id: ASC}) {
+        id
+        content
+      }
+    }    
+  }
+auth: |
+  {
+    "role": "ADMIN"
+  }
+response: |
+  {
+    "data": {
+      "all_users_with_docs": [
+        {
+          "id": 1,
+          "name": "u1",
+          "documents": [
+            {
+              "id": 3,
+              "content": "content3"
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "name": "u2",
+          "documents": [
+            {
+              "id": 1,
+              "content": "content1"
+            },
+            {
+              "id": 2,
+              "content": "content2"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "name": "u3",
+          "documents": [
+            {
+              "id": 4,
+              "content": "content4"
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "name": "u4",
+          "documents": []
+        },
+        {
+          "id": 5,
+          "name": "u5",
+          "documents": []
+        }
+      ],
+      "users_with_doc_1": [
+        {
+          "id": 2,
+          "name": "u2",
+          "documents": [
+            {
+              "id": 1,
+              "content": "content1"
+            },
+            {
+              "id": 2,
+              "content": "content2"
+            }
+          ]
+        }
+      ]
+    }
+  }

--- a/integration-tests/ownership-access-check/tests/query/all-users-admin.exotest
+++ b/integration-tests/ownership-access-check/tests/query/all-users-admin.exotest
@@ -16,6 +16,22 @@ operation: |
         content
       }
     }
+    all_users_no_order_by: users @unordered {
+      id
+      name
+      documents @unordered {
+        id
+        content
+      }
+    }
+    all_users_predicate_on_docs_no_order_by: users @unordered {
+      id
+      name
+      documents(where: {user: {id: {eq: 2}}}) @unordered {
+        id
+        content
+      }
+    }
   }
 auth: |
   {
@@ -105,6 +121,88 @@ response: |
           "name": "u5",
           "documents": []
         }
-      ]
+      ],
+      "all_users_no_order_by": [
+        {
+          "id": 1,
+          "name": "u1",
+          "documents": [
+            {
+              "id": 3,
+              "content": "content3"
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "name": "u2",
+          "documents": [
+            {
+              "id": 1,
+              "content": "content1"
+            },
+            {
+              "id": 2,
+              "content": "content2"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "name": "u3",
+          "documents": [
+            {
+              "id": 4,
+              "content": "content4"
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "name": "u4",
+          "documents": []
+        },
+        {
+          "id": 5,
+          "name": "u5",
+          "documents": []
+        }
+      ],
+      "all_users_predicate_on_docs_no_order_by": [
+        {
+          "id": 1,
+          "name": "u1",
+          "documents": []
+        },
+        {
+          "id": 2,
+          "name": "u2",
+          "documents": [
+            {
+              "id": 1,
+              "content": "content1"
+            },
+            {
+              "id": 2,
+              "content": "content2"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "name": "u3",
+          "documents": []
+        },
+        {
+          "id": 4,
+          "name": "u4",
+          "documents": []
+        },
+        {
+          "id": 5,
+          "name": "u5",
+          "documents": []
+        }
+      ]      
     }
   }

--- a/integration-tests/ownership-access-check/tests/query/all-users-admin.exotest
+++ b/integration-tests/ownership-access-check/tests/query/all-users-admin.exotest
@@ -1,0 +1,66 @@
+operation: |
+  query {
+    users { 
+      id
+      name
+      documents {
+        id
+        content
+      }
+    }
+  }
+auth: |
+  {
+    "role": "ADMIN"
+  }
+response: |
+  {
+    "data": {
+      "users": [
+        {
+          "id": 1,
+          "name": "u1",
+          "documents": [
+            {
+              "id": 3,
+              "content": "content3"
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "name": "u2",
+          "documents": [
+            {
+              "id": 1,
+              "content": "content1"
+            },
+            {
+              "id": 2,
+              "content": "content2"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "name": "u3",
+          "documents": [
+            {
+              "id": 4,
+              "content": "content4"
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "name": "u4",
+          "documents": []
+        },
+        {
+          "id": 5,
+          "name": "u5",
+          "documents": []
+        }
+      ]
+    }
+  }

--- a/integration-tests/ownership-access-check/tests/query/all-users-admin.exotest
+++ b/integration-tests/ownership-access-check/tests/query/all-users-admin.exotest
@@ -1,9 +1,17 @@
 operation: |
   query {
-    users(orderBy: {id: ASC}) {
+    all_users: users(orderBy: {id: ASC}) {
       id
       name
       documents(orderBy: {id: ASC}) {
+        id
+        content
+      }
+    }
+    all_users_predicate_on_docs: users(orderBy: {id: ASC}) {
+      id
+      name
+      documents(where: {user: {id: {eq: 2}}}, orderBy: {id: ASC}) {
         id
         content
       }
@@ -16,7 +24,7 @@ auth: |
 response: |
   {
     "data": {
-      "users": [
+      "all_users": [
         {
           "id": 1,
           "name": "u1",
@@ -50,6 +58,42 @@ response: |
               "content": "content4"
             }
           ]
+        },
+        {
+          "id": 4,
+          "name": "u4",
+          "documents": []
+        },
+        {
+          "id": 5,
+          "name": "u5",
+          "documents": []
+        }
+      ],
+      "all_users_predicate_on_docs": [
+        {
+          "id": 1,
+          "name": "u1",
+          "documents": []
+        },
+        {
+          "id": 2,
+          "name": "u2",
+          "documents": [
+            {
+              "id": 1,
+              "content": "content1"
+            },
+            {
+              "id": 2,
+              "content": "content2"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "name": "u3",
+          "documents": []
         },
         {
           "id": 4,

--- a/integration-tests/ownership-access-check/tests/query/all-users-admin.exotest
+++ b/integration-tests/ownership-access-check/tests/query/all-users-admin.exotest
@@ -1,9 +1,9 @@
 operation: |
   query {
-    users { 
+    users(orderBy: {id: ASC}) {
       id
       name
-      documents {
+      documents(orderBy: {id: ASC}) {
         id
         content
       }

--- a/integration-tests/ownership-access-check/tests/query/all-users-non-admin-with-predicate.exotest
+++ b/integration-tests/ownership-access-check/tests/query/all-users-non-admin-with-predicate.exotest
@@ -25,6 +25,14 @@ operation: |
         content
       }
     }
+    all_users_predicate_on_docs: users(orderBy: {id: ASC}) {
+      id
+      name
+      documents(where: {user: {id: {eq: 2}}}, orderBy: {id: ASC}) {
+        id
+        content
+      }
+    }
   }
 auth: |
   {
@@ -92,6 +100,43 @@ response: |
             }
           ]
         }
+      ],
+      "all_users_predicate_on_docs": [
+        {
+          "id": 1,
+          "name": "u1",
+          "documents": []
+        },
+        {
+          "id": 2,
+          "name": "u2",
+          "documents": [
+            {
+              "id": 1,
+              "content": "content1"
+            },
+            {
+              "id": 2,
+              "content": "content2"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "name": "u3",
+          "documents": []
+        },
+        {
+          "id": 4,
+          "name": "u4",
+          "documents": []
+        },
+        {
+          "id": 5,
+          "name": "u5",
+          "documents": []
+        }
       ]
-    }
+    }      
   }
+  

--- a/integration-tests/ownership-access-check/tests/query/all-users-non-admin-with-predicate.exotest
+++ b/integration-tests/ownership-access-check/tests/query/all-users-non-admin-with-predicate.exotest
@@ -1,0 +1,97 @@
+operation: |
+  query {
+    users_with_doc_1: users(where: {documents: {id: {eq: 1}}}, orderBy: {id: ASC}) { 
+      id
+      name
+      documents(orderBy: {id: ASC}) {
+        id
+        content
+      }
+    }
+    # This users doesn't own doc 3, so the user who holds the doc will be returned, but not the doc (`User` has `@access(true)`)
+    users_with_doc_3: users(where: {documents: {id: {eq: 3}}}, orderBy: {id: ASC}) { 
+      id
+      name
+      documents(orderBy: {id: ASC}) {
+        id
+        content
+      }
+    }
+    all_users_with_docs: users(orderBy: {id: ASC}) { 
+      id
+      name
+      documents(where: {id: {gt: 0}}, orderBy: {id: ASC}) {
+        id
+        content
+      }
+    }    
+  }
+auth: |
+  {
+    "sub": 2,
+    "role": "USER"
+  }
+response: |
+  {
+    "data": {
+      "users_with_doc_3": [
+        {
+          "id": 1,
+          "name": "u1",
+          "documents": []
+        }
+      ],
+      "all_users_with_docs": [
+        {
+          "id": 1,
+          "name": "u1",
+          "documents": []
+        },
+        {
+          "id": 2,
+          "name": "u2",
+          "documents": [
+            {
+              "id": 1,
+              "content": "content1"
+            },
+            {
+              "id": 2,
+              "content": "content2"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "name": "u3",
+          "documents": []
+        },
+        {
+          "id": 4,
+          "name": "u4",
+          "documents": []
+        },
+        {
+          "id": 5,
+          "name": "u5",
+          "documents": []
+        }
+      ],
+      "users_with_doc_1": [
+        {
+          "id": 2,
+          "name": "u2",
+          "documents": [
+            {
+              "id": 1,
+              "content": "content1"
+            },
+            {
+              "id": 2,
+              "content": "content2"
+            }
+          ]
+        }
+      ]
+    }
+  }

--- a/integration-tests/ownership-access-check/tests/query/all-users-non-admin-with-predicate.exotest
+++ b/integration-tests/ownership-access-check/tests/query/all-users-non-admin-with-predicate.exotest
@@ -8,7 +8,7 @@ operation: |
         content
       }
     }
-    # This users doesn't own doc 3, so the user who holds the doc will be returned, but not the doc (`User` has `@access(true)`)
+    # This users doesn't own doc 3, so the user who holds the doc will be returned, but not the documents (`User` has `@access(true)`)
     users_with_doc_3: users(where: {documents: {id: {eq: 3}}}, orderBy: {id: ASC}) {
       id
       name
@@ -33,6 +33,39 @@ operation: |
         content
       }
     }
+    users_with_doc_1_no_order_by: users(where: {documents: {id: {eq: 1}}}) @unordered {
+      id
+      name
+      documents @unordered {
+        id
+        content
+      }
+    }
+    # This users doesn't own doc 3, so the user who holds the doc will be returned, but not the documents (`User` has `@access(true)`)
+    users_with_doc_3_no_order_by: users(where: {documents: {id: {eq: 3}}}) @unordered {
+      id
+      name
+      documents @unordered {
+        id
+        content
+      }
+    }
+    all_users_with_docs_no_order_by: users @unordered {
+      id
+      name
+      documents(where: {id: {gt: 0}}) @unordered {
+        id
+        content
+      }
+    }
+    all_users_predicate_on_docs_no_order_by: users @unordered {
+      id
+      name
+      documents(where: {user: {id: {eq: 2}}}) @unordered {
+        id
+        content
+      }
+    }    
   }
 auth: |
   {
@@ -136,7 +169,102 @@ response: |
           "name": "u5",
           "documents": []
         }
-      ]
+      ],
+      "users_with_doc_3_no_order_by": [
+        {
+          "id": 1,
+          "name": "u1",
+          "documents": []
+        }
+      ],
+      "all_users_with_docs_no_order_by": [
+        {
+          "id": 1,
+          "name": "u1",
+          "documents": []
+        },
+        {
+          "id": 2,
+          "name": "u2",
+          "documents": [
+            {
+              "id": 1,
+              "content": "content1"
+            },
+            {
+              "id": 2,
+              "content": "content2"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "name": "u3",
+          "documents": []
+        },
+        {
+          "id": 4,
+          "name": "u4",
+          "documents": []
+        },
+        {
+          "id": 5,
+          "name": "u5",
+          "documents": []
+        }
+      ],
+      "users_with_doc_1_no_order_by": [
+        {
+          "id": 2,
+          "name": "u2",
+          "documents": [
+            {
+              "id": 1,
+              "content": "content1"
+            },
+            {
+              "id": 2,
+              "content": "content2"
+            }
+          ]
+        }
+      ],
+      "all_users_predicate_on_docs_no_order_by": [
+        {
+          "id": 1,
+          "name": "u1",
+          "documents": []
+        },
+        {
+          "id": 2,
+          "name": "u2",
+          "documents": [
+            {
+              "id": 1,
+              "content": "content1"
+            },
+            {
+              "id": 2,
+              "content": "content2"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "name": "u3",
+          "documents": []
+        },
+        {
+          "id": 4,
+          "name": "u4",
+          "documents": []
+        },
+        {
+          "id": 5,
+          "name": "u5",
+          "documents": []
+        }
+      ]      
     }      
   }
   

--- a/integration-tests/ownership-access-check/tests/query/all-users-non-admin-with-predicate.exotest
+++ b/integration-tests/ownership-access-check/tests/query/all-users-non-admin-with-predicate.exotest
@@ -1,6 +1,6 @@
 operation: |
   query {
-    users_with_doc_1: users(where: {documents: {id: {eq: 1}}}, orderBy: {id: ASC}) { 
+    users_with_doc_1: users(where: {documents: {id: {eq: 1}}}, orderBy: {id: ASC}) {
       id
       name
       documents(orderBy: {id: ASC}) {
@@ -9,7 +9,7 @@ operation: |
       }
     }
     # This users doesn't own doc 3, so the user who holds the doc will be returned, but not the doc (`User` has `@access(true)`)
-    users_with_doc_3: users(where: {documents: {id: {eq: 3}}}, orderBy: {id: ASC}) { 
+    users_with_doc_3: users(where: {documents: {id: {eq: 3}}}, orderBy: {id: ASC}) {
       id
       name
       documents(orderBy: {id: ASC}) {
@@ -17,14 +17,14 @@ operation: |
         content
       }
     }
-    all_users_with_docs: users(orderBy: {id: ASC}) { 
+    all_users_with_docs: users(orderBy: {id: ASC}) {
       id
       name
       documents(where: {id: {gt: 0}}, orderBy: {id: ASC}) {
         id
         content
       }
-    }    
+    }
   }
 auth: |
   {

--- a/integration-tests/ownership-access-check/tests/query/all-users-non-admin.exotest
+++ b/integration-tests/ownership-access-check/tests/query/all-users-non-admin.exotest
@@ -8,6 +8,14 @@ operation: |
         content
       }
     }
+    users_no_order_by: users @unordered {
+      id
+      name
+      documents @unordered {
+        id
+        content
+      }
+    }
   }
 auth: |
   {
@@ -56,6 +64,46 @@ response: |
           "documents": [
           ]
         }
-      ]
+      ],
+      "users_no_order_by": [
+        {
+          "id": 1,
+          "name": "u1",
+          "documents": [
+          ]
+        },
+        {
+          "id": 2,
+          "name": "u2",
+          "documents": [
+            {
+              "id": 1,
+              "content": "content1",
+            },
+            {
+              "id": 2,
+              "content": "content2",
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "name": "u3",
+          "documents": [
+          ]
+        },
+        {
+          "id": 4,
+          "name": "u4",
+          "documents": [
+          ]
+        },
+        {
+          "id": 5,
+          "name": "u5",
+          "documents": [
+          ]
+        }
+      ]      
     }
   }

--- a/integration-tests/ownership-access-check/tests/query/all-users-non-admin.exotest
+++ b/integration-tests/ownership-access-check/tests/query/all-users-non-admin.exotest
@@ -1,6 +1,6 @@
 operation: |
   query {
-    users(orderBy: {id: ASC}) { 
+    users(orderBy: {id: ASC}) {
       id
       name
       documents(orderBy: {id: ASC}) {

--- a/integration-tests/ownership-access-check/tests/query/all-users-non-admin.exotest
+++ b/integration-tests/ownership-access-check/tests/query/all-users-non-admin.exotest
@@ -1,9 +1,9 @@
 operation: |
   query {
-    users { 
+    users(orderBy: {id: ASC}) { 
       id
       name
-      documents {
+      documents(orderBy: {id: ASC}) {
         id
         content
       }

--- a/integration-tests/ownership-access-check/tests/query/all-users.exotest
+++ b/integration-tests/ownership-access-check/tests/query/all-users.exotest
@@ -1,0 +1,61 @@
+operation: |
+  query {
+    users { 
+      id
+      name
+      documents {
+        id
+        content
+      }
+    }
+  }
+auth: |
+  {
+    "sub": 2,
+    "role": "USER"
+  }
+response: |
+  {
+    "data": {
+      "users": [
+        {
+          "id": 1,
+          "name": "u1",
+          "documents": [
+          ]
+        },
+        {
+          "id": 2,
+          "name": "u2",
+          "documents": [
+            {
+              "id": 1,
+              "content": "content1",
+            },
+            {
+              "id": 2,
+              "content": "content2",
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "name": "u3",
+          "documents": [
+          ]
+        },
+        {
+          "id": 4,
+          "name": "u4",
+          "documents": [
+          ]
+        },
+        {
+          "id": 5,
+          "name": "u5",
+          "documents": [
+          ]
+        }
+      ]
+    }
+  }

--- a/integration-tests/ownership-access-check/tests/update/indirect-update.exotest
+++ b/integration-tests/ownership-access-check/tests/update/indirect-update.exotest
@@ -65,7 +65,7 @@ stages:
   # Ensure that the earlier mutation did work
   - operation: |
       query {
-        allDocs: documents(orderBy: {id: ASC}) {
+        allDocs: documents @unordered {
           id
           content
           user {
@@ -73,7 +73,7 @@ stages:
             name
           }
         }
-        allUsers: users(orderBy: {id: ASC}) {
+        allUsers: users @unordered {
           id
           name
           documents {

--- a/integration-tests/ownership-access-check/tests/update/indirect-update.exotest
+++ b/integration-tests/ownership-access-check/tests/update/indirect-update.exotest
@@ -3,7 +3,7 @@ stages:
   - operation: |
       mutation {
         # Update all documents through user, but implicitly only if the user owns them
-        # Note that in this example (in practice, unrealistically, but appropriate for testing) there is no access control for the User type
+        # Note that in this example (in practice, unrealistically, but appropriate for testing) `User` has `@access(true)`
         updateUsers(where: {id: {gt: 0}}, data: {name: "updated-user2", documents: {update: {id: 1, content: "indirect-update"}}}) { 
           id
           name

--- a/integration-tests/ownership-access-check/tests/update/indirect-update.exotest
+++ b/integration-tests/ownership-access-check/tests/update/indirect-update.exotest
@@ -28,15 +28,7 @@ stages:
             {
               "id": 1,
               "name": "updated-user2",
-              "documents": [
-                {
-                  "id": 2,
-                  "content": "content2",
-                  "user": {
-                    "id": 2
-                  }
-                }
-              ]
+              "documents": []
             },
             {
               "id": 2,
@@ -54,54 +46,39 @@ stages:
             {
               "id": 3,
               "name": "updated-user2",
-              "documents": [
-                {
-                  "id": 2,
-                  "content": "content2",
-                  "user": {
-                    "id": 2
-                  }
-                }
-              ]
+              "documents": []
             },
             {
               "id": 4,
               "name": "updated-user2",
-              "documents": [
-                {
-                  "id": 2,
-                  "content": "content2",
-                  "user": {
-                    "id": 2
-                  }
-                }
-              ]
+              "documents": []
             },
             {
               "id": 5,
               "name": "updated-user2",
-              "documents": [
-                {
-                  "id": 2,
-                  "content": "content2",
-                  "user": {
-                    "id": 2
-                  }
-                }
-              ]
+              "documents": []
             }
           ]
         }
       }
+
   # Ensure that the earlier mutation did work
   - operation: |
       query {
-        documents(orderBy: {id: ASC}) {
+        allDocs: documents(orderBy: {id: ASC}) {
           id
           content
           user {
             id
             name
+          }
+        }
+        allUsers: users(orderBy: {id: ASC}) {
+          id
+          name
+          documents {
+            id
+            content
           }
         }
       }
@@ -112,7 +89,54 @@ stages:
     response: |
       {
         "data": {
-          "documents": [
+          "allUsers": [
+            {
+              "id": 1,
+              "name": "updated-user2",
+              "documents": [
+                {
+                  "id": 3,
+                  "content": "content3"
+                }
+              ]
+            },
+            {
+              "id": 2,
+              "name": "updated-user2",
+              "documents": [
+                {
+                  "id": 2,
+                  "content": "content2"
+                }
+              ]
+            },
+            {
+              "id": 3,
+              "name": "updated-user2",
+              "documents": [
+                {
+                  "id": 4,
+                  "content": "content4"
+                }
+              ]
+            },
+            {
+              "id": 4,
+              "name": "updated-user2",
+              "documents": []
+            },
+            {
+              "id": 5,
+              "name": "updated-user2",
+              "documents": [
+                {
+                  "id": 1,
+                  "content": "indirect-update"
+                }
+              ]
+            }
+          ],
+          "allDocs": [
             {
               "id": 1,
               "content": "indirect-update",

--- a/libs/exo-sql/src/asql/column_path.rs
+++ b/libs/exo-sql/src/asql/column_path.rs
@@ -209,6 +209,7 @@ impl PhysicalColumnPath {
         self
     }
 
+    #[cfg(test)]
     pub fn from_columns(columns: Vec<ColumnId>, database: &Database) -> Self {
         assert!(
             !columns.is_empty(),

--- a/libs/exo-sql/src/sql/relation.rs
+++ b/libs/exo-sql/src/sql/relation.rs
@@ -12,6 +12,9 @@ pub struct OneToMany {
 pub struct ManyToOne {
     pub self_column_id: ColumnId,
     pub foreign_pk_column_id: ColumnId,
+    /// A name that may be used to alias the foreign table. This is useful when
+    /// multiple columns in a table refer to the same foreign table. For example,
+    /// `concerts` may have a `main_venue_id` and a `alt_venue_id`.
     pub foreign_table_alias: Option<String>,
 }
 
@@ -38,6 +41,7 @@ impl ManyToOne {
     }
 }
 
+/// Many to one id, which is an index into the `Database.relations` vector
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct ManyToOneId(pub(crate) usize);
 
@@ -47,6 +51,7 @@ impl ManyToOneId {
     }
 }
 
+/// One to many id, which refers to its corresponding many to one id (`Database` keeps track of only the many to one id)
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct OneToManyId(pub(crate) ManyToOneId);
 

--- a/libs/exo-sql/src/transform/join_util.rs
+++ b/libs/exo-sql/src/transform/join_util.rs
@@ -11,13 +11,13 @@ use crate::{
     asql::column_path::{ColumnPathLink, RelationLink},
     sql::{column::Column, join::LeftJoin, predicate::ConcretePredicate, table::Table},
     transform::{
-        pg::make_alias,
+        pg::selection_level::make_alias,
         table_dependency::{DependencyLink, TableDependency},
     },
     Database, PhysicalColumnPath, TableId,
 };
 
-use super::pg::SelectionLevel;
+use super::pg::selection_level::SelectionLevel;
 
 /// Compute the join needed to access the leaf columns of a list of column paths. Will return a
 /// `Table::Physical` if there are no dependencies to join otherwise a `Table::Join`.
@@ -39,6 +39,7 @@ pub fn compute_join(
             selection_level_alias,
         );
 
+        // We don't use the alias for the top level table in predicate either, so match the behavior here
         let init_table = {
             Table::physical(
                 dependency.table_id,
@@ -95,7 +96,7 @@ pub fn compute_join(
 mod tests {
     use crate::{
         sql::ExpressionBuilder,
-        transform::{pg::SelectionLevel, test_util::TestSetup},
+        transform::{pg::selection_level::SelectionLevel, test_util::TestSetup},
         PhysicalColumnPath,
     };
 

--- a/libs/exo-sql/src/transform/pg/delete_transformer.rs
+++ b/libs/exo-sql/src/transform/pg/delete_transformer.rs
@@ -21,7 +21,7 @@ use crate::{
     Database,
 };
 
-use super::Postgres;
+use super::{Postgres, SelectionLevel};
 
 impl DeleteTransformer for Postgres {
     #[instrument(
@@ -63,7 +63,12 @@ impl DeleteTransformer for Postgres {
         // ```
         // We need a subselect because the target of a DELETE statement must be a physical table,
         // not a join.
-        let predicate = self.to_predicate(&abstract_delete.predicate, false, database);
+        let predicate = self.to_predicate(
+            &abstract_delete.predicate,
+            &SelectionLevel::TopLevel,
+            false,
+            database,
+        );
 
         // The root delete operation returning all columns of the table being deleted. This will be
         // later used as a CTE.

--- a/libs/exo-sql/src/transform/pg/delete_transformer.rs
+++ b/libs/exo-sql/src/transform/pg/delete_transformer.rs
@@ -21,7 +21,7 @@ use crate::{
     Database,
 };
 
-use super::{Postgres, SelectionLevel};
+use super::{selection_level::SelectionLevel, Postgres};
 
 impl DeleteTransformer for Postgres {
     #[instrument(

--- a/libs/exo-sql/src/transform/pg/mod.rs
+++ b/libs/exo-sql/src/transform/pg/mod.rs
@@ -7,76 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::{Database, RelationId};
-
-pub mod delete_transformer;
+mod delete_transformer;
 mod insert_transformer;
 mod order_by_transformer;
 mod predicate_transformer;
 mod select;
 mod update_transformer;
 
+pub mod selection_level;
+
 pub struct Postgres {}
-
-#[derive(Debug, Clone)]
-pub enum SelectionLevel {
-    /// Top level selection
-    TopLevel,
-    /// Nested sub selection, which each element representing the relation between parent and child selection
-    /// For example, if we have a query like: `concerts { venue { .. }}`, the selection level for the venue
-    /// selection will be `Nested(vec![RelationId::ManyToOne(<venues.id, concerts.venue_id>)])`.
-    Nested(Vec<RelationId>),
-}
-
-impl SelectionLevel {
-    fn is_top_level(&self) -> bool {
-        matches!(self, SelectionLevel::TopLevel)
-    }
-
-    fn with_relation_id(&self, relation_id: RelationId) -> Self {
-        match self {
-            SelectionLevel::TopLevel => SelectionLevel::Nested(vec![relation_id]),
-            SelectionLevel::Nested(relation_ids) => {
-                let mut relation_ids = relation_ids.clone();
-                relation_ids.push(relation_id);
-                SelectionLevel::Nested(relation_ids)
-            }
-        }
-    }
-
-    pub fn tail_relation_id(&self) -> Option<&RelationId> {
-        match self {
-            SelectionLevel::TopLevel => None,
-            SelectionLevel::Nested(relation_ids) => relation_ids.last(),
-        }
-    }
-
-    pub fn alias(&self, database: &Database) -> Option<String> {
-        match self {
-            SelectionLevel::TopLevel => None,
-            SelectionLevel::Nested(relation_ids) => {
-                Some(relation_ids.iter().fold(String::new(), |acc, relation_id| {
-                    let foreign_table_id = match relation_id {
-                        RelationId::ManyToOne(r) => r.deref(database).self_column_id.table_id,
-                        RelationId::OneToMany(r) => r.deref(database).self_pk_column_id.table_id,
-                    };
-                    let name = &database.get_table(foreign_table_id).name;
-                    join_alias_components(&acc, name)
-                }))
-            }
-        }
-    }
-}
-
-const ALIAS_SEPARATOR: &str = "$";
-
-pub fn make_alias(name: &str, context_name: &Option<String>) -> String {
-    match context_name {
-        Some(ref context_name) => join_alias_components(context_name, name),
-        None => name.to_owned(),
-    }
-}
-
-fn join_alias_components(context_name: &str, name: &str) -> String {
-    format!("{context_name}{ALIAS_SEPARATOR}{name}")
-}

--- a/libs/exo-sql/src/transform/pg/mod.rs
+++ b/libs/exo-sql/src/transform/pg/mod.rs
@@ -44,6 +44,13 @@ impl SelectionLevel {
         }
     }
 
+    pub fn tail_relation_id(&self) -> Option<&RelationId> {
+        match self {
+            SelectionLevel::TopLevel => None,
+            SelectionLevel::Nested(relation_ids) => relation_ids.last(),
+        }
+    }
+
     pub fn alias(&self, database: &Database) -> Option<String> {
         match self {
             SelectionLevel::TopLevel => None,

--- a/libs/exo-sql/src/transform/pg/mod.rs
+++ b/libs/exo-sql/src/transform/pg/mod.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use crate::RelationId;
+
 pub mod delete_transformer;
 mod insert_transformer;
 mod order_by_transformer;
@@ -16,8 +18,29 @@ mod update_transformer;
 
 pub struct Postgres {}
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub enum SelectionLevel {
+    /// Top level selection
     TopLevel,
-    Nested,
+    /// Nested sub selection, which each element representing the relation between parent and child selection
+    /// For example, if we have a query like: `concerts { venue { .. }}`, the selection level for the venue
+    /// selection will be `Nested(vec![RelationId::ManyToOne(<venues.id, concerts.venue_id>)])`.
+    Nested(Vec<RelationId>),
+}
+
+impl SelectionLevel {
+    fn is_top_level(&self) -> bool {
+        matches!(self, SelectionLevel::TopLevel)
+    }
+
+    fn with_relation_id(&self, relation_id: RelationId) -> Self {
+        match self {
+            SelectionLevel::TopLevel => SelectionLevel::Nested(vec![relation_id]),
+            SelectionLevel::Nested(relation_ids) => {
+                let mut relation_ids = relation_ids.clone();
+                relation_ids.push(relation_id);
+                SelectionLevel::Nested(relation_ids)
+            }
+        }
+    }
 }

--- a/libs/exo-sql/src/transform/pg/predicate_transformer.rs
+++ b/libs/exo-sql/src/transform/pg/predicate_transformer.rs
@@ -10,12 +10,12 @@
 use crate::{
     asql::column_path::{ColumnPathLink, RelationLink},
     sql::predicate::ConcretePredicate,
-    transform::{pg::SelectionLevel, transformer::PredicateTransformer},
+    transform::{pg::selection_level::SelectionLevel, transformer::PredicateTransformer},
     AbstractPredicate, AbstractSelect, AliasedSelectionElement, Column, ColumnPath, Database,
     PhysicalColumnPath, Selection, SelectionElement,
 };
 
-use super::{make_alias, Postgres};
+use super::{selection_level::make_alias, Postgres};
 
 impl PredicateTransformer for Postgres {
     fn to_predicate(

--- a/libs/exo-sql/src/transform/pg/predicate_transformer.rs
+++ b/libs/exo-sql/src/transform/pg/predicate_transformer.rs
@@ -18,12 +18,6 @@ use crate::{
 use super::{make_alias, Postgres};
 
 impl PredicateTransformer for Postgres {
-    /// Transform an abstract predicate into a concrete predicate
-    ///
-    /// # Arguments
-    /// * `predicate` - The predicate to transform
-    /// * `tables_supplied` - Whether the tables are already in context. If they are, the predicate can simply use the table.column syntax.
-    ///                       If they are not, the predicate will need to bring in the tables being referred to.
     fn to_predicate(
         &self,
         predicate: &AbstractPredicate,

--- a/libs/exo-sql/src/transform/pg/predicate_transformer.rs
+++ b/libs/exo-sql/src/transform/pg/predicate_transformer.rs
@@ -158,8 +158,7 @@ fn to_subselect_predicate(
 
                     let select = select_transformer.compute_select(
                         &abstract_select,
-                        None,
-                        SelectionLevel::Nested,
+                        &SelectionLevel::TopLevel,
                         true, // allow duplicate rows to be returned since this is going to be used as a part of `IN`
                         database,
                     );

--- a/libs/exo-sql/src/transform/pg/select/plain_join_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/select/plain_join_strategy.rs
@@ -7,11 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::{
-    sql::select::Select,
-    transform::{pg::SelectionLevel, transformer::OrderByTransformer},
-    Database, Selection,
-};
+use crate::{sql::select::Select, transform::transformer::OrderByTransformer, Database, Selection};
 
 use super::{
     selection_context::SelectionContext,
@@ -98,11 +94,7 @@ impl SelectionStrategy for PlainJoinStrategy {
         }
     }
 
-    fn to_select<'a>(
-        &self,
-        selection_context: SelectionContext<'_, 'a>,
-        database: &'a Database,
-    ) -> Select {
+    fn to_select(&self, selection_context: SelectionContext<'_>, database: &Database) -> Select {
         let SelectionContext {
             abstract_select,
             additional_predicate,
@@ -123,9 +115,10 @@ impl SelectionStrategy for PlainJoinStrategy {
             database,
         );
 
-        let selection_aggregate = abstract_select
-            .selection
-            .selection_aggregate(transformer, database);
+        let selection_aggregate =
+            abstract_select
+                .selection
+                .selection_aggregate(selection_level, transformer, database);
 
         Select {
             table: join,
@@ -138,7 +131,7 @@ impl SelectionStrategy for PlainJoinStrategy {
             offset: abstract_select.offset.clone(),
             limit: abstract_select.limit.clone(),
             group_by: None,
-            top_level_selection: selection_level == SelectionLevel::TopLevel,
+            top_level_selection: selection_level.is_top_level(),
         }
     }
 }

--- a/libs/exo-sql/src/transform/pg/select/plain_join_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/select/plain_join_strategy.rs
@@ -97,10 +97,9 @@ impl SelectionStrategy for PlainJoinStrategy {
     fn to_select(&self, selection_context: SelectionContext<'_>, database: &Database) -> Select {
         let SelectionContext {
             abstract_select,
-            additional_predicate,
+            selection_level,
             predicate_column_paths,
             order_by_column_paths,
-            selection_level,
             transformer,
             ..
         } = selection_context;
@@ -110,7 +109,7 @@ impl SelectionStrategy for PlainJoinStrategy {
             &abstract_select.predicate,
             predicate_column_paths,
             order_by_column_paths,
-            additional_predicate,
+            selection_level,
             transformer,
             database,
         );

--- a/libs/exo-sql/src/transform/pg/select/plain_subquery_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/select/plain_subquery_strategy.rs
@@ -68,13 +68,8 @@ impl SelectionStrategy for PlainSubqueryStrategy {
         !selection_context.has_a_one_to_many_predicate || selection_context.allow_duplicate_rows
     }
 
-    fn to_select(
-        &self,
-        selection_context: SelectionContext<'_, '_>,
-        _database: &Database,
-    ) -> Select {
+    fn to_select(&self, selection_context: SelectionContext<'_>, database: &Database) -> Select {
         let SelectionContext {
-            database,
             abstract_select,
             additional_predicate,
             selection_level,

--- a/libs/exo-sql/src/transform/pg/select/plain_subquery_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/select/plain_subquery_strategy.rs
@@ -71,7 +71,6 @@ impl SelectionStrategy for PlainSubqueryStrategy {
     fn to_select(&self, selection_context: SelectionContext<'_>, database: &Database) -> Select {
         let SelectionContext {
             abstract_select,
-            additional_predicate,
             selection_level,
             predicate_column_paths,
             order_by_column_paths,
@@ -84,7 +83,7 @@ impl SelectionStrategy for PlainSubqueryStrategy {
             &abstract_select.predicate,
             predicate_column_paths,
             order_by_column_paths,
-            additional_predicate,
+            selection_level,
             transformer,
             database,
         );

--- a/libs/exo-sql/src/transform/pg/select/select_transformer.rs
+++ b/libs/exo-sql/src/transform/pg/select/select_transformer.rs
@@ -12,13 +12,12 @@ use tracing::instrument;
 use crate::{
     asql::select::AbstractSelect,
     sql::{
-        predicate::ConcretePredicate,
         select::Select,
         sql_operation::SQLOperation,
         transaction::{ConcreteTransactionStep, TransactionScript, TransactionStep},
     },
     transform::{pg::SelectionLevel, transformer::SelectTransformer},
-    Column, Database, ManyToOne, OneToMany, RelationId,
+    Database,
 };
 
 use super::{
@@ -140,40 +139,9 @@ impl Postgres {
         allow_duplicate_rows: bool,
         database: &Database,
     ) -> Select {
-        let subselect_relation = match selection_level {
-            SelectionLevel::TopLevel => None,
-            SelectionLevel::Nested(relation_ids) => relation_ids.last().copied(),
-        };
-        let additional_predicate = subselect_relation.map(|relation_id| {
-            let (self_column_id, foreign_column_id) = match relation_id {
-                RelationId::OneToMany(relation_id) => {
-                    let OneToMany {
-                        self_pk_column_id,
-                        foreign_column_id,
-                    } = relation_id.deref(database);
-
-                    (self_pk_column_id, foreign_column_id)
-                }
-                RelationId::ManyToOne(relation_id) => {
-                    let ManyToOne {
-                        self_column_id,
-                        foreign_pk_column_id,
-                        ..
-                    } = relation_id.deref(database);
-                    (self_column_id, foreign_pk_column_id)
-                }
-            };
-
-            ConcretePredicate::Eq(
-                Column::physical(self_column_id, None),
-                Column::physical(foreign_column_id, None),
-            )
-        });
-
         let selection_context = SelectionContext::new(
             database,
             abstract_select,
-            additional_predicate,
             selection_level,
             allow_duplicate_rows,
             self,

--- a/libs/exo-sql/src/transform/pg/select/select_transformer.rs
+++ b/libs/exo-sql/src/transform/pg/select/select_transformer.rs
@@ -16,7 +16,7 @@ use crate::{
         sql_operation::SQLOperation,
         transaction::{ConcreteTransactionStep, TransactionScript, TransactionStep},
     },
-    transform::{pg::SelectionLevel, transformer::SelectTransformer},
+    transform::{pg::selection_level::SelectionLevel, transformer::SelectTransformer},
     Database,
 };
 

--- a/libs/exo-sql/src/transform/pg/select/selection.rs
+++ b/libs/exo-sql/src/transform/pg/select/selection.rs
@@ -12,7 +12,7 @@ use crate::{
         json_agg::JsonAgg,
         json_object::{JsonObject, JsonObjectElement},
     },
-    transform::pg::{Postgres, SelectionLevel},
+    transform::pg::{selection_level::SelectionLevel, Postgres},
     AliasedSelectionElement, Column, Database, Selection, SelectionCardinality, SelectionElement,
 };
 

--- a/libs/exo-sql/src/transform/pg/select/selection_context.rs
+++ b/libs/exo-sql/src/transform/pg/select/selection_context.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use crate::{
-    transform::pg::{Postgres, SelectionLevel},
+    transform::pg::{selection_level::SelectionLevel, Postgres},
     AbstractSelect, ColumnPath, Database, PhysicalColumnPath,
 };
 

--- a/libs/exo-sql/src/transform/pg/select/selection_context.rs
+++ b/libs/exo-sql/src/transform/pg/select/selection_context.rs
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0.
 
 use crate::{
-    sql::predicate::ConcretePredicate,
     transform::pg::{Postgres, SelectionLevel},
     AbstractSelect, ColumnPath, Database, PhysicalColumnPath,
 };
@@ -20,7 +19,6 @@ pub(crate) struct SelectionContext<'c> {
     pub has_a_one_to_many_predicate: bool,
     pub predicate_column_paths: Vec<PhysicalColumnPath>,
     pub order_by_column_paths: Vec<PhysicalColumnPath>,
-    pub additional_predicate: Option<ConcretePredicate>,
     pub selection_level: &'c SelectionLevel,
     pub allow_duplicate_rows: bool,
     pub transformer: &'c Postgres,
@@ -30,7 +28,6 @@ impl<'c> SelectionContext<'c> {
     pub fn new(
         database: &Database,
         abstract_select: &'c AbstractSelect,
-        additional_predicate: Option<ConcretePredicate>,
         selection_level: &'c SelectionLevel,
         allow_duplicate_rows: bool,
         transformer: &'c Postgres,
@@ -71,7 +68,6 @@ impl<'c> SelectionContext<'c> {
             has_a_one_to_many_predicate,
             predicate_column_paths,
             order_by_column_paths,
-            additional_predicate,
             selection_level,
             allow_duplicate_rows,
             transformer,

--- a/libs/exo-sql/src/transform/pg/select/selection_context.rs
+++ b/libs/exo-sql/src/transform/pg/select/selection_context.rs
@@ -15,24 +15,23 @@ use crate::{
 
 /// A context for the selection transformation to avoid repeating the same work
 /// by each strategy.
-pub(crate) struct SelectionContext<'c, 'a> {
-    pub database: &'a Database,
+pub(crate) struct SelectionContext<'c> {
     pub abstract_select: &'c AbstractSelect,
     pub has_a_one_to_many_predicate: bool,
     pub predicate_column_paths: Vec<PhysicalColumnPath>,
     pub order_by_column_paths: Vec<PhysicalColumnPath>,
     pub additional_predicate: Option<ConcretePredicate>,
-    pub selection_level: SelectionLevel,
+    pub selection_level: &'c SelectionLevel,
     pub allow_duplicate_rows: bool,
     pub transformer: &'c Postgres,
 }
 
-impl<'c, 'a> SelectionContext<'c, 'a> {
+impl<'c> SelectionContext<'c> {
     pub fn new(
-        database: &'a Database,
+        database: &Database,
         abstract_select: &'c AbstractSelect,
         additional_predicate: Option<ConcretePredicate>,
-        selection_level: SelectionLevel,
+        selection_level: &'c SelectionLevel,
         allow_duplicate_rows: bool,
         transformer: &'c Postgres,
     ) -> Self {
@@ -68,7 +67,6 @@ impl<'c, 'a> SelectionContext<'c, 'a> {
             .any(|path| path.has_one_to_many(database));
 
         Self {
-            database,
             abstract_select,
             has_a_one_to_many_predicate,
             predicate_column_paths,

--- a/libs/exo-sql/src/transform/pg/select/selection_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/select/selection_strategy.rs
@@ -125,8 +125,11 @@ pub(super) fn join_info(
         .unwrap_or(selection_level);
 
     let predicate = transformer.to_predicate(predicate, predicate_selection_level, true, database);
-    let relation_predicate =
-        compute_relation_predicate(selection_level, matches!(join, Table::Join(_)), database);
+    let relation_predicate = compute_relation_predicate(
+        predicate_selection_level,
+        matches!(join, Table::Join(_)),
+        database,
+    );
 
     let predicate = ConcretePredicate::and(predicate, relation_predicate);
 

--- a/libs/exo-sql/src/transform/pg/select/selection_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/select/selection_strategy.rs
@@ -38,11 +38,7 @@ pub(crate) trait SelectionStrategy {
     fn suitable(&self, selection_context: &SelectionContext) -> bool;
 
     /// Computes the SQL query for the given selection context. If a strategy
-    fn to_select<'a>(
-        &self,
-        selection_context: SelectionContext<'_, 'a>,
-        database: &'a Database,
-    ) -> Select;
+    fn to_select(&self, selection_context: SelectionContext<'_>, database: &Database) -> Select;
 }
 
 /// Compute an inner select that picks up all the columns from the given table, and applies the
@@ -76,12 +72,12 @@ pub(super) fn compute_inner_select(
 pub(super) fn nest_subselect(
     inner_select: Select,
     selection: &Selection,
-    selection_level: SelectionLevel,
+    selection_level: &SelectionLevel,
     alias: &str,
     transformer: &Postgres,
     database: &Database,
 ) -> Select {
-    let selection_aggregate = selection.selection_aggregate(transformer, database);
+    let selection_aggregate = selection.selection_aggregate(selection_level, transformer, database);
 
     Select {
         table: Table::SubSelect {
@@ -94,7 +90,7 @@ pub(super) fn nest_subselect(
         offset: None,
         limit: None,
         group_by: None,
-        top_level_selection: selection_level == SelectionLevel::TopLevel,
+        top_level_selection: selection_level.is_top_level(),
     }
 }
 

--- a/libs/exo-sql/src/transform/pg/select/selection_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/select/selection_strategy.rs
@@ -11,7 +11,10 @@ use crate::{
     sql::{predicate::ConcretePredicate, select::Select, table::Table},
     transform::{
         join_util,
-        pg::{make_alias, Postgres, SelectionLevel},
+        pg::{
+            selection_level::{make_alias, SelectionLevel},
+            Postgres,
+        },
         transformer::{OrderByTransformer, PredicateTransformer},
     },
     AbstractOrderBy, AbstractPredicate, Column, Database, Limit, ManyToOne, Offset, OneToMany,

--- a/libs/exo-sql/src/transform/pg/select/selection_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/select/selection_strategy.rs
@@ -166,11 +166,10 @@ pub fn compute_relation_predicate(
             };
 
             let alias = if use_alias {
-                let alias_prefix = selection_level.alias(database);
-                alias_prefix.map(|ref alias_prefix| {
-                    let self_table = database.get_table(self_column_id.table_id);
-                    make_alias(&self_table.name, alias_prefix)
-                })
+                Some(make_alias(
+                    &database.get_table(self_column_id.table_id).name,
+                    &selection_level.alias(database),
+                ))
             } else {
                 None
             };

--- a/libs/exo-sql/src/transform/pg/select/selection_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/select/selection_strategy.rs
@@ -11,10 +11,7 @@ use crate::{
     sql::{predicate::ConcretePredicate, select::Select, table::Table},
     transform::{
         join_util,
-        pg::{
-            selection_level::{make_alias, SelectionLevel},
-            Postgres,
-        },
+        pg::{selection_level::SelectionLevel, Postgres},
         transformer::{OrderByTransformer, PredicateTransformer},
     },
     AbstractOrderBy, AbstractPredicate, Column, Database, Limit, ManyToOne, Offset, OneToMany,
@@ -171,9 +168,9 @@ pub(super) fn compute_relation_predicate(
             };
 
             let alias = if use_alias {
-                Some(make_alias(
-                    &database.get_table(self_column_id.table_id).name,
-                    &selection_level.alias(database),
+                Some(selection_level.alias(
+                    database.get_table(self_column_id.table_id).name.clone(),
+                    database,
                 ))
             } else {
                 None

--- a/libs/exo-sql/src/transform/pg/select/selection_strategy_chain.rs
+++ b/libs/exo-sql/src/transform/pg/select/selection_strategy_chain.rs
@@ -32,10 +32,10 @@ impl<'s> SelectionStrategyChain<'s> {
 
     /// Find the first strategy that is suitable for the given selection context, and return a
     /// `Select` object that can be used to generate the SQL query.
-    pub fn to_select<'a>(
+    pub fn to_select(
         &self,
-        selection_context: SelectionContext<'_, 'a>,
-        database: &'a Database,
+        selection_context: SelectionContext<'_>,
+        database: &Database,
     ) -> Option<Select> {
         let strategy = self
             .strategies

--- a/libs/exo-sql/src/transform/pg/select/subquery_with_in_predicate_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/select/subquery_with_in_predicate_strategy.rs
@@ -115,11 +115,7 @@ impl SelectionStrategy for SubqueryWithInPredicateStrategy {
         true
     }
 
-    fn to_select<'a>(
-        &self,
-        selection_context: SelectionContext<'_, 'a>,
-        database: &'a Database,
-    ) -> Select {
+    fn to_select(&self, selection_context: SelectionContext<'_>, database: &Database) -> Select {
         let SelectionContext {
             abstract_select,
             additional_predicate,

--- a/libs/exo-sql/src/transform/pg/select/subquery_with_in_predicate_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/select/subquery_with_in_predicate_strategy.rs
@@ -129,14 +129,20 @@ impl SelectionStrategy for SubqueryWithInPredicateStrategy {
         // Use only order by columns to form the join, since the predicate part is already taken
         // care by the `to_subselect_predicate` call above. The use of `order_by_column_paths` is
         // essential to be able to refer to columns in related field in the order by clause.
-        let table = join_util::compute_join(abstract_select.table_id, &order_by_column_paths);
+        let table = join_util::compute_join(
+            abstract_select.table_id,
+            &order_by_column_paths,
+            selection_level,
+            database,
+        );
 
-        let additional_predicate = compute_relation_predicate(selection_level, database);
+        let additional_predicate = compute_relation_predicate(selection_level, false, database);
 
         // We don't use the the columns specified in the abstract predicate to form the join (we use
         // only order-by), so we let the predicate transformer know that it should not assume that
         // all tables are joined.
-        let predicate = transformer.to_predicate(&abstract_select.predicate, false, database);
+        let predicate =
+            transformer.to_predicate(&abstract_select.predicate, selection_level, false, database);
         let predicate = ConcretePredicate::and(predicate, additional_predicate);
 
         let inner_select = compute_inner_select(

--- a/libs/exo-sql/src/transform/pg/selection_level.rs
+++ b/libs/exo-sql/src/transform/pg/selection_level.rs
@@ -2,8 +2,8 @@ use crate::{Database, RelationId};
 
 /// Representation of the level of a subselection in a query.
 ///
-/// This serve two purposes:
-/// - Passing an attribute to [crate::select::Select] to indicate if it is a top-level computaiton
+/// This serves two purposes:
+/// - Passing an attribute to [crate::select::Select] to indicate if it is a top-level computation
 ///   (which, in turn, forces `::text` cast for the result)
 /// - Computing the alias of a selection (explained below)
 ///

--- a/libs/exo-sql/src/transform/pg/selection_level.rs
+++ b/libs/exo-sql/src/transform/pg/selection_level.rs
@@ -1,0 +1,64 @@
+use crate::{Database, RelationId};
+
+#[derive(Debug, Clone)]
+pub enum SelectionLevel {
+    /// Top level selection
+    TopLevel,
+    /// Nested sub selection, which each element representing the relation between parent and child selection
+    /// For example, if we have a query like: `concerts { venue { .. }}`, the selection level for the venue
+    /// selection will be `Nested(vec![RelationId::ManyToOne(<venues.id, concerts.venue_id>)])`.
+    Nested(Vec<RelationId>),
+}
+
+impl SelectionLevel {
+    pub(super) fn is_top_level(&self) -> bool {
+        matches!(self, SelectionLevel::TopLevel)
+    }
+
+    pub(super) fn with_relation_id(&self, relation_id: RelationId) -> Self {
+        match self {
+            SelectionLevel::TopLevel => SelectionLevel::Nested(vec![relation_id]),
+            SelectionLevel::Nested(relation_ids) => {
+                let mut relation_ids = relation_ids.clone();
+                relation_ids.push(relation_id);
+                SelectionLevel::Nested(relation_ids)
+            }
+        }
+    }
+
+    pub(super) fn tail_relation_id(&self) -> Option<&RelationId> {
+        match self {
+            SelectionLevel::TopLevel => None,
+            SelectionLevel::Nested(relation_ids) => relation_ids.last(),
+        }
+    }
+
+    pub(crate) fn alias(&self, database: &Database) -> Option<String> {
+        match self {
+            SelectionLevel::TopLevel => None,
+            SelectionLevel::Nested(relation_ids) => {
+                Some(relation_ids.iter().fold(String::new(), |acc, relation_id| {
+                    let foreign_table_id = match relation_id {
+                        RelationId::ManyToOne(r) => r.deref(database).self_column_id.table_id,
+                        RelationId::OneToMany(r) => r.deref(database).self_pk_column_id.table_id,
+                    };
+                    let name = &database.get_table(foreign_table_id).name;
+                    join_alias_components(&acc, name)
+                }))
+            }
+        }
+    }
+}
+
+const ALIAS_SEPARATOR: &str = "$";
+
+pub(crate) fn make_alias(name: &str, context_name: &Option<String>) -> String {
+    match context_name {
+        Some(ref context_name) => join_alias_components(context_name, name),
+        None => name.to_owned(),
+    }
+}
+
+fn join_alias_components(context_name: &str, name: &str) -> String {
+    format!("{context_name}{ALIAS_SEPARATOR}{name}")
+}

--- a/libs/exo-sql/src/transform/pg/update_transformer.rs
+++ b/libs/exo-sql/src/transform/pg/update_transformer.rs
@@ -49,7 +49,7 @@ use crate::{
     ColumnId, Database,
 };
 
-use super::{Postgres, SelectionLevel};
+use super::{selection_level::SelectionLevel, Postgres};
 
 impl UpdateTransformer for Postgres {
     /// Transform an abstract update into a transaction script.

--- a/libs/exo-sql/src/transform/pg/update_transformer.rs
+++ b/libs/exo-sql/src/transform/pg/update_transformer.rs
@@ -49,7 +49,7 @@ use crate::{
     ColumnId, Database,
 };
 
-use super::Postgres;
+use super::{Postgres, SelectionLevel};
 
 impl UpdateTransformer for Postgres {
     /// Transform an abstract update into a transaction script.
@@ -75,7 +75,12 @@ impl UpdateTransformer for Postgres {
             .map(|(c, v)| (*c, v.into()))
             .collect();
 
-        let predicate = self.to_predicate(&abstract_update.predicate, false, database);
+        let predicate = self.to_predicate(
+            &abstract_update.predicate,
+            &SelectionLevel::TopLevel,
+            false,
+            database,
+        );
 
         let select = self.to_select(&abstract_update.selection, database);
 
@@ -211,6 +216,7 @@ fn update_op<'a>(
         table: database.get_table(nested_update.update.table_id),
         predicate: predicate_transformer.to_predicate(
             &nested_update.update.predicate,
+            &SelectionLevel::TopLevel,
             false,
             database,
         ),
@@ -288,8 +294,12 @@ fn delete_op<'a>(
     //     ),
     // );
 
-    let predicate =
-        predicate_transformer.to_predicate(&nested_delete.delete.predicate, false, database);
+    let predicate = predicate_transformer.to_predicate(
+        &nested_delete.delete.predicate,
+        &SelectionLevel::TopLevel,
+        false,
+        database,
+    );
 
     TemplateSQLOperation::Delete(TemplateDelete {
         table: database.get_table(nested_delete.delete.table_id),

--- a/libs/exo-sql/src/transform/transformer.rs
+++ b/libs/exo-sql/src/transform/transformer.rs
@@ -94,6 +94,14 @@ pub trait UpdateTransformer {
 }
 
 pub trait PredicateTransformer {
+    /// Transform an abstract predicate into a concrete predicate
+    ///
+    /// # Arguments
+    /// * `predicate` - The predicate to transform
+    /// * `selection_level` - The selection level of that led to this predicate (through subselects)
+    /// * `tables_supplied` - Whether the tables are already in context. If they are, the predicate can simply use the table.column syntax.
+    ///                       If they are not, the predicate will need to bring in the tables being referred to.
+    /// * `database` - The database
     fn to_predicate(
         &self,
         predicate: &AbstractPredicate,

--- a/libs/exo-sql/src/transform/transformer.rs
+++ b/libs/exo-sql/src/transform/transformer.rs
@@ -19,7 +19,7 @@ use crate::{
     AbstractOrderBy, AbstractPredicate, Database,
 };
 
-use super::pg::{Postgres, SelectionLevel};
+use super::pg::{selection_level::SelectionLevel, Postgres};
 
 /// Transform an abstract operation into a transaction script
 pub trait OperationTransformer {

--- a/libs/exo-sql/src/transform/transformer.rs
+++ b/libs/exo-sql/src/transform/transformer.rs
@@ -19,7 +19,7 @@ use crate::{
     AbstractOrderBy, AbstractPredicate, Database,
 };
 
-use super::pg::Postgres;
+use super::pg::{Postgres, SelectionLevel};
 
 /// Transform an abstract operation into a transaction script
 pub trait OperationTransformer {
@@ -97,6 +97,7 @@ pub trait PredicateTransformer {
     fn to_predicate(
         &self,
         predicate: &AbstractPredicate,
+        selection_level: &SelectionLevel,
         assume_tables_in_context: bool,
         database: &Database,
     ) -> ConcretePredicate;


### PR DESCRIPTION
When introducing a subselect, we need to introduce a new context by aliasing the outer tables. This PR enhances `SelectionLevel` to carry more information and use it to introduce alias. See doc comments for `SelectionLevel` for more details.