### PR TITLE
Allow tests to specify unordered arrays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3580,13 +3580,15 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.29.0"
+version = "1.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a28d25139df397cbca21408bb742cf6837e04cdbebf1b07b760caf971d6a972"
+checksum = "a0770b0a3d4c70567f0d58331f3088b0e4c4f56c9b8d764efe654b4a5d46de3a"
 dependencies = [
  "console",
  "lazy_static",
  "linked-hash-map",
+ "pest",
+ "pest_derive",
  "serde",
  "similar",
  "yaml-rust",
@@ -4889,6 +4891,40 @@ checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
 dependencies = [
  "thiserror",
  "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be99c4c1d2fc2769b1d00239431d711d08f6efedcecb8b6e30707160aee99c15"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e56094789873daa36164de2e822b3888c6ae4b4f9da555a1103587658c805b1e"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2 1.0.56",
+ "quote 1.0.27",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6733073c7cff3d8459fda0e42f13a047870242aed8b509fe98000928975f359e"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ futures = "0.3"
 heck = "0.4.0"
 include_dir = "0.7.2"
 indexmap = "1.9.3"
-insta = "1.29.0"
+insta = { version = "1.31.0", features = ["redactions"] }
 jsonwebtoken = "8.1.1"
 lazy_static = "1.4.0"
 maybe-owned = "0.3.4"

--- a/crates/testing/src/exotest/assertion/assert.js
+++ b/crates/testing/src/exotest/assertion/assert.js
@@ -19,61 +19,145 @@ export async function evaluate(testvariables) {
     return JSON.parse(JSON.stringify(json));
 }
 
-export async function test(actualPayload, testvariables) {
+export async function test(actualPayload, testvariables, unorderedSelections) {
     var $ = testvariables;
 
     // substituted in from Rust
     const expectedPayload = "%%JSON%%";
 
-    var lastKey = undefined;
+    await assert_equals(expectedPayload, actualPayload, [], unorderedSelections);
+}
 
-    async function _test(expected, actual) {
-        switch (typeof(expected)) {
-            case "object": {
+async function assert_equals(expected, actual, path, unorderedSelections) {
+    switch (typeof (expected)) {
+        case "object": {
+            if (Array.isArray(expected)) {
+                await assert_array_equal(expected, actual, path, unorderedSelections);
+            } else {
                 // recursively verify that all key/values in expectedResponse are present in actualValue
                 for (const key in expected) {
-                    lastKey = key;
                     const expectedValue = expected[key];
                     const actualValue = actual[key];
 
-                    await _test(expectedValue, actualValue, testvariables);
+                    const new_path = [...path, key];
+
+                    await assert_equals(expectedValue, actualValue, new_path, unorderedSelections);
                 }
 
                 // recursively verify that no extraneous key/values are present in actualValue
                 for (const key in actual) {
                     if (expected[key] === undefined) {
-                        throw new ExographError("unexpected key " + key.toString() + " in actual response")
+                        throw new ExographError("unexpected key " + key.toString() + " in actual response " + " at " + path_to_string(path))
                     }
                 }
-
-                break;
             }
-            case "function": {
-                let result = expected(actual);
 
-                if (result === undefined) {
-                    throw new ExographError("assertion function for field " + lastKey + " did not return a value, cannot check")
-                }
+            break;
+        }
+        case "function": {
+            let result = expected(actual);
 
-                // if this function is a Promise, resolve the promise before asserting
-                if (Object.getPrototypeOf(result) === Promise.prototype) {
-                    result = await result;
-                }
-
-                // assert true
-                if (result === false) {
-                    throw new ExographError("assert function failed for field " + lastKey + "!\nactual: " + JSON.stringify(actual))
-                }
-                break;
+            if (result === undefined) {
+                throw new ExographError("assertion function for field " + path_to_string(path) + " did not return a value, cannot check")
             }
-            default: {
-                if (expected !== actual) {
-                    throw new ExographError("assert failed: expected " + expected + " on key " + lastKey + ", got " + actual)
+
+            // if this function is a Promise, resolve the promise before asserting
+            if (Object.getPrototypeOf(result) === Promise.prototype) {
+                result = await result;
+            }
+
+            // assert true
+            if (result === false) {
+                throw new ExographError("assert function failed for field " + path_to_string(path) + "!\nactual: " + JSON.stringify(actual))
+            }
+            break;
+        }
+        default: {
+            if (expected !== actual) {
+                throw new ExographError("assert failed: expected " + expected + " on key " + path_to_string(path) + ", got " + actual)
+            }
+            break;
+        }
+    }
+}
+
+async function assert_array_equal(expected, actual, path, unorderedSelections) {
+    if (expected.length !== actual.length) {
+        throw new ExographError("assert failed: expected array length " + expected.length + ", got " + actual.length)
+    }
+    const unordered = array_contains_path(unorderedSelections, path);
+
+    if (unordered) {
+        await assert_equal_unordeded(expected, actual, path, unorderedSelections);
+    } else {
+        // We still assert one by one, since at a lower level we may have unordered arrays
+        for (let i = 0; i < expected.length; i++) {
+            const expected_item = expected[i];
+            const actual_item = actual[i];
+            await assert_equals(expected_item, actual_item, path, unorderedSelections);
+        }
+    }
+}
+
+async function assert_equal_unordeded(expected, actual, path, unorderedSelections) {
+    if (expected.length !== actual.length) {
+        throw new ExographError("assert failed: expected array length " + expected.length + ", got " + actual.length)
+    }
+
+    if (expected.length !== 0) {
+        const expected_item = expected.pop();
+
+        let match = false;
+        for (let i = 0; i < actual.length; i++) {
+            const actual_item = actual[i];
+
+            try {
+                await assert_equals(expected_item, actual_item, path, unorderedSelections);
+                // An element matched, remove it from the actual array
+                actual.splice(i, 1);
+                match = true;
+                break;
+            } catch (e) {
+                if (e instanceof ExographError) {
+                    // ignore (we might find a match later)
+                } else {
+                    throw e;
                 }
+            }
+        }
+
+        if (match) {
+            // Test the remaining items in the array
+            await assert_equal_unordeded(expected, actual, path, unorderedSelections);
+        } else {
+            throw new ExographError("assert failed: could not find a match for " + JSON.stringify(expected_item) + " at " + path_to_string(path)) + " in the actual array";
+        }
+    }
+}
+
+function array_contains_path(paths, path) {
+    for (const item of paths) {
+        if (item.length !== path.length) {
+            continue;
+        }
+
+        let match = true;
+        for (let i = 0; i < item.length; i++) {
+            if (item[i] !== path[i]) {
+                match = false;
                 break;
             }
         }
+
+        if (match) {
+            return true;
+        }
     }
 
-    await _test(expectedPayload, actualPayload);
+    return false;
+}
+
+// Nicer path for printing (e.g. 'a.b.c')
+function path_to_string(path) {
+    return "'" + path.join(".") + "'";
 }

--- a/crates/testing/src/exotest/snapshots/testing__exotest__testvariable_bindings__tests__bindings_build.snap
+++ b/crates/testing/src/exotest/snapshots/testing__exotest__testvariable_bindings__tests__bindings_build.snap
@@ -1,14 +1,15 @@
 ---
-source: test/src/exotest/testvariable_bindings.rs
-expression: bindings
-
+source: crates/testing/src/exotest/testvariable_bindings.rs
+expression: metadata
 ---
-createLog_id:
-  - data
-  - createLog
-  - id
-log1_ids:
-  - data
-  - log1
-  - id
+bindings:
+  createLog_id:
+    - data
+    - createLog
+    - id
+  log1_ids:
+    - data
+    - log1
+    - id
+unordered_paths: []
 

--- a/crates/testing/src/exotest/snapshots/testing__exotest__testvariable_bindings__tests__unordered_build.snap
+++ b/crates/testing/src/exotest/snapshots/testing__exotest__testvariable_bindings__tests__unordered_build.snap
@@ -1,0 +1,18 @@
+---
+source: crates/testing/src/exotest/testvariable_bindings.rs
+expression: metadata
+---
+bindings: {}
+unordered_paths:
+  - - data
+    - getOrders
+  - - data
+    - getOrders
+    - items_enforced_order
+    - sizes
+  - - data
+    - getOrders
+    - items_unenforced_order
+  - - data
+    - getProducts
+

--- a/integration-tests/basic-model-no-auth/tests/venues-by-concert-id-no-nesting.exotest
+++ b/integration-tests/basic-model-no-auth/tests/venues-by-concert-id-no-nesting.exotest
@@ -1,6 +1,6 @@
 operation: |
     query {
-        venues(where: {concerts: {id: {lt: 100}}}) { # Essentially, all venues, but with a nested where clause
+        venues(where: {concerts: {id: {lt: 100}}}) @unordered { # Essentially, all venues, but with a nested where clause
             id
             name
             published
@@ -12,16 +12,16 @@ response: |
       "data": {
         "venues": [
           {
-            "id": 1,
-            "name": "Venue1",
-            "published": true,
-            "latitude": 37.7749
-          },
-          {
             "id": 2,
             "name": "Venue2",
             "published": false,
             "latitude": 35.6762
+          },
+          {
+            "id": 1,
+            "name": "Venue1",
+            "published": true,
+            "latitude": 37.7749
           }
         ]
       }


### PR DESCRIPTION
Often, the test writer does not care about the order of the elements in the output array. In fact, in the case of the Postgres module, unless `@orderBy` is specified, the order of the elements is not guaranteed. In such cases, we may see false failures due to a mismatch in the order.

Furthermore, in our integration tests, we want to ensure that system's behavior is correct regardless even if `orderBy` is not specified. Especially by specifying `orderBy` we affect the query strategy, which may lead to different than one with no `orderBy` specified.

In this PR, we allow the test writer to use the `@unordered` directive to specify that the order of the elements in the output array does not matter.

As an example, we use this directive in one test in this PR. We will expand the usage as we go.

Fixes #850