### PR TITLE
Use an arena to keep access control expression

### DIFF
--- a/crates/postgres-subsystem/postgres-model-builder/src/access_utils.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/access_utils.rs
@@ -49,7 +49,7 @@ enum JsonPathSelection<'a> {
 
 pub fn compute_input_predicate_expression(
     expr: &AstExpr<Typed>,
-    self_type_info: Option<&EntityType>,
+    self_type_info: &EntityType,
     resolved_env: &ResolvedTypeEnv,
     subsystem_primitive_types: &MappedArena<PostgresPrimitiveType>,
     subsystem_entity_types: &MappedArena<EntityType>,
@@ -129,7 +129,7 @@ pub fn compute_input_predicate_expression(
 
 pub fn compute_predicate_expression(
     expr: &AstExpr<Typed>,
-    self_type_info: Option<&EntityType>,
+    self_type_info: &EntityType,
     resolved_env: &ResolvedTypeEnv,
     subsystem_primitive_types: &MappedArena<PostgresPrimitiveType>,
     subsystem_entity_types: &MappedArena<EntityType>,
@@ -230,7 +230,7 @@ pub fn compute_predicate_expression(
 
 fn compute_primitive_db_expr(
     expr: &AstExpr<Typed>,
-    self_type_info: Option<&EntityType>,
+    self_type_info: &EntityType,
     resolved_env: &ResolvedTypeEnv,
     subsystem_primitive_types: &MappedArena<PostgresPrimitiveType>,
     subsystem_entity_types: &MappedArena<EntityType>,
@@ -271,7 +271,7 @@ fn compute_primitive_db_expr(
 
 fn compute_primitive_json_expr(
     expr: &AstExpr<Typed>,
-    self_type_info: Option<&EntityType>,
+    self_type_info: &EntityType,
     resolved_env: &ResolvedTypeEnv,
     subsystem_primitive_types: &MappedArena<PostgresPrimitiveType>,
     subsystem_entity_types: &MappedArena<EntityType>,
@@ -355,7 +355,7 @@ fn compute_relational_op<PrimExpr: Send + Sync>(
 
 fn compute_column_selection<'a>(
     selection: &FieldSelection<Typed>,
-    self_type_info: Option<&'a EntityType>,
+    self_type_info: &'a EntityType,
     resolved_env: &'a ResolvedTypeEnv<'a>,
     subsystem_primitive_types: &'a MappedArena<PostgresPrimitiveType>,
     subsystem_entity_types: &'a MappedArena<EntityType>,
@@ -382,7 +382,7 @@ fn compute_column_selection<'a>(
 
     if path_elements[0] == "self" {
         let (_, column_path, field_type) = path_elements[1..].iter().fold(
-            (self_type_info, None::<PhysicalColumnPath>, None),
+            (Some(self_type_info), None::<PhysicalColumnPath>, None),
             |(self_type_info, column_path, _field_type), field_name| {
                 let self_type_info =
                     self_type_info.expect("Type for the access selection is not defined");
@@ -418,7 +418,7 @@ fn compute_column_selection<'a>(
 
 fn compute_json_selection<'a>(
     selection: &FieldSelection<Typed>,
-    self_type_info: Option<&'a EntityType>,
+    self_type_info: &'a EntityType,
     resolved_env: &'a ResolvedTypeEnv<'a>,
     subsystem_primitive_types: &'a MappedArena<PostgresPrimitiveType>,
     subsystem_entity_types: &'a MappedArena<EntityType>,
@@ -436,7 +436,7 @@ fn compute_json_selection<'a>(
 
     if path_elements[0] == "self" {
         let (_, json_path, field_type) = path_elements[1..].iter().fold(
-            (self_type_info, Vec::new(), None),
+            (Some(self_type_info), Vec::new(), None),
             |(self_type_info, json_path, _field_type), field_name| {
                 let self_type_info =
                     self_type_info.expect("Type for the access selection is not defined");

--- a/crates/postgres-subsystem/postgres-model-builder/src/create_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/create_mutation_builder.rs
@@ -52,12 +52,13 @@ impl Builder for CreateMutationBuilder {
     }
 
     fn build_expanded(&self, resolved_env: &ResolvedTypeEnv, building: &mut SystemContextBuilding) {
-        fn creation_access_is_false(entity_type: &EntityType) -> bool {
+        let creation_access_is_false = |entity_type: &EntityType| -> bool {
             matches!(
-                entity_type.access.creation,
+                building.input_access_expressions[entity_type.access.creation],
                 AccessPredicateExpression::BooleanLiteral(false)
             )
-        }
+        };
+
         for (_, entity_type) in building.entity_types.iter() {
             if !creation_access_is_false(entity_type) {
                 for (existing_id, expanded_type) in self.expanded_data_type(

--- a/crates/postgres-subsystem/postgres-model-builder/src/create_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/create_mutation_builder.rs
@@ -10,13 +10,10 @@
 //! Build mutation input types associated with creation (`<Type>CreationInput`) and
 //! the create mutations (`create<Type>`, and `create<Type>s`)
 
-use core_plugin_interface::{
-    core_model::{
-        access::AccessPredicateExpression,
-        mapped_arena::MappedArena,
-        types::{BaseOperationReturnType, FieldType, OperationReturnType},
-    },
-    core_model_builder::ast::ast_types::AstExpr,
+use core_plugin_interface::core_model::{
+    access::AccessPredicateExpression,
+    mapped_arena::MappedArena,
+    types::{BaseOperationReturnType, FieldType, OperationReturnType},
 };
 
 use postgres_model::{
@@ -43,7 +40,7 @@ impl Builder for CreateMutationBuilder {
         resolved_composite_type: &ResolvedCompositeType,
         types: &MappedArena<ResolvedType>,
     ) -> Vec<String> {
-        if let AstExpr::BooleanLiteral(false, _) = resolved_composite_type.access.creation {
+        if !resolved_composite_type.access.creation_allowed() {
             return vec![];
         }
         let mut field_types = self.data_param_field_type_names(resolved_composite_type, types);

--- a/crates/postgres-subsystem/postgres-model-builder/src/delete_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/delete_mutation_builder.rs
@@ -48,7 +48,9 @@ impl Builder for DeleteMutationBuilder {
     ) {
         // Since there are no special input types for deletion, no expansion is needed
         for (entity_type_id, entity_type) in building.entity_types.iter() {
-            if let AccessPredicateExpression::BooleanLiteral(false) = entity_type.access.delete {
+            if let AccessPredicateExpression::BooleanLiteral(false) =
+                building.database_access_expressions[entity_type.access.delete]
+            {
                 continue;
             }
             for mutation in self.build_mutations(entity_type_id, entity_type, building) {

--- a/crates/postgres-subsystem/postgres-model-builder/src/resolved_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/resolved_builder.rs
@@ -934,8 +934,6 @@ mod tests {
     use builder::{load_subsystem_builders, parser, typechecker};
     use std::fs::File;
 
-    // FIXME: separate out unit tests into respective plugins
-
     #[test]
     fn with_annotations() {
         let src = r#"

--- a/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__column_names_for_non_standard_relational_field_names.snap
+++ b/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__column_names_for_non_standard_relational_field_names.snap
@@ -85,18 +85,12 @@ values:
             default_value: ~
         table_name: concerts
         access:
-          creation:
-            BooleanLiteral:
-              - false
-          read:
-            BooleanLiteral:
-              - false
-          update:
-            BooleanLiteral:
-              - false
-          delete:
-            BooleanLiteral:
-              - false
+          default: ~
+          query: ~
+          mutation: ~
+          creation: ~
+          update: ~
+          delete: ~
   - - ~
     - Composite:
         name: Venue
@@ -149,18 +143,12 @@ values:
             default_value: ~
         table_name: venues
         access:
-          creation:
-            BooleanLiteral:
-              - false
-          read:
-            BooleanLiteral:
-              - false
-          update:
-            BooleanLiteral:
-              - false
-          delete:
-            BooleanLiteral:
-              - false
+          default: ~
+          query: ~
+          mutation: ~
+          creation: ~
+          update: ~
+          delete: ~
   - ~
   - ~
   - ~

--- a/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__field_name_variations.snap
+++ b/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__field_name_variations.snap
@@ -107,18 +107,12 @@ values:
             default_value: ~
         table_name: entitys
         access:
-          creation:
-            BooleanLiteral:
-              - false
-          read:
-            BooleanLiteral:
-              - false
-          update:
-            BooleanLiteral:
-              - false
-          delete:
-            BooleanLiteral:
-              - false
+          default: ~
+          query: ~
+          mutation: ~
+          creation: ~
+          update: ~
+          delete: ~
 map:
   Blob:
     index: 10

--- a/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__with_access.snap
+++ b/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__with_access.snap
@@ -74,7 +74,7 @@ values:
             default_value: ~
         table_name: concerts
         access:
-          creation:
+          default:
             LogicalOp:
               Or:
                 - RelationalOp:
@@ -105,99 +105,11 @@ values:
                           index: 0
                           generation: ~
                 - Primitive: Boolean
-          read:
-            LogicalOp:
-              Or:
-                - RelationalOp:
-                    Eq:
-                      - FieldSelection:
-                          Select:
-                            - Single:
-                                - - AuthContext
-                                - Reference:
-                                    index: 15
-                                    generation: ~
-                            - - role
-                            - Reference:
-                                index: 4
-                                generation: ~
-                      - StringLiteral:
-                          - ROLE_ADMIN
-                      - Primitive: Boolean
-                - FieldSelection:
-                    Select:
-                      - Single:
-                          - - self
-                          - Reference:
-                              index: 16
-                              generation: ~
-                      - - public
-                      - Reference:
-                          index: 0
-                          generation: ~
-                - Primitive: Boolean
-          update:
-            LogicalOp:
-              Or:
-                - RelationalOp:
-                    Eq:
-                      - FieldSelection:
-                          Select:
-                            - Single:
-                                - - AuthContext
-                                - Reference:
-                                    index: 15
-                                    generation: ~
-                            - - role
-                            - Reference:
-                                index: 4
-                                generation: ~
-                      - StringLiteral:
-                          - ROLE_ADMIN
-                      - Primitive: Boolean
-                - FieldSelection:
-                    Select:
-                      - Single:
-                          - - self
-                          - Reference:
-                              index: 16
-                              generation: ~
-                      - - public
-                      - Reference:
-                          index: 0
-                          generation: ~
-                - Primitive: Boolean
-          delete:
-            LogicalOp:
-              Or:
-                - RelationalOp:
-                    Eq:
-                      - FieldSelection:
-                          Select:
-                            - Single:
-                                - - AuthContext
-                                - Reference:
-                                    index: 15
-                                    generation: ~
-                            - - role
-                            - Reference:
-                                index: 4
-                                generation: ~
-                      - StringLiteral:
-                          - ROLE_ADMIN
-                      - Primitive: Boolean
-                - FieldSelection:
-                    Select:
-                      - Single:
-                          - - self
-                          - Reference:
-                              index: 16
-                              generation: ~
-                      - - public
-                      - Reference:
-                          index: 0
-                          generation: ~
-                - Primitive: Boolean
+          query: ~
+          mutation: ~
+          creation: ~
+          update: ~
+          delete: ~
   - - ~
     - Composite:
         name: Venue
@@ -227,18 +139,14 @@ values:
             default_value: ~
         table_name: venues
         access:
-          creation:
+          default:
             BooleanLiteral:
               - true
-          read:
-            BooleanLiteral:
-              - true
-          update:
-            BooleanLiteral:
-              - true
-          delete:
-            BooleanLiteral:
-              - true
+          query: ~
+          mutation: ~
+          creation: ~
+          update: ~
+          delete: ~
   - - ~
     - Composite:
         name: Artist
@@ -268,18 +176,14 @@ values:
             default_value: ~
         table_name: artists
         access:
-          creation:
+          default:
             BooleanLiteral:
               - false
-          read:
-            BooleanLiteral:
-              - false
-          update:
-            BooleanLiteral:
-              - false
-          delete:
-            BooleanLiteral:
-              - false
+          query: ~
+          mutation: ~
+          creation: ~
+          update: ~
+          delete: ~
   - ~
   - ~
   - ~

--- a/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__with_access_default_values.snap
+++ b/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__with_access_default_values.snap
@@ -74,7 +74,7 @@ values:
             default_value: ~
         table_name: concerts
         access:
-          creation:
+          default:
             LogicalOp:
               Or:
                 - RelationalOp:
@@ -105,99 +105,11 @@ values:
                           index: 0
                           generation: ~
                 - Primitive: Boolean
-          read:
-            LogicalOp:
-              Or:
-                - RelationalOp:
-                    Eq:
-                      - FieldSelection:
-                          Select:
-                            - Single:
-                                - - AuthContext
-                                - Reference:
-                                    index: 15
-                                    generation: ~
-                            - - role
-                            - Reference:
-                                index: 4
-                                generation: ~
-                      - StringLiteral:
-                          - ROLE_ADMIN
-                      - Primitive: Boolean
-                - FieldSelection:
-                    Select:
-                      - Single:
-                          - - self
-                          - Reference:
-                              index: 16
-                              generation: ~
-                      - - public
-                      - Reference:
-                          index: 0
-                          generation: ~
-                - Primitive: Boolean
-          update:
-            LogicalOp:
-              Or:
-                - RelationalOp:
-                    Eq:
-                      - FieldSelection:
-                          Select:
-                            - Single:
-                                - - AuthContext
-                                - Reference:
-                                    index: 15
-                                    generation: ~
-                            - - role
-                            - Reference:
-                                index: 4
-                                generation: ~
-                      - StringLiteral:
-                          - ROLE_ADMIN
-                      - Primitive: Boolean
-                - FieldSelection:
-                    Select:
-                      - Single:
-                          - - self
-                          - Reference:
-                              index: 16
-                              generation: ~
-                      - - public
-                      - Reference:
-                          index: 0
-                          generation: ~
-                - Primitive: Boolean
-          delete:
-            LogicalOp:
-              Or:
-                - RelationalOp:
-                    Eq:
-                      - FieldSelection:
-                          Select:
-                            - Single:
-                                - - AuthContext
-                                - Reference:
-                                    index: 15
-                                    generation: ~
-                            - - role
-                            - Reference:
-                                index: 4
-                                generation: ~
-                      - StringLiteral:
-                          - ROLE_ADMIN
-                      - Primitive: Boolean
-                - FieldSelection:
-                    Select:
-                      - Single:
-                          - - self
-                          - Reference:
-                              index: 16
-                              generation: ~
-                      - - public
-                      - Reference:
-                          index: 0
-                          generation: ~
-                - Primitive: Boolean
+          query: ~
+          mutation: ~
+          creation: ~
+          update: ~
+          delete: ~
 map:
   Blob:
     index: 10

--- a/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__with_annotations.snap
+++ b/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__with_annotations.snap
@@ -121,18 +121,12 @@ values:
             default_value: ~
         table_name: custom_concerts
         access:
-          creation:
-            BooleanLiteral:
-              - false
-          read:
-            BooleanLiteral:
-              - false
-          update:
-            BooleanLiteral:
-              - false
-          delete:
-            BooleanLiteral:
-              - false
+          default: ~
+          query: ~
+          mutation: ~
+          creation: ~
+          update: ~
+          delete: ~
   - - ~
     - Composite:
         name: Venue
@@ -201,18 +195,12 @@ values:
             default_value: ~
         table_name: venues
         access:
-          creation:
-            BooleanLiteral:
-              - false
-          read:
-            BooleanLiteral:
-              - false
-          update:
-            BooleanLiteral:
-              - false
-          delete:
-            BooleanLiteral:
-              - false
+          default: ~
+          query: ~
+          mutation: ~
+          creation: ~
+          update: ~
+          delete: ~
   - ~
   - ~
   - ~

--- a/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__with_camel_case_model_and_fields.snap
+++ b/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__with_camel_case_model_and_fields.snap
@@ -63,18 +63,12 @@ values:
             default_value: ~
         table_name: concert_infos
         access:
-          creation:
-            BooleanLiteral:
-              - false
-          read:
-            BooleanLiteral:
-              - false
-          update:
-            BooleanLiteral:
-              - false
-          delete:
-            BooleanLiteral:
-              - false
+          default: ~
+          query: ~
+          mutation: ~
+          creation: ~
+          update: ~
+          delete: ~
 map:
   Blob:
     index: 10

--- a/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__with_defaults.snap
+++ b/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__with_defaults.snap
@@ -102,18 +102,12 @@ values:
             default_value: ~
         table_name: concerts
         access:
-          creation:
-            BooleanLiteral:
-              - false
-          read:
-            BooleanLiteral:
-              - false
-          update:
-            BooleanLiteral:
-              - false
-          delete:
-            BooleanLiteral:
-              - false
+          default: ~
+          query: ~
+          mutation: ~
+          creation: ~
+          update: ~
+          delete: ~
   - - ~
     - Composite:
         name: Venue
@@ -157,18 +151,12 @@ values:
             default_value: ~
         table_name: venues
         access:
-          creation:
-            BooleanLiteral:
-              - false
-          read:
-            BooleanLiteral:
-              - false
-          update:
-            BooleanLiteral:
-              - false
-          delete:
-            BooleanLiteral:
-              - false
+          default: ~
+          query: ~
+          mutation: ~
+          creation: ~
+          update: ~
+          delete: ~
   - ~
   - ~
   - ~

--- a/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__with_multiple_matching_field_with_column_annotation.snap
+++ b/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__with_multiple_matching_field_with_column_annotation.snap
@@ -85,18 +85,12 @@ values:
             default_value: ~
         table_name: concerts
         access:
-          creation:
-            BooleanLiteral:
-              - false
-          read:
-            BooleanLiteral:
-              - false
-          update:
-            BooleanLiteral:
-              - false
-          delete:
-            BooleanLiteral:
-              - false
+          default: ~
+          query: ~
+          mutation: ~
+          creation: ~
+          update: ~
+          delete: ~
   - - ~
     - Composite:
         name: Venue
@@ -150,18 +144,12 @@ values:
             default_value: ~
         table_name: venues
         access:
-          creation:
-            BooleanLiteral:
-              - false
-          read:
-            BooleanLiteral:
-              - false
-          update:
-            BooleanLiteral:
-              - false
-          delete:
-            BooleanLiteral:
-              - false
+          default: ~
+          query: ~
+          mutation: ~
+          creation: ~
+          update: ~
+          delete: ~
   - ~
   - ~
   - ~

--- a/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__with_optional_fields.snap
+++ b/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__with_optional_fields.snap
@@ -87,18 +87,12 @@ values:
             default_value: ~
         table_name: concerts
         access:
-          creation:
-            BooleanLiteral:
-              - false
-          read:
-            BooleanLiteral:
-              - false
-          update:
-            BooleanLiteral:
-              - false
-          delete:
-            BooleanLiteral:
-              - false
+          default: ~
+          query: ~
+          mutation: ~
+          creation: ~
+          update: ~
+          delete: ~
   - - ~
     - Composite:
         name: Venue
@@ -153,18 +147,12 @@ values:
             default_value: ~
         table_name: venues
         access:
-          creation:
-            BooleanLiteral:
-              - false
-          read:
-            BooleanLiteral:
-              - false
-          update:
-            BooleanLiteral:
-              - false
-          delete:
-            BooleanLiteral:
-              - false
+          default: ~
+          query: ~
+          mutation: ~
+          creation: ~
+          update: ~
+          delete: ~
   - ~
   - ~
   - ~

--- a/crates/postgres-subsystem/postgres-model-builder/src/system_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/system_builder.rs
@@ -8,7 +8,10 @@
 // by the Apache License, Version 2.0.
 
 use core_plugin_interface::{
-    core_model::mapped_arena::{MappedArena, SerializableSlabIndex},
+    core_model::{
+        access::AccessPredicateExpression,
+        mapped_arena::{MappedArena, SerializableSlab, SerializableSlabIndex},
+    },
     core_model_builder::{
         builder::system_builder::BaseModelSystem, error::ModelBuildingError,
         typechecker::typ::TypecheckedSystem,
@@ -16,6 +19,7 @@ use core_plugin_interface::{
 };
 
 use postgres_model::{
+    access::{DatabaseAccessPrimitiveExpression, InputAccessPrimitiveExpression},
     aggregate::AggregateType,
     mutation::PostgresMutation,
     order::OrderByParameterType,
@@ -64,6 +68,9 @@ pub fn build(
             database: building.database,
             mutation_types: building.mutation_types.values(),
             mutations: building.mutations,
+
+            input_access_expressions: building.input_access_expressions,
+            database_access_expressions: building.database_access_expressions,
         }
     };
 
@@ -118,7 +125,7 @@ fn build_expanded(
     Ok(())
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct SystemContextBuilding {
     pub primitive_types: MappedArena<PostgresPrimitiveType>,
     pub entity_types: MappedArena<EntityType>,
@@ -134,7 +141,39 @@ pub struct SystemContextBuilding {
 
     pub mutation_types: MappedArena<MutationType>,
     pub mutations: MappedArena<PostgresMutation>,
+
+    pub input_access_expressions:
+        SerializableSlab<AccessPredicateExpression<InputAccessPrimitiveExpression>>,
+    pub database_access_expressions:
+        SerializableSlab<AccessPredicateExpression<DatabaseAccessPrimitiveExpression>>,
+
     pub database: Database,
+}
+
+impl Default for SystemContextBuilding {
+    fn default() -> Self {
+        Self {
+            primitive_types: MappedArena::default(),
+            entity_types: MappedArena::default(),
+
+            aggregate_types: MappedArena::default(),
+
+            order_by_types: MappedArena::default(),
+            predicate_types: MappedArena::default(),
+
+            pk_queries: MappedArena::default(),
+            collection_queries: MappedArena::default(),
+            aggregate_queries: MappedArena::default(),
+
+            mutation_types: MappedArena::default(),
+            mutations: MappedArena::default(),
+
+            input_access_expressions: SerializableSlab::new(),
+            database_access_expressions: SerializableSlab::new(),
+
+            database: Database::default(),
+        }
+    }
 }
 
 impl SystemContextBuilding {

--- a/crates/postgres-subsystem/postgres-model-builder/src/system_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/system_builder.rs
@@ -148,8 +148,8 @@ pub struct SystemContextBuilding {
     pub database: Database,
 }
 
-/// Structrue to keep track of access expressions arena and a special index for the oft-used restrictive access.
-/// By keeping track of the restrictive access index, we avoid creating multiple index for the same `False` expression.
+/// Structure to keep track of access expressions arena and a special index for the oft-used restrictive access.
+/// By keeping track of the restrictive access index, we avoid creating multiple indices for the same `False` expression.
 #[derive(Debug)]
 pub struct AccessExpressionsBuilding<T: Send + Sync> {
     elems: SerializableSlab<AccessPredicateExpression<T>>,

--- a/crates/postgres-subsystem/postgres-model-builder/src/type_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/type_builder.rs
@@ -17,6 +17,7 @@ use super::{access_builder::ResolvedAccess, access_utils, resolved_builder::Reso
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
 use core_plugin_interface::{
     core_model::{
+        access::AccessPredicateExpression,
         context_type::{get_context, ContextType},
         mapped_arena::{MappedArena, SerializableSlabIndex},
         primitive_type::PrimitiveType,
@@ -32,7 +33,10 @@ use exo_sql::{
 
 use heck::ToSnakeCase;
 use postgres_model::{
-    access::{Access, UpdateAccessExpression},
+    access::{
+        Access, DatabaseAccessPrimitiveExpression, InputAccessPrimitiveExpression,
+        UpdateAccessExpression,
+    },
     aggregate::{AggregateField, AggregateFieldType},
     relation::{ManyToOneRelation, OneToManyRelation, PostgresRelation, RelationCardinality},
     types::{
@@ -416,44 +420,111 @@ fn expand_type_access(
     Ok(())
 }
 
+/// Compute access expression for database access.
+///
+/// Goes over the chain of the expressions and maps the first non-optiona expression to a database access expression.
+fn compute_database_access_expr(
+    ast_exprs: &[&Option<AstExpr<Typed>>],
+    entity_id: SerializableSlabIndex<EntityType>,
+    resolved_env: &ResolvedTypeEnv,
+    building: &mut SystemContextBuilding,
+) -> Result<
+    SerializableSlabIndex<AccessPredicateExpression<DatabaseAccessPrimitiveExpression>>,
+    ModelBuildingError,
+> {
+    let entity = &building.entity_types[entity_id];
+
+    let expr = ast_exprs
+        .iter()
+        .find_map(|ast_expr| {
+            ast_expr.as_ref().map(|ast_expr| {
+                access_utils::compute_predicate_expression(
+                    ast_expr,
+                    entity,
+                    resolved_env,
+                    &building.primitive_types,
+                    &building.entity_types,
+                    &building.database,
+                )
+            })
+        })
+        .transpose()?;
+
+    Ok(match expr {
+        Some(AccessPredicateExpression::BooleanLiteral(false)) | None => building
+            .database_access_expressions
+            .restricted_access_index(),
+        Some(expr) => building.database_access_expressions.insert(expr),
+    })
+}
+
+fn compute_input_access_expr(
+    ast_exprs: &[&Option<AstExpr<Typed>>],
+    entity_id: SerializableSlabIndex<EntityType>,
+    resolved_env: &ResolvedTypeEnv,
+    building: &mut SystemContextBuilding,
+) -> Result<
+    SerializableSlabIndex<AccessPredicateExpression<InputAccessPrimitiveExpression>>,
+    ModelBuildingError,
+> {
+    let entity = &building.entity_types[entity_id];
+
+    let expr = ast_exprs
+        .iter()
+        .find_map(|ast_expr| {
+            ast_expr.as_ref().map(|ast_expr| {
+                access_utils::compute_input_predicate_expression(
+                    ast_expr,
+                    entity,
+                    resolved_env,
+                    &building.primitive_types,
+                    &building.entity_types,
+                )
+            })
+        })
+        .transpose()?;
+
+    Ok(match expr {
+        Some(AccessPredicateExpression::BooleanLiteral(false)) | None => {
+            building.input_access_expressions.restricted_access_index()
+        }
+        Some(expr) => building.input_access_expressions.insert(expr),
+    })
+}
+
 pub fn compute_access_composite_types(
     resolved: &ResolvedAccess,
-    self_type_info: SerializableSlabIndex<EntityType>,
+    entity_id: SerializableSlabIndex<EntityType>,
     resolved_env: &ResolvedTypeEnv,
     building: &mut SystemContextBuilding,
 ) -> Result<Access, ModelBuildingError> {
-    let self_type_info = &building.entity_types[self_type_info];
-    let mut access_expr = |expr: &AstExpr<Typed>| {
-        let expr = access_utils::compute_predicate_expression(
-            expr,
-            Some(self_type_info),
-            resolved_env,
-            &building.primitive_types,
-            &building.entity_types,
-            &building.database,
-        );
-        expr.map(|expr| building.database_access_expressions.insert(expr))
+    let mut compute_input_access_expr = |ast_exprs: &[&Option<AstExpr<Typed>>]| {
+        compute_input_access_expr(ast_exprs, entity_id, resolved_env, building)
     };
 
-    let mut access_json_expr = |expr: &AstExpr<Typed>| {
-        let expr = access_utils::compute_input_predicate_expression(
-            expr,
-            Some(self_type_info),
-            resolved_env,
-            &building.primitive_types,
-            &building.entity_types,
-        );
-        expr.map(|expr| building.input_access_expressions.insert(expr))
+    let creation_input_access =
+        compute_input_access_expr(&[&resolved.creation, &resolved.mutation, &resolved.default])?;
+    let update_input_access =
+        compute_input_access_expr(&[&resolved.update, &resolved.mutation, &resolved.default])?;
+
+    let mut compute_database_access_expr = |ast_exprs: &[&Option<AstExpr<Typed>>]| {
+        compute_database_access_expr(ast_exprs, entity_id, resolved_env, building)
     };
+
+    let query_access = compute_database_access_expr(&[&resolved.query, &resolved.default])?;
+    let update_database_access =
+        compute_database_access_expr(&[&resolved.update, &resolved.mutation, &resolved.default])?;
+    let delete_access =
+        compute_database_access_expr(&[&resolved.delete, &resolved.mutation, &resolved.default])?;
 
     Ok(Access {
-        creation: access_json_expr(&resolved.creation)?,
-        read: access_expr(&resolved.read)?,
+        read: query_access,
+        creation: creation_input_access,
         update: UpdateAccessExpression {
-            input: access_json_expr(&resolved.update)?,
-            database: access_expr(&resolved.update)?,
+            input: update_input_access,
+            database: update_database_access,
         },
-        delete: access_expr(&resolved.delete)?,
+        delete: delete_access,
     })
 }
 

--- a/crates/postgres-subsystem/postgres-model-builder/src/type_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/type_builder.rs
@@ -422,7 +422,7 @@ fn expand_type_access(
 
 /// Compute access expression for database access.
 ///
-/// Goes over the chain of the expressions and maps the first non-optiona expression to a database access expression.
+/// Goes over the chain of the expressions and maps the first non-optional expression to a database access expression.
 fn compute_database_access_expr(
     ast_exprs: &[&Option<AstExpr<Typed>>],
     entity_id: SerializableSlabIndex<EntityType>,

--- a/crates/postgres-subsystem/postgres-model-builder/src/update_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/update_mutation_builder.rs
@@ -9,13 +9,10 @@
 
 //! Build update mutation types `<Type>UpdateInput`, `update<Type>`, and `update<Type>s`
 
-use core_plugin_interface::{
-    core_model::{
-        access::AccessPredicateExpression,
-        mapped_arena::{MappedArena, SerializableSlabIndex},
-        types::{BaseOperationReturnType, FieldType, Named, OperationReturnType},
-    },
-    core_model_builder::ast::ast_types::AstExpr,
+use core_plugin_interface::core_model::{
+    access::AccessPredicateExpression,
+    mapped_arena::{MappedArena, SerializableSlabIndex},
+    types::{BaseOperationReturnType, FieldType, Named, OperationReturnType},
 };
 use postgres_model::{
     mutation::{DataParameter, DataParameterType, PostgresMutationParameters},
@@ -45,7 +42,7 @@ impl Builder for UpdateMutationBuilder {
         types: &MappedArena<ResolvedType>,
     ) -> Vec<String> {
         // TODO: This implementation is the same for CreateMutationBuilder. Fix it when we refactor non-mutations builders
-        if let AstExpr::BooleanLiteral(false, _) = resolved_composite_type.access.update {
+        if !resolved_composite_type.access.update_allowed() {
             return vec![];
         }
         let mut field_types = self.data_param_field_type_names(resolved_composite_type, types);

--- a/crates/postgres-subsystem/postgres-model-builder/src/update_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/update_mutation_builder.rs
@@ -55,15 +55,15 @@ impl Builder for UpdateMutationBuilder {
 
     /// Expand the mutation input types as well as build the mutation
     fn build_expanded(&self, resolved_env: &ResolvedTypeEnv, building: &mut SystemContextBuilding) {
-        fn update_access_is_false(entity_type: &EntityType) -> bool {
+        let update_access_is_false = |entity_type: &EntityType| -> bool {
             matches!(
-                entity_type.access.update.input,
+                building.input_access_expressions[entity_type.access.update.input],
                 AccessPredicateExpression::BooleanLiteral(false)
             ) || matches!(
-                entity_type.access.update.existing,
+                building.database_access_expressions[entity_type.access.update.database],
                 AccessPredicateExpression::BooleanLiteral(false)
             )
-        }
+        };
         for (_, entity_type) in building.entity_types.iter() {
             if !update_access_is_false(entity_type) {
                 for (existing_id, expanded_type) in self.expanded_data_type(

--- a/crates/postgres-subsystem/postgres-model/src/access.rs
+++ b/crates/postgres-subsystem/postgres-model/src/access.rs
@@ -7,44 +7,27 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use core_plugin_interface::core_model::access::AccessPredicateExpression;
-use core_plugin_interface::core_model::access::CommonAccessPrimitiveExpression;
+use core_plugin_interface::core_model::{
+    access::{AccessPredicateExpression, CommonAccessPrimitiveExpression},
+    mapped_arena::SerializableSlabIndex,
+};
 use exo_sql::PhysicalColumnPath;
 use serde::{Deserialize, Serialize};
 
 /// Access specification for a model
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Access {
-    pub creation: AccessPredicateExpression<InputAccessPrimitiveExpression>,
-    pub read: AccessPredicateExpression<DatabaseAccessPrimitiveExpression>,
+    pub creation: SerializableSlabIndex<AccessPredicateExpression<InputAccessPrimitiveExpression>>,
+    pub read: SerializableSlabIndex<AccessPredicateExpression<DatabaseAccessPrimitiveExpression>>,
     pub update: UpdateAccessExpression,
-    pub delete: AccessPredicateExpression<DatabaseAccessPrimitiveExpression>,
+    pub delete: SerializableSlabIndex<AccessPredicateExpression<DatabaseAccessPrimitiveExpression>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct UpdateAccessExpression {
-    pub input: AccessPredicateExpression<InputAccessPrimitiveExpression>,
-    pub existing: AccessPredicateExpression<DatabaseAccessPrimitiveExpression>,
-}
-
-impl UpdateAccessExpression {
-    pub const fn restrictive() -> Self {
-        Self {
-            input: AccessPredicateExpression::BooleanLiteral(false),
-            existing: AccessPredicateExpression::BooleanLiteral(false),
-        }
-    }
-}
-
-impl Access {
-    pub const fn restrictive() -> Self {
-        Self {
-            creation: AccessPredicateExpression::BooleanLiteral(false),
-            read: AccessPredicateExpression::BooleanLiteral(false),
-            update: UpdateAccessExpression::restrictive(),
-            delete: AccessPredicateExpression::BooleanLiteral(false),
-        }
-    }
+    pub input: SerializableSlabIndex<AccessPredicateExpression<InputAccessPrimitiveExpression>>,
+    pub database:
+        SerializableSlabIndex<AccessPredicateExpression<DatabaseAccessPrimitiveExpression>>,
 }
 
 /// Primitive expression (that doesn't contain any other expressions).

--- a/crates/postgres-subsystem/postgres-model/src/subsystem.rs
+++ b/crates/postgres-subsystem/postgres-model/src/subsystem.rs
@@ -16,12 +16,14 @@ use super::{
     query::PkQuery,
 };
 use crate::{
+    access::{DatabaseAccessPrimitiveExpression, InputAccessPrimitiveExpression},
     aggregate::AggregateType,
     query::{AggregateQuery, CollectionQuery},
     types::{EntityType, MutationType, PostgresPrimitiveType},
 };
 use core_plugin_interface::{
     core_model::{
+        access::AccessPredicateExpression,
         context_type::{ContextContainer, ContextType},
         mapped_arena::{MappedArena, SerializableSlab},
         type_normalization::{FieldDefinitionProvider, TypeDefinitionProvider},
@@ -51,6 +53,11 @@ pub struct PostgresSubsystem {
     // mutation related
     pub mutation_types: SerializableSlab<MutationType>, // create, update, delete input types such as `PersonUpdateInput`
     pub mutations: MappedArena<PostgresMutation>,
+
+    pub input_access_expressions:
+        SerializableSlab<AccessPredicateExpression<InputAccessPrimitiveExpression>>,
+    pub database_access_expressions:
+        SerializableSlab<AccessPredicateExpression<DatabaseAccessPrimitiveExpression>>,
 
     pub database: Database,
 }
@@ -130,6 +137,10 @@ impl Default for PostgresSubsystem {
             aggregate_queries: MappedArena::default(),
             mutation_types: SerializableSlab::new(),
             mutations: MappedArena::default(),
+
+            input_access_expressions: SerializableSlab::new(),
+            database_access_expressions: SerializableSlab::new(),
+
             database: Database::default(),
         }
     }


### PR DESCRIPTION
This is in preparation for an upcoming one, where we need to make access control expressions (which are not `Clone`) be a part of other cloneable structs. So we introduce an arena to keep the indices (which are cloneable) in those structs.

Even though support for that functionality is the primary goal, this PR improves code by avoiding duplicated clones of `AstExpr` (see the comment for the second commit for more details).