### PR TITLE
Gracefully exit server when an error occurs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6135,6 +6135,7 @@ dependencies = [
  "resolver",
  "serde_json",
  "server-common",
+ "thiserror",
  "tracing",
  "tracing-actix-web",
 ]

--- a/crates/server-actix/Cargo.toml
+++ b/crates/server-actix/Cargo.toml
@@ -27,6 +27,7 @@ actix-web = { version = "4.1.0", default-features = false, features = [
 ] }
 actix-cors = "0.6.2"
 actix-files = "0.6.2"
+thiserror.workspace = true
 
 serde_json = { workspace = true, features = ["preserve_order"] }
 futures.workspace = true


### PR DESCRIPTION
We have been using `std::process::exit` to exit the server when, for example, the port is already in use. However, this causes an ugly error message to be printed to the console:
```
...
Applying migrations...
Error: Port 9876 is already in use. Check if there is another process running at that port.
thread '<unnamed>' panicked at 'cannot access a Thread Local Storage value during or after destruction: AccessError', /rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/std/src/thread/local.rs:246:26
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
fatal runtime error: thread local panicked on drop
```

This commit changes the `main` function to simply return an `Err`, which will cause the server to exit gracefully.