### PR TITLE
Lazily extract JWT and cookie context values

### DIFF
--- a/crates/core-subsystem/core-resolver/src/access_solver.rs
+++ b/crates/core-subsystem/core-resolver/src/access_solver.rs
@@ -15,7 +15,7 @@ use core_model::access::{
 use thiserror::Error;
 
 use crate::{
-    context::{ContextParsingError, RequestContext},
+    context::{ContextExtractionError, RequestContext},
     context_extractor::ContextExtractor,
     number_cmp::NumberWrapper,
     value::Val,
@@ -32,7 +32,7 @@ pub trait AccessPredicate<'a>:
 #[derive(Error, Debug)]
 pub enum AccessSolverError {
     #[error("{0}")]
-    ContextExtraction(#[from] ContextParsingError),
+    ContextExtraction(#[from] ContextExtractionError),
 }
 
 /// Solve access control logic.

--- a/crates/core-subsystem/core-resolver/src/access_solver.rs
+++ b/crates/core-subsystem/core-resolver/src/access_solver.rs
@@ -12,9 +12,12 @@ use core_model::access::{
     AccessLogicalExpression, AccessPredicateExpression, AccessRelationalOp,
     CommonAccessPrimitiveExpression,
 };
+use thiserror::Error;
 
 use crate::{
-    context::RequestContext, context_extractor::ContextExtractor, number_cmp::NumberWrapper,
+    context::{ContextParsingError, RequestContext},
+    context_extractor::ContextExtractor,
+    number_cmp::NumberWrapper,
     value::Val,
 };
 
@@ -24,6 +27,12 @@ pub trait AccessPredicate<'a>:
 {
     fn and(self, other: Self) -> Self;
     fn or(self, other: Self) -> Self;
+}
+
+#[derive(Error, Debug)]
+pub enum AccessSolverError {
+    #[error("{0}")]
+    ContextExtraction(#[from] ContextParsingError),
 }
 
 /// Solve access control logic.
@@ -54,7 +63,7 @@ where
         request_context: &RequestContext<'a>,
         input_context: Option<&'a Val>, // User provided context (such as input to a mutation)
         expr: &AccessPredicateExpression<PrimExpr>,
-    ) -> Option<Res> {
+    ) -> Result<Option<Res>, AccessSolverError> {
         match expr {
             AccessPredicateExpression::LogicalOp(op) => {
                 self.solve_logical_op(request_context, input_context, op)
@@ -64,7 +73,7 @@ where
                 self.solve_relational_op(request_context, input_context, op)
                     .await
             }
-            AccessPredicateExpression::BooleanLiteral(value) => Some((*value).into()),
+            AccessPredicateExpression::BooleanLiteral(value) => Ok(Some((*value).into())),
         }
     }
 
@@ -78,7 +87,7 @@ where
         request_context: &RequestContext<'a>,
         input_context: Option<&'a Val>,
         op: &AccessRelationalOp<PrimExpr>,
-    ) -> Option<Res>;
+    ) -> Result<Option<Res>, AccessSolverError>;
 
     /// Solve logical operations such as `not`, `and`, `or`.
     async fn solve_logical_op(
@@ -86,16 +95,17 @@ where
         request_context: &RequestContext<'a>,
         input_context: Option<&'a Val>,
         op: &AccessLogicalExpression<PrimExpr>,
-    ) -> Option<Res> {
-        match op {
+    ) -> Result<Option<Res>, AccessSolverError> {
+        Ok(match op {
             AccessLogicalExpression::Not(underlying) => {
-                let underlying_predicate =
-                    self.solve(request_context, input_context, underlying).await;
+                let underlying_predicate = self
+                    .solve(request_context, input_context, underlying)
+                    .await?;
                 underlying_predicate.map(|p| p.not())
             }
             AccessLogicalExpression::And(left, right) => {
-                let left_predicate = self.solve(request_context, input_context, left).await;
-                let right_predicate = self.solve(request_context, input_context, right).await;
+                let left_predicate = self.solve(request_context, input_context, left).await?;
+                let right_predicate = self.solve(request_context, input_context, right).await?;
 
                 match (left_predicate, right_predicate) {
                     (Some(left_predicate), Some(right_predicate)) => {
@@ -105,8 +115,8 @@ where
                 }
             }
             AccessLogicalExpression::Or(left, right) => {
-                let left_predicate = self.solve(request_context, input_context, left).await;
-                let right_predicate = self.solve(request_context, input_context, right).await;
+                let left_predicate = self.solve(request_context, input_context, left).await?;
+                let right_predicate = self.solve(request_context, input_context, right).await?;
 
                 match (left_predicate, right_predicate) {
                     (Some(left_predicate), Some(right_predicate)) => {
@@ -117,7 +127,7 @@ where
                     (None, None) => None,
                 }
             }
-        }
+        })
     }
 }
 
@@ -127,24 +137,23 @@ pub async fn reduce_common_primitive_expression<'a>(
     context_extractor: &(impl ContextExtractor + Send + Sync),
     request_context: &RequestContext<'a>,
     expr: &'a CommonAccessPrimitiveExpression,
-) -> Option<Val> {
-    match expr {
+) -> Result<Option<Val>, AccessSolverError> {
+    Ok(match expr {
         CommonAccessPrimitiveExpression::ContextSelection(selection) => context_extractor
             .extract_context_selection(request_context, selection)
-            .await
-            .unwrap()
+            .await?
             .cloned(),
         CommonAccessPrimitiveExpression::StringLiteral(value) => Some(Val::String(value.clone())),
         CommonAccessPrimitiveExpression::BooleanLiteral(value) => Some(Val::Bool(*value)),
         CommonAccessPrimitiveExpression::NumberLiteral(value) => Some(Val::Number((*value).into())),
-    }
+    })
 }
 
 pub fn eq_values(left_value: &Val, right_value: &Val) -> bool {
     match (left_value, right_value) {
         (Val::Number(left_number), Val::Number(right_number)) => {
             // We have a more general implementation of `PartialEq` for `Val` that accounts for
-            // different number types. So, we use that implementaiton here instead of using just `==`
+            // different number types. So, we use that implementation here instead of using just `==`
             NumberWrapper(left_number.clone()).partial_cmp(&NumberWrapper(right_number.clone()))
                 == Some(std::cmp::Ordering::Equal)
         }

--- a/crates/core-subsystem/core-resolver/src/context/context_extractor.rs
+++ b/crates/core-subsystem/core-resolver/src/context/context_extractor.rs
@@ -10,7 +10,7 @@
 use async_trait::async_trait;
 use serde_json::Value;
 
-use super::{request::Request, ContextParsingError, RequestContext};
+use super::{request::Request, ContextExtractionError, RequestContext};
 
 /// Extractor for a particular context field
 ///
@@ -22,14 +22,14 @@ pub trait ContextExtractor {
     fn annotation_name(&self) -> &str;
 
     // extract a context field from this struct
-    async fn extract_context_field<'r>(
+    async fn extract_context_field(
         &self,
         key: &str,
         request_context: &RequestContext,
         request: &(dyn Request + Send + Sync),
-    ) -> Result<Option<Value>, ContextParsingError>;
+    ) -> Result<Option<Value>, ContextExtractionError>;
 }
-pub type BoxedParsedContext<'a> = Box<dyn ContextExtractor + 'a + Send + Sync>;
+pub type BoxedContextExtractor<'a> = Box<dyn ContextExtractor + 'a + Send + Sync>;
 
 #[cfg(feature = "test-context")]
 pub struct TestRequestContext {
@@ -43,12 +43,12 @@ impl ContextExtractor for TestRequestContext {
         "test"
     }
 
-    async fn extract_context_field<'r>(
+    async fn extract_context_field(
         &self,
         key: &str,
         _request_context: &RequestContext,
         _request: &(dyn Request + Send + Sync),
-    ) -> Result<Option<Value>, ContextParsingError> {
+    ) -> Result<Option<Value>, ContextExtractionError> {
         Ok(self.test_values.get(key).cloned())
     }
 }

--- a/crates/core-subsystem/core-resolver/src/context/error.rs
+++ b/crates/core-subsystem/core-resolver/src/context/error.rs
@@ -28,4 +28,7 @@ pub enum ContextParsingError {
 
     #[error("Field not found: `{0}`")]
     FieldNotFound(String),
+
+    #[error("{0}")]
+    Generic(String),
 }

--- a/crates/core-subsystem/core-resolver/src/context/error.rs
+++ b/crates/core-subsystem/core-resolver/src/context/error.rs
@@ -10,7 +10,7 @@
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-pub enum ContextParsingError {
+pub enum ContextExtractionError {
     #[error("Could not find source `{0}`")]
     SourceNotFound(String),
 

--- a/crates/core-subsystem/core-resolver/src/context/mod.rs
+++ b/crates/core-subsystem/core-resolver/src/context/mod.rs
@@ -7,9 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod context_extractor;
 mod error;
 mod overridden_context;
-mod parsed_context;
 pub mod provider;
 mod request;
 mod request_context;
@@ -17,9 +17,9 @@ mod user_request_context;
 
 pub use provider::jwt::{JwtAuthenticator, LOCAL_JWT_SECRET};
 
-pub use error::ContextParsingError;
+pub use error::ContextExtractionError;
 pub use request::Request;
 pub use request_context::RequestContext;
 
 #[cfg(feature = "test-context")]
-pub use parsed_context::TestRequestContext;
+pub use context_extractor::TestRequestContext;

--- a/crates/core-subsystem/core-resolver/src/context/overridden_context.rs
+++ b/crates/core-subsystem/core-resolver/src/context/overridden_context.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 
 use crate::value::Val;
 
-use super::{ContextParsingError, RequestContext};
+use super::{ContextExtractionError, RequestContext};
 
 pub struct OverriddenContext<'a> {
     pub base_context: &'a RequestContext<'a>,
@@ -35,8 +35,8 @@ impl<'a> OverriddenContext<'a> {
         source_annotation: &str,
         source_annotation_key: &Option<&str>,
         field_name: &str,
-        coerce_value: &(impl Fn(Val) -> Result<Val, ContextParsingError> + std::marker::Sync),
-    ) -> Result<Option<&'a Val>, ContextParsingError> {
+        coerce_value: &(impl Fn(Val) -> Result<Val, ContextExtractionError> + std::marker::Sync),
+    ) -> Result<Option<&'a Val>, ContextExtractionError> {
         let cache_key = (context_type_name.to_owned(), field_name.to_owned());
 
         let cached_value: Option<&Option<Val>> = self.context_cache.get(&cache_key);

--- a/crates/core-subsystem/core-resolver/src/context/parsed_context.rs
+++ b/crates/core-subsystem/core-resolver/src/context/parsed_context.rs
@@ -26,7 +26,7 @@ pub trait ParsedContext {
     async fn extract_context_field<'r>(
         &self,
         key: &str,
-        request_context: &'r RequestContext<'r>,
+        request_context: &RequestContext,
         request: &(dyn Request + Send + Sync),
     ) -> Result<Option<Value>, ContextParsingError>;
 }
@@ -47,7 +47,7 @@ impl ParsedContext for TestRequestContext {
     async fn extract_context_field<'r>(
         &self,
         key: &str,
-        _request_context: &'r RequestContext<'r>,
+        _request_context: &RequestContext,
         _request: &(dyn Request + Send + Sync),
     ) -> Result<Option<Value>, ContextParsingError> {
         Ok(self.test_values.get(key).cloned())

--- a/crates/core-subsystem/core-resolver/src/context/parsed_context.rs
+++ b/crates/core-subsystem/core-resolver/src/context/parsed_context.rs
@@ -12,12 +12,11 @@ use serde_json::Value;
 
 use super::{request::Request, ContextParsingError, RequestContext};
 
-// Represents a parsed context
-//
-// Provides methods to extract context fields out of a given struct
-// This trait should be implemented on objects that represent a particular source of parsed context fields
+/// Extractor for a particular context field
+///
+/// This trait should be implemented on objects that represent a particular source of parsed context fields
 #[async_trait]
-pub trait ParsedContext {
+pub trait ContextExtractor {
     // what annotation does this extractor provide values for?
     // e.g. "jwt", "header", etc.
     fn annotation_name(&self) -> &str;
@@ -30,7 +29,7 @@ pub trait ParsedContext {
         request: &(dyn Request + Send + Sync),
     ) -> Result<Option<Value>, ContextParsingError>;
 }
-pub type BoxedParsedContext<'a> = Box<dyn ParsedContext + 'a + Send + Sync>;
+pub type BoxedParsedContext<'a> = Box<dyn ContextExtractor + 'a + Send + Sync>;
 
 #[cfg(feature = "test-context")]
 pub struct TestRequestContext {
@@ -39,7 +38,7 @@ pub struct TestRequestContext {
 
 #[cfg(feature = "test-context")]
 #[async_trait]
-impl ParsedContext for TestRequestContext {
+impl ContextExtractor for TestRequestContext {
     fn annotation_name(&self) -> &str {
         "test"
     }

--- a/crates/core-subsystem/core-resolver/src/context/parsed_context.rs
+++ b/crates/core-subsystem/core-resolver/src/context/parsed_context.rs
@@ -10,7 +10,7 @@
 use async_trait::async_trait;
 use serde_json::Value;
 
-use super::{request::Request, RequestContext};
+use super::{request::Request, ContextParsingError, RequestContext};
 
 // Represents a parsed context
 //
@@ -28,7 +28,7 @@ pub trait ParsedContext {
         key: &str,
         request_context: &'r RequestContext<'r>,
         request: &'r (dyn Request + Send + Sync),
-    ) -> Option<Value>;
+    ) -> Result<Option<Value>, ContextParsingError>;
 }
 pub type BoxedParsedContext<'a> = Box<dyn ParsedContext + 'a + Send + Sync>;
 
@@ -49,7 +49,7 @@ impl ParsedContext for TestRequestContext {
         key: &str,
         _request_context: &'r RequestContext<'r>,
         _request: &'r (dyn Request + Send + Sync),
-    ) -> Option<Value> {
-        self.test_values.get(key).cloned()
+    ) -> Result<Option<Value>, ContextParsingError> {
+        Ok(self.test_values.get(key).cloned())
     }
 }

--- a/crates/core-subsystem/core-resolver/src/context/parsed_context.rs
+++ b/crates/core-subsystem/core-resolver/src/context/parsed_context.rs
@@ -27,7 +27,7 @@ pub trait ParsedContext {
         &self,
         key: &str,
         request_context: &'r RequestContext<'r>,
-        request: &'r (dyn Request + Send + Sync),
+        request: &(dyn Request + Send + Sync),
     ) -> Result<Option<Value>, ContextParsingError>;
 }
 pub type BoxedParsedContext<'a> = Box<dyn ParsedContext + 'a + Send + Sync>;
@@ -48,7 +48,7 @@ impl ParsedContext for TestRequestContext {
         &self,
         key: &str,
         _request_context: &'r RequestContext<'r>,
-        _request: &'r (dyn Request + Send + Sync),
+        _request: &(dyn Request + Send + Sync),
     ) -> Result<Option<Value>, ContextParsingError> {
         Ok(self.test_values.get(key).cloned())
     }

--- a/crates/core-subsystem/core-resolver/src/context/provider/cookie.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/cookie.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 use tokio::sync::OnceCell;
 
 use crate::context::{
-    error::ContextParsingError, parsed_context::ParsedContext, request::Request, RequestContext,
+    error::ContextParsingError, parsed_context::ContextExtractor, request::Request, RequestContext,
 };
 
 pub struct CookieExtractor {
@@ -52,7 +52,7 @@ impl CookieExtractor {
 }
 
 #[async_trait]
-impl ParsedContext for CookieExtractor {
+impl ContextExtractor for CookieExtractor {
     fn annotation_name(&self) -> &str {
         "cookie"
     }

--- a/crates/core-subsystem/core-resolver/src/context/provider/cookie.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/cookie.rs
@@ -60,7 +60,7 @@ impl ParsedContext for CookieExtractor {
     async fn extract_context_field<'r>(
         &self,
         key: &str,
-        _request_context: &'r RequestContext<'r>,
+        _request_context: &RequestContext,
         request: &(dyn Request + Send + Sync),
     ) -> Result<Option<Value>, ContextParsingError> {
         Ok(self

--- a/crates/core-subsystem/core-resolver/src/context/provider/cookie.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/cookie.rs
@@ -61,9 +61,10 @@ impl ParsedContext for ParsedCookieContext {
         key: &str,
         _request_context: &'r RequestContext<'r>,
         _request: &'r (dyn Request + Send + Sync),
-    ) -> Option<Value> {
-        self.cookies
+    ) -> Result<Option<Value>, ContextParsingError> {
+        Ok(self
+            .cookies
             .get(key)
-            .map(|c| (*c.value()).to_string().into())
+            .map(|c| (*c.value()).to_string().into()))
     }
 }

--- a/crates/core-subsystem/core-resolver/src/context/provider/environment.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/environment.rs
@@ -13,7 +13,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::context::{
-    parsed_context::ContextExtractor, request::Request, ContextParsingError, RequestContext,
+    context_extractor::ContextExtractor, request::Request, ContextExtractionError, RequestContext,
 };
 
 pub struct EnvironmentContextExtractor<'a> {
@@ -26,12 +26,12 @@ impl<'a> ContextExtractor for EnvironmentContextExtractor<'a> {
         "env"
     }
 
-    async fn extract_context_field<'r>(
+    async fn extract_context_field(
         &self,
         key: &str,
         _request_context: &RequestContext,
         _request: &(dyn Request + Send + Sync),
-    ) -> Result<Option<Value>, ContextParsingError> {
+    ) -> Result<Option<Value>, ContextExtractionError> {
         Ok(self.env.get(key).map(|v| v.as_str().into()))
     }
 }

--- a/crates/core-subsystem/core-resolver/src/context/provider/environment.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/environment.rs
@@ -13,7 +13,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::context::{
-    parsed_context::ParsedContext, request::Request, ContextParsingError, RequestContext,
+    parsed_context::ContextExtractor, request::Request, ContextParsingError, RequestContext,
 };
 
 pub struct EnvironmentContextExtractor<'a> {
@@ -21,7 +21,7 @@ pub struct EnvironmentContextExtractor<'a> {
 }
 
 #[async_trait]
-impl<'a> ParsedContext for EnvironmentContextExtractor<'a> {
+impl<'a> ContextExtractor for EnvironmentContextExtractor<'a> {
     fn annotation_name(&self) -> &str {
         "env"
     }

--- a/crates/core-subsystem/core-resolver/src/context/provider/environment.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/environment.rs
@@ -30,7 +30,7 @@ impl<'a> ParsedContext for EnvironmentContextExtractor<'a> {
         &self,
         key: &str,
         _request_context: &'r RequestContext<'r>,
-        _request: &'r (dyn Request + Send + Sync),
+        _request: &(dyn Request + Send + Sync),
     ) -> Result<Option<Value>, ContextParsingError> {
         Ok(self.env.get(key).map(|v| v.as_str().into()))
     }

--- a/crates/core-subsystem/core-resolver/src/context/provider/environment.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/environment.rs
@@ -12,7 +12,9 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use serde_json::Value;
 
-use crate::context::{parsed_context::ParsedContext, request::Request, RequestContext};
+use crate::context::{
+    parsed_context::ParsedContext, request::Request, ContextParsingError, RequestContext,
+};
 
 pub struct EnvironmentContextExtractor<'a> {
     pub env: &'a HashMap<String, String>,
@@ -29,7 +31,7 @@ impl<'a> ParsedContext for EnvironmentContextExtractor<'a> {
         key: &str,
         _request_context: &'r RequestContext<'r>,
         _request: &'r (dyn Request + Send + Sync),
-    ) -> Option<Value> {
-        self.env.get(key).map(|v| v.as_str().into())
+    ) -> Result<Option<Value>, ContextParsingError> {
+        Ok(self.env.get(key).map(|v| v.as_str().into()))
     }
 }

--- a/crates/core-subsystem/core-resolver/src/context/provider/environment.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/environment.rs
@@ -29,7 +29,7 @@ impl<'a> ParsedContext for EnvironmentContextExtractor<'a> {
     async fn extract_context_field<'r>(
         &self,
         key: &str,
-        _request_context: &'r RequestContext<'r>,
+        _request_context: &RequestContext,
         _request: &(dyn Request + Send + Sync),
     ) -> Result<Option<Value>, ContextParsingError> {
         Ok(self.env.get(key).map(|v| v.as_str().into()))

--- a/crates/core-subsystem/core-resolver/src/context/provider/header.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/header.rs
@@ -25,7 +25,7 @@ impl ParsedContext for HeaderExtractor {
     async fn extract_context_field<'r>(
         &self,
         key: &str,
-        _request_context: &'r RequestContext<'r>,
+        _request_context: &RequestContext,
         request: &(dyn Request + Send + Sync),
     ) -> Result<Option<Value>, ContextParsingError> {
         Ok(request

--- a/crates/core-subsystem/core-resolver/src/context/provider/header.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/header.rs
@@ -10,7 +10,9 @@
 use async_trait::async_trait;
 use serde_json::Value;
 
-use crate::context::{parsed_context::ParsedContext, request::Request, RequestContext};
+use crate::context::{
+    parsed_context::ParsedContext, request::Request, ContextParsingError, RequestContext,
+};
 
 pub struct HeaderExtractor;
 
@@ -25,9 +27,9 @@ impl ParsedContext for HeaderExtractor {
         key: &str,
         _request_context: &'r RequestContext<'r>,
         request: &'r (dyn Request + Send + Sync),
-    ) -> Option<Value> {
-        request
+    ) -> Result<Option<Value>, ContextParsingError> {
+        Ok(request
             .get_header(&key.to_ascii_lowercase())
-            .map(|str| str.as_str().into())
+            .map(|str| str.as_str().into()))
     }
 }

--- a/crates/core-subsystem/core-resolver/src/context/provider/header.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/header.rs
@@ -11,13 +11,13 @@ use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::context::{
-    parsed_context::ParsedContext, request::Request, ContextParsingError, RequestContext,
+    parsed_context::ContextExtractor, request::Request, ContextParsingError, RequestContext,
 };
 
 pub struct HeaderExtractor;
 
 #[async_trait]
-impl ParsedContext for HeaderExtractor {
+impl ContextExtractor for HeaderExtractor {
     fn annotation_name(&self) -> &str {
         "header"
     }

--- a/crates/core-subsystem/core-resolver/src/context/provider/header.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/header.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::context::{
-    parsed_context::ContextExtractor, request::Request, ContextParsingError, RequestContext,
+    context_extractor::ContextExtractor, request::Request, ContextExtractionError, RequestContext,
 };
 
 pub struct HeaderExtractor;
@@ -22,12 +22,12 @@ impl ContextExtractor for HeaderExtractor {
         "header"
     }
 
-    async fn extract_context_field<'r>(
+    async fn extract_context_field(
         &self,
         key: &str,
         _request_context: &RequestContext,
         request: &(dyn Request + Send + Sync),
-    ) -> Result<Option<Value>, ContextParsingError> {
+    ) -> Result<Option<Value>, ContextExtractionError> {
         Ok(request
             .get_header(&key.to_ascii_lowercase())
             .map(|str| str.as_str().into()))

--- a/crates/core-subsystem/core-resolver/src/context/provider/header.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/header.rs
@@ -26,7 +26,7 @@ impl ParsedContext for HeaderExtractor {
         &self,
         key: &str,
         _request_context: &'r RequestContext<'r>,
-        request: &'r (dyn Request + Send + Sync),
+        request: &(dyn Request + Send + Sync),
     ) -> Result<Option<Value>, ContextParsingError> {
         Ok(request
             .get_header(&key.to_ascii_lowercase())

--- a/crates/core-subsystem/core-resolver/src/context/provider/ip.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/ip.rs
@@ -26,7 +26,7 @@ impl ParsedContext for IpExtractor {
         &self,
         _key: &str,
         _request_context: &'r RequestContext<'r>,
-        request: &'r (dyn Request + Send + Sync),
+        request: &(dyn Request + Send + Sync),
     ) -> Result<Option<Value>, ContextParsingError> {
         Ok(request.get_ip().map(|ip| ip.to_string().into()))
     }

--- a/crates/core-subsystem/core-resolver/src/context/provider/ip.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/ip.rs
@@ -10,7 +10,9 @@
 use async_trait::async_trait;
 use serde_json::Value;
 
-use crate::context::{parsed_context::ParsedContext, request::Request, RequestContext};
+use crate::context::{
+    parsed_context::ParsedContext, request::Request, ContextParsingError, RequestContext,
+};
 
 pub struct IpExtractor;
 
@@ -25,7 +27,7 @@ impl ParsedContext for IpExtractor {
         _key: &str,
         _request_context: &'r RequestContext<'r>,
         request: &'r (dyn Request + Send + Sync),
-    ) -> Option<Value> {
-        request.get_ip().map(|ip| ip.to_string().into())
+    ) -> Result<Option<Value>, ContextParsingError> {
+        Ok(request.get_ip().map(|ip| ip.to_string().into()))
     }
 }

--- a/crates/core-subsystem/core-resolver/src/context/provider/ip.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/ip.rs
@@ -11,13 +11,13 @@ use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::context::{
-    parsed_context::ParsedContext, request::Request, ContextParsingError, RequestContext,
+    parsed_context::ContextExtractor, request::Request, ContextParsingError, RequestContext,
 };
 
 pub struct IpExtractor;
 
 #[async_trait]
-impl ParsedContext for IpExtractor {
+impl ContextExtractor for IpExtractor {
     fn annotation_name(&self) -> &str {
         "clientIp"
     }

--- a/crates/core-subsystem/core-resolver/src/context/provider/ip.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/ip.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::context::{
-    parsed_context::ContextExtractor, request::Request, ContextParsingError, RequestContext,
+    context_extractor::ContextExtractor, request::Request, ContextExtractionError, RequestContext,
 };
 
 pub struct IpExtractor;
@@ -22,12 +22,12 @@ impl ContextExtractor for IpExtractor {
         "clientIp"
     }
 
-    async fn extract_context_field<'r>(
+    async fn extract_context_field(
         &self,
         _key: &str,
         _request_context: &RequestContext,
         request: &(dyn Request + Send + Sync),
-    ) -> Result<Option<Value>, ContextParsingError> {
+    ) -> Result<Option<Value>, ContextExtractionError> {
         Ok(request.get_ip().map(|ip| ip.to_string().into()))
     }
 }

--- a/crates/core-subsystem/core-resolver/src/context/provider/ip.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/ip.rs
@@ -25,7 +25,7 @@ impl ParsedContext for IpExtractor {
     async fn extract_context_field<'r>(
         &self,
         _key: &str,
-        _request_context: &'r RequestContext<'r>,
+        _request_context: &RequestContext,
         request: &(dyn Request + Send + Sync),
     ) -> Result<Option<Value>, ContextParsingError> {
         Ok(request.get_ip().map(|ip| ip.to_string().into()))

--- a/crates/core-subsystem/core-resolver/src/context/provider/jwt.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/jwt.rs
@@ -127,7 +127,7 @@ impl ParsedContext for ParsedJwtContext {
     async fn extract_context_field<'r>(
         &self,
         key: &str,
-        _request_context: &'r RequestContext<'r>,
+        _request_context: &RequestContext,
         _request: &(dyn Request + Send + Sync),
     ) -> Result<Option<Value>, ContextParsingError> {
         Ok(self.jwt_claims.get(key).cloned())

--- a/crates/core-subsystem/core-resolver/src/context/provider/jwt.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/jwt.rs
@@ -129,7 +129,7 @@ impl ParsedContext for ParsedJwtContext {
         key: &str,
         _request_context: &'r RequestContext<'r>,
         _request: &'r (dyn Request + Send + Sync),
-    ) -> Option<Value> {
-        self.jwt_claims.get(key).cloned()
+    ) -> Result<Option<Value>, ContextParsingError> {
+        Ok(self.jwt_claims.get(key).cloned())
     }
 }

--- a/crates/core-subsystem/core-resolver/src/context/provider/jwt.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/jwt.rs
@@ -128,7 +128,7 @@ impl ParsedContext for ParsedJwtContext {
         &self,
         key: &str,
         _request_context: &'r RequestContext<'r>,
-        _request: &'r (dyn Request + Send + Sync),
+        _request: &(dyn Request + Send + Sync),
     ) -> Result<Option<Value>, ContextParsingError> {
         Ok(self.jwt_claims.get(key).cloned())
     }

--- a/crates/core-subsystem/core-resolver/src/context/provider/query.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/query.rs
@@ -35,7 +35,7 @@ impl ParsedContext for QueryExtractor<'_> {
         &self,
         key: &str,
         request_context: &'r RequestContext<'r>,
-        _request: &'r (dyn Request + Send + Sync),
+        _request: &(dyn Request + Send + Sync),
     ) -> Result<Option<serde_json::Value>, ContextParsingError> {
         let query = format!("query {{ {} }}", key.to_owned());
 

--- a/crates/core-subsystem/core-resolver/src/context/provider/query.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/query.rs
@@ -34,7 +34,7 @@ impl ParsedContext for QueryExtractor<'_> {
     async fn extract_context_field<'r>(
         &self,
         key: &str,
-        request_context: &'r RequestContext<'r>,
+        request_context: &RequestContext,
         _request: &(dyn Request + Send + Sync),
     ) -> Result<Option<serde_json::Value>, ContextParsingError> {
         let query = format!("query {{ {} }}", key.to_owned());

--- a/crates/core-subsystem/core-resolver/src/context/provider/query.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/query.rs
@@ -9,7 +9,7 @@
 
 use async_trait::async_trait;
 
-use crate::context::parsed_context::ParsedContext;
+use crate::context::parsed_context::ContextExtractor;
 use crate::context::request::Request;
 use crate::context::{ContextParsingError, RequestContext};
 use crate::system_resolver::SystemResolver;
@@ -26,7 +26,7 @@ impl<'a> QueryExtractor<'a> {
 }
 
 #[async_trait]
-impl ParsedContext for QueryExtractor<'_> {
+impl ContextExtractor for QueryExtractor<'_> {
     fn annotation_name(&self) -> &str {
         "query"
     }

--- a/crates/core-subsystem/core-resolver/src/context/request_context.rs
+++ b/crates/core-subsystem/core-resolver/src/context/request_context.rs
@@ -12,8 +12,9 @@ use async_recursion::async_recursion;
 use crate::{system_resolver::SystemResolver, value::Val};
 
 use super::{
-    error::ContextParsingError, overridden_context::OverriddenContext,
-    parsed_context::BoxedParsedContext, request::Request, user_request_context::UserRequestContext,
+    context_extractor::BoxedContextExtractor, error::ContextExtractionError,
+    overridden_context::OverriddenContext, request::Request,
+    user_request_context::UserRequestContext,
 };
 
 use serde_json::Value;
@@ -29,9 +30,9 @@ pub enum RequestContext<'a> {
 impl<'a> RequestContext<'a> {
     pub fn new(
         request: &'a (dyn Request + Send + Sync),
-        parsed_contexts: Vec<BoxedParsedContext<'a>>,
+        parsed_contexts: Vec<BoxedContextExtractor<'a>>,
         system_resolver: &'a SystemResolver,
-    ) -> Result<RequestContext<'a>, ContextParsingError> {
+    ) -> Result<RequestContext<'a>, ContextExtractionError> {
         Ok(RequestContext::User(UserRequestContext::new(
             request,
             parsed_contexts,
@@ -59,8 +60,8 @@ impl<'a> RequestContext<'a> {
         source_annotation: &str,
         source_annotation_key: &Option<&str>,
         field_name: &str,
-        coerce_value: &(impl Fn(Val) -> Result<Val, ContextParsingError> + std::marker::Sync),
-    ) -> Result<Option<&'a Val>, ContextParsingError> {
+        coerce_value: &(impl Fn(Val) -> Result<Val, ContextExtractionError> + std::marker::Sync),
+    ) -> Result<Option<&'a Val>, ContextExtractionError> {
         match self {
             RequestContext::User(user_request_context) => {
                 user_request_context

--- a/crates/core-subsystem/core-resolver/src/context/user_request_context.rs
+++ b/crates/core-subsystem/core-resolver/src/context/user_request_context.rs
@@ -49,7 +49,7 @@ impl<'a> UserRequestContext<'a> {
             Box::new(QueryExtractor::new(system_resolver)),
             Box::new(HeaderExtractor),
             Box::new(IpExtractor),
-            CookieExtractor::parse_context(request)?,
+            Box::new(CookieExtractor::new()),
             JwtAuthenticator::parse_context(system_resolver.jwt_authenticator.as_ref(), request)?,
         ];
 

--- a/crates/core-subsystem/core-resolver/src/context/user_request_context.rs
+++ b/crates/core-subsystem/core-resolver/src/context/user_request_context.rs
@@ -15,9 +15,10 @@ use exo_sql::TransactionHolder;
 
 use crate::{system_resolver::SystemResolver, value::Val};
 
+use super::provider::jwt::JwtExtractor;
 use super::provider::{
     cookie::CookieExtractor, environment::EnvironmentContextExtractor, header::HeaderExtractor,
-    ip::IpExtractor, jwt::JwtAuthenticator, query::QueryExtractor,
+    ip::IpExtractor, query::QueryExtractor,
 };
 use super::{
     error::ContextParsingError, parsed_context::BoxedParsedContext, request::Request,
@@ -50,7 +51,7 @@ impl<'a> UserRequestContext<'a> {
             Box::new(HeaderExtractor),
             Box::new(IpExtractor),
             Box::new(CookieExtractor::new()),
-            JwtAuthenticator::parse_context(system_resolver.jwt_authenticator.as_ref(), request)?,
+            Box::new(JwtExtractor::new(system_resolver.jwt_authenticator.clone())), // JwtAuthenticator::parse_context(system_resolver.jwt_authenticator.as_ref(), request)?,
         ];
 
         Ok(UserRequestContext {

--- a/crates/core-subsystem/core-resolver/src/context/user_request_context.rs
+++ b/crates/core-subsystem/core-resolver/src/context/user_request_context.rs
@@ -51,7 +51,7 @@ impl<'a> UserRequestContext<'a> {
             Box::new(HeaderExtractor),
             Box::new(IpExtractor),
             Box::new(CookieExtractor::new()),
-            Box::new(JwtExtractor::new(system_resolver.jwt_authenticator.clone())), // JwtAuthenticator::parse_context(system_resolver.jwt_authenticator.as_ref(), request)?,
+            Box::new(JwtExtractor::new(system_resolver.jwt_authenticator.clone())),
         ];
 
         Ok(UserRequestContext {

--- a/crates/core-subsystem/core-resolver/src/context/user_request_context.rs
+++ b/crates/core-subsystem/core-resolver/src/context/user_request_context.rs
@@ -117,7 +117,7 @@ impl<'a> UserRequestContext<'a> {
 
         Ok(parsed_context
             .extract_context_field(key, request_context, self.request)
-            .await
+            .await?
             .map(Val::from))
     }
 }

--- a/crates/deno-subsystem/deno-resolver/src/deno_execution_error.rs
+++ b/crates/deno-subsystem/deno-resolver/src/deno_execution_error.rs
@@ -8,8 +8,8 @@
 // by the Apache License, Version 2.0.
 
 use core_plugin_interface::core_resolver::{
-    context::ContextParsingError, plugin::SubsystemResolutionError,
-    system_resolver::SystemResolutionError,
+    access_solver::AccessSolverError, context::ContextParsingError,
+    plugin::SubsystemResolutionError, system_resolver::SystemResolutionError,
 };
 use thiserror::Error;
 
@@ -66,6 +66,14 @@ impl DenoExecutionError {
                     .downcast_ref::<SystemResolutionError>()
                     .map(|error| error.user_error_message()),
             },
+        }
+    }
+}
+
+impl From<AccessSolverError> for DenoExecutionError {
+    fn from(error: AccessSolverError) -> Self {
+        match error {
+            AccessSolverError::ContextExtraction(_) => DenoExecutionError::Authorization,
         }
     }
 }

--- a/crates/deno-subsystem/deno-resolver/src/deno_execution_error.rs
+++ b/crates/deno-subsystem/deno-resolver/src/deno_execution_error.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use core_plugin_interface::core_resolver::{
-    access_solver::AccessSolverError, context::ContextParsingError,
+    access_solver::AccessSolverError, context::ContextExtractionError,
     plugin::SubsystemResolutionError, system_resolver::SystemResolutionError,
 };
 use thiserror::Error;
@@ -30,7 +30,7 @@ pub enum DenoExecutionError {
     Generic(String),
 
     #[error("{0}")]
-    ContextExtraction(#[from] ContextParsingError),
+    ContextExtraction(#[from] ContextExtractionError),
 }
 
 impl DenoExecutionError {

--- a/crates/postgres-subsystem/postgres-resolver/src/postgres_execution_error.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/postgres_execution_error.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use core_plugin_interface::core_resolver::{
-    access_solver::AccessSolverError, context::ContextParsingError,
+    access_solver::AccessSolverError, context::ContextExtractionError,
 };
 use thiserror::Error;
 use tracing::error;
@@ -45,7 +45,7 @@ pub enum PostgresExecutionError {
     MissingArgument(String),
 
     #[error("{0}")]
-    ContextExtraction(#[from] ContextParsingError),
+    ContextExtraction(#[from] ContextExtractionError),
 }
 
 impl PostgresExecutionError {

--- a/crates/postgres-subsystem/postgres-resolver/src/postgres_execution_error.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/postgres_execution_error.rs
@@ -7,7 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use core_plugin_interface::core_resolver::context::ContextParsingError;
+use core_plugin_interface::core_resolver::{
+    access_solver::AccessSolverError, context::ContextParsingError,
+};
 use thiserror::Error;
 use tracing::error;
 
@@ -63,6 +65,15 @@ impl PostgresExecutionError {
         }
     }
 }
+
+impl From<AccessSolverError> for PostgresExecutionError {
+    fn from(error: AccessSolverError) -> Self {
+        match error {
+            AccessSolverError::ContextExtraction(_) => PostgresExecutionError::Authorization,
+        }
+    }
+}
+
 pub(crate) trait WithContext {
     fn with_context(self, context: String) -> Self;
 }

--- a/crates/postgres-subsystem/postgres-resolver/src/util.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/util.rs
@@ -83,7 +83,7 @@ async fn check_create_access<'a>(
 ) -> Result<AbstractPredicate, PostgresExecutionError> {
     Ok(subsystem
         .solve(request_context, input_context, expr)
-        .await
+        .await?
         .map(|predicate| predicate.0)
         .unwrap_or(AbstractPredicate::False))
 }
@@ -95,7 +95,7 @@ async fn check_retrieve_access<'a>(
 ) -> Result<AbstractPredicate, PostgresExecutionError> {
     Ok(subsystem
         .solve(request_context, None, expr)
-        .await
+        .await?
         .map(|p| p.0)
         .unwrap_or(AbstractPredicate::False))
 }
@@ -109,7 +109,7 @@ async fn check_update_access<'a>(
     // First check the input predicate (i.e. the "data" parameter matches the access predicate)
     let input_predicate = subsystem
         .solve(request_context, input_context, &expr.input)
-        .await
+        .await?
         .map(|p| p.0)
         .unwrap_or(AbstractPredicate::False);
 
@@ -122,7 +122,7 @@ async fn check_update_access<'a>(
     // Now compute the database access predicate (the "where" clause to the update statement)
     Ok(subsystem
         .solve(request_context, None, &expr.existing)
-        .await
+        .await?
         .map(|p| p.0)
         .unwrap_or(AbstractPredicate::False))
 }
@@ -134,7 +134,7 @@ async fn check_delete_access<'a>(
 ) -> Result<AbstractPredicate, PostgresExecutionError> {
     Ok(subsystem
         .solve(request_context, None, expr)
-        .await
+        .await?
         .map(|p| p.0)
         .unwrap_or(AbstractPredicate::False))
 }

--- a/crates/server-actix/src/lib.rs
+++ b/crates/server-actix/src/lib.rs
@@ -12,7 +12,7 @@ mod request;
 use actix_web::web::Bytes;
 use actix_web::{web, Error, HttpRequest, HttpResponse, Responder};
 
-use core_resolver::context::{ContextParsingError, RequestContext};
+use core_resolver::context::{ContextExtractionError, RequestContext};
 use core_resolver::system_resolver::SystemResolver;
 use core_resolver::OperationsPayload;
 use request::ActixRequest;
@@ -61,10 +61,10 @@ pub async fn resolve(
 
         Err(err) => {
             let (message, mut base_response) = match err {
-                ContextParsingError::Unauthorized => {
+                ContextExtractionError::Unauthorized => {
                     (error_msg!("Unauthorized"), HttpResponse::Unauthorized())
                 }
-                ContextParsingError::Malformed => {
+                ContextExtractionError::Malformed => {
                     (error_msg!("Malformed header"), HttpResponse::BadRequest())
                 }
                 _ => (error_msg!("Unknown error"), HttpResponse::Unauthorized()),

--- a/crates/server-aws-lambda/src/lib.rs
+++ b/crates/server-aws-lambda/src/lib.rs
@@ -12,7 +12,7 @@
 mod request;
 
 use core_resolver::{
-    context::{ContextParsingError, RequestContext},
+    context::{ContextExtractionError, RequestContext},
     system_resolver::SystemResolver,
     OperationsPayload,
 };

--- a/crates/server-aws-lambda/src/lib.rs
+++ b/crates/server-aws-lambda/src/lib.rs
@@ -98,8 +98,8 @@ pub async fn resolve(
 
         Err(err) => {
             let response = match err {
-                ContextParsingError::Unauthorized => error_msg("Unauthorized", 401),
-                ContextParsingError::Malformed => error_msg("Malformed header", 400),
+                ContextExtractionError::Unauthorized => error_msg("Unauthorized", 401),
+                ContextExtractionError::Malformed => error_msg("Malformed header", 400),
                 _ => error_msg("Unknown error", 401),
             };
 


### PR DESCRIPTION
In the existing implementation, we eagerly extract JWT and cookie values. As a result, even when no context used `@jwt` or `@cookie`, the corresponding extraction logic is executed (the intention was to avoid per-field extraction by loading all JWT claims and all cookies once per request). Due to this, we incur an overhead, especially for operations that didn't need JWT/cookie context (such as those with `@access(true)`. Another user-facing effect is the printing of the following message:
```
2023-07-24T23:46:55.958435Z  WARN core_resolver::context::provider::jwt: EXO_JWT_SECRET is not set, not parsing JWT tokens
```
(and with the recent change of schema refreshing logic, this message got printed every two seconds!).

In this PR, we make both these contexts lazy. We use `OnceCell` to ensure the computation occurs only once per request. In the process, we also make `ContextExtractor::extract_context_field` return `Result`.