### PR TITLE
Refactor access control check for mutations

### DIFF
--- a/crates/postgres-subsystem/postgres-model-builder/src/builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/builder.rs
@@ -48,7 +48,7 @@ pub trait Builder {
                 MutationType {
                     name: type_name.to_string(),
                     fields: vec![],
-                    table_id: SerializableSlabIndex::shallow(),
+                    entity_id: SerializableSlabIndex::shallow(),
                 },
             );
         }

--- a/crates/postgres-subsystem/postgres-model-builder/src/mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/mutation_builder.rs
@@ -381,11 +381,7 @@ pub trait DataParamBuilder<D> {
             MutationType {
                 name: existing_type_name,
                 fields: input_type_fields,
-                table_id: building
-                    .entity_types
-                    .get_by_key(&entity_type.name)
-                    .unwrap()
-                    .table_id,
+                entity_id: building.entity_types.get_id(&entity_type.name).unwrap(),
             },
         ));
 
@@ -415,7 +411,7 @@ pub trait DataParamBuilder<D> {
             .get_by_key(&existing_type_name)
             .unwrap_or_else(|| panic!("Could not find type {existing_type_name} to expand"));
 
-        if existing.table_id == SerializableSlabIndex::shallow() {
+        if existing.entity_id == SerializableSlabIndex::shallow() {
             // If not already expanded
             self.expanded_data_type(
                 field_type,

--- a/crates/postgres-subsystem/postgres-model-builder/src/reference_input_type_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/reference_input_type_builder.rs
@@ -77,11 +77,7 @@ fn expanded_reference_types(
         MutationType {
             name: existing_type_name,
             fields: reference_type_fields,
-            table_id: building
-                .entity_types
-                .get_by_key(&entity_type.name)
-                .unwrap()
-                .table_id,
+            entity_id: building.entity_types.get_id(&entity_type.name).unwrap(),
         },
     )]
 }

--- a/crates/postgres-subsystem/postgres-model-builder/src/update_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/update_mutation_builder.rs
@@ -196,7 +196,7 @@ impl DataParamBuilder<DataParameter> for UpdateMutationBuilder {
         let existing_type_id = building.mutation_types.get_id(&existing_type_name).unwrap();
 
         // If not already expanded
-        if building.mutation_types[existing_type_id].table_id == SerializableSlabIndex::shallow() {
+        if building.mutation_types[existing_type_id].entity_id == SerializableSlabIndex::shallow() {
             let fields_info = vec![
                 (
                     "create",
@@ -241,11 +241,7 @@ impl DataParamBuilder<DataParameter> for UpdateMutationBuilder {
                 MutationType {
                     name: existing_type_name.clone(),
                     fields,
-                    table_id: building
-                        .entity_types
-                        .get_by_key(&field_type.name)
-                        .unwrap()
-                        .table_id,
+                    entity_id: building.entity_types.get_id(&field_type.name).unwrap(),
                 },
             )];
 

--- a/crates/postgres-subsystem/postgres-model/src/types.rs
+++ b/crates/postgres-subsystem/postgres-model/src/types.rs
@@ -25,7 +25,7 @@ use core_plugin_interface::core_model::{
     },
     types::{FieldType, Named},
 };
-use exo_sql::{PhysicalTable, TableId};
+use exo_sql::PhysicalTable;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
@@ -123,7 +123,7 @@ impl Named for EntityType {
 pub struct MutationType {
     pub name: String,
     pub fields: Vec<PostgresField<MutationType>>,
-    pub table_id: TableId,
+    pub entity_id: SerializableSlabIndex<EntityType>,
 }
 
 impl EntityType {

--- a/crates/postgres-subsystem/postgres-resolver/src/aggregate_query.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/aggregate_query.rs
@@ -37,7 +37,7 @@ impl OperationSelectionResolver for AggregateQuery {
         subsystem: &'a PostgresSubsystem,
     ) -> Result<AbstractSelect, PostgresExecutionError> {
         let access_predicate = check_access(
-            &self.return_type,
+            self.return_type.typ(&subsystem.entity_types),
             &SQLOperationKind::Retrieve,
             subsystem,
             request_context,

--- a/crates/postgres-subsystem/postgres-resolver/src/postgres_query.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/postgres_query.rs
@@ -100,7 +100,7 @@ async fn compute_select<'content>(
     request_context: &'content RequestContext<'content>,
 ) -> Result<AbstractSelect, PostgresExecutionError> {
     let access_predicate = check_access(
-        return_type,
+        return_type.typ(&subsystem.entity_types),
         &SQLOperationKind::Retrieve,
         subsystem,
         request_context,

--- a/integration-tests/ownership-access-check/tests/create/invalid-create-user-mismatch-collection-input.exotest
+++ b/integration-tests/ownership-access-check/tests/create/invalid-create-user-mismatch-collection-input.exotest
@@ -1,8 +1,8 @@
 stages:
-  # User cannot update a document that is not theirs
+  # User 2 is trying to create documents for user 1 as well as self
   - operation: |
       mutation {
-        updateDocument(id: 1, data: {content: "updated-content"}) {
+        createDocuments(data: [{content: "new-self-content", user: {id: 2}}, {content: "new-other-content", user: {id: 1}}]) {
           id
           content
           user {
@@ -13,16 +13,18 @@ stages:
       }
     auth: |
       {
-        "sub": 3,
+        "sub": 2,
         "role": "USER"
       }
     response: |
       {
-        "data": {
-          "updateDocument": null
-        }
+        "errors": [
+          {
+            "message": "Not authorized"
+          }
+        ]
       }
-  # Ensure that the earlier mutation did work
+  # Ensure that the earlier mutation didn't work
   - operation: |
       query {
         documents(orderBy: {id: ASC}) {

--- a/integration-tests/ownership-access-check/tests/update/indirect-delete-unowned.exotest
+++ b/integration-tests/ownership-access-check/tests/update/indirect-delete-unowned.exotest
@@ -1,0 +1,178 @@
+stages:
+  # User deletes only their own documents (user 2 owns document 1 and 2)
+  - operation: |
+      mutation {
+        updateUsers(where: {id: {gt: 0}}, data: {name: "updated-user2", documents: {delete: {id: 3}}}) { 
+          id
+          name
+          documents {
+            id
+            content
+            user {
+              id
+            }
+          }
+        }
+      }
+    auth: |
+      {
+        "sub": 2,
+        "role": "USER"
+      }
+    response: |
+      {
+        "data": {
+          "updateUsers": [
+            {
+              "id": 1,
+              "name": "updated-user2",
+              "documents": []
+            },
+            {
+              "id": 2,
+              "name": "updated-user2",
+              "documents": [
+                {
+                  "id": 1,
+                  "content": "content1",
+                  "user": {
+                    "id": 2
+                  }
+                },
+                {
+                  "id": 2,
+                  "content": "content2",
+                  "user": {
+                    "id": 2
+                  }
+                }
+              ]
+            },
+            {
+              "id": 3,
+              "name": "updated-user2",
+              "documents": []
+            },
+            {
+              "id": 4,
+              "name": "updated-user2",
+              "documents": []
+            },
+            {
+              "id": 5,
+              "name": "updated-user2",
+              "documents": []
+            }
+          ]
+        }
+      }
+
+  # Ensure that the earlier mutation didn't change data
+  - operation: |
+      query {
+        allDocs: documents @unordered {
+          id
+          content
+          user {
+            id
+            name
+          }
+        }
+        allUsers: users @unordered {
+          id
+          name
+          documents @unordered {
+            id
+            content
+          }
+        }
+      }
+    auth: |
+      {
+        "role": "ADMIN"
+      }
+    response: |
+      {
+        "data": {
+          "allDocs": [
+            {
+              "id": 1,
+              "content": "content1",
+              "user": {
+                "id": 2,
+                "name": "updated-user2"
+              }
+            },
+            {
+              "id": 2,
+              "content": "content2",
+              "user": {
+                "id": 2,
+                "name": "updated-user2"
+              }
+            },
+            {
+              "id": 3,
+              "content": "content3",
+              "user": {
+                "id": 1,
+                "name": "updated-user2"
+              }
+            },
+            {
+              "id": 4,
+              "content": "content4",
+              "user": {
+                "id": 3,
+                "name": "updated-user2"
+              }
+            }
+          ],
+          "allUsers": [
+            {
+              "id": 1,
+              "name": "updated-user2",
+              "documents": [
+                {
+                  "id": 3,
+                  "content": "content3"
+                }
+              ]
+            },
+            {
+              "id": 2,
+              "name": "updated-user2",
+              "documents": [
+                {
+                  "id": 1,
+                  "content": "content1"
+                },
+                {
+                  "id": 2,
+                  "content": "content2"
+                }
+              ]
+            },
+            {
+              "id": 3,
+              "name": "updated-user2",
+              "documents": [
+                {
+                  "id": 4,
+                  "content": "content4"
+                }
+              ]
+            },
+            {
+              "id": 4,
+              "name": "updated-user2",
+              "documents": []
+            },
+            {
+              "id": 5,
+              "name": "updated-user2",
+              "documents": []
+            }
+          ]
+        }
+      }

--- a/integration-tests/ownership-access-check/tests/update/indirect-update-unowned.exotest
+++ b/integration-tests/ownership-access-check/tests/update/indirect-update-unowned.exotest
@@ -1,0 +1,180 @@
+stages:
+  # User can updates only their own documents (user 2 owns document 1 and 2)
+  - operation: |
+      mutation {
+        # Update all documents through user, but implicitly only if the user owns them
+        # Since user 2 does not own document 3, it should not be updated due to access control rules
+        updateUsers(where: {id: {gt: 0}}, data: {name: "updated-user2", documents: {update: {id: 3, content: "indirect-update"}}}) { 
+          id
+          name
+          documents @unordered {
+            id
+            content
+            user {
+              id
+            }
+          }
+        }
+      }
+    auth: |
+      {
+        "sub": 2,
+        "role": "USER"
+      }
+    response: |
+      {
+        "data": {
+          "updateUsers": [
+            {
+              "id": 1,
+              "name": "updated-user2",
+              "documents": []
+            },
+            {
+              "id": 2,
+              "name": "updated-user2",
+              "documents": [
+                {
+                  "id": 1,
+                  "content": "content1",
+                  "user": {
+                    "id": 2
+                  }
+                },
+                {
+                  "id": 2,
+                  "content": "content2",
+                  "user": {
+                    "id": 2
+                  }
+                }
+              ]
+            },
+            {
+              "id": 3,
+              "name": "updated-user2",
+              "documents": []
+            },
+            {
+              "id": 4,
+              "name": "updated-user2",
+              "documents": []
+            },
+            {
+              "id": 5,
+              "name": "updated-user2",
+              "documents": []
+            }
+          ]
+        }
+      }
+
+  # Ensure that the earlier mutation didn't change data
+  - operation: |
+      query {
+        allDocs: documents @unordered {
+          id
+          content
+          user {
+            id
+            name
+          }
+        }
+        allUsers: users @unordered {
+          id
+          name
+          documents @unordered {
+            id
+            content
+          }
+        }
+      }
+    auth: |
+      {
+        "role": "ADMIN"
+      }
+    response: |
+      {
+        "data": {
+          "allDocs": [
+            {
+              "id": 1,
+              "content": "content1",
+              "user": {
+                "id": 2,
+                "name": "updated-user2"
+              }
+            },
+            {
+              "id": 2,
+              "content": "content2",
+              "user": {
+                "id": 2,
+                "name": "updated-user2"
+              }
+            },
+            {
+              "id": 3,
+              "content": "content3",
+              "user": {
+                "id": 1,
+                "name": "updated-user2"
+              }
+            },
+            {
+              "id": 4,
+              "content": "content4",
+              "user": {
+                "id": 3,
+                "name": "updated-user2"
+              }
+            }
+          ],
+          "allUsers": [
+            {
+              "id": 1,
+              "name": "updated-user2",
+              "documents": [
+                {
+                  "id": 3,
+                  "content": "content3"
+                }
+              ]
+            },
+            {
+              "id": 2,
+              "name": "updated-user2",
+              "documents": [
+                {
+                  "id": 1,
+                  "content": "content1"
+                },
+                {
+                  "id": 2,
+                  "content": "content2"
+                }
+              ]
+            },
+            {
+              "id": 3,
+              "name": "updated-user2",
+              "documents": [
+                {
+                  "id": 4,
+                  "content": "content4"
+                }
+              ]
+            },
+            {
+              "id": 4,
+              "name": "updated-user2",
+              "documents": []
+            },
+            {
+              "id": 5,
+              "name": "updated-user2",
+              "documents": []
+            }
+          ]
+        }
+      }

--- a/integration-tests/ownership-access-check/tests/update/invalid-update-user-mismatch.exotest
+++ b/integration-tests/ownership-access-check/tests/update/invalid-update-user-mismatch.exotest
@@ -1,8 +1,8 @@
 stages:
-  # User 2 is trying to create a document for user 1
+  # User 2 is trying to update a document for user 2 (who owns document 1 and 2)
   - operation: |
       mutation {
-        createDocument(data: {content: "new-content", user: {id: 1}}) {
+        updateDocument(id: 1, data: {content: "updated-content"}) {
           id
           content
           user {
@@ -13,18 +13,16 @@ stages:
       }
     auth: |
       {
-        "sub": 2,
+        "sub": 3,
         "role": "USER"
       }
     response: |
       {
-        "errors": [
-          {
-            "message": "Not authorized"
-          }
-        ]
+        "data": {
+          "updateDocument": null
+        }
       }
-  # Ensure that the earlier mutation didn't work
+  # Ensure that the earlier mutation did work
   - operation: |
       query {
         documents(orderBy: {id: ASC}) {


### PR DESCRIPTION
- Make `MutationType` carry `EntityType` instead of just the `TableId`.
- Make `access_check` with with an `EntityType` instead of `OperationReturnType`.
- Push the check for access check on nested param to each element