### PR TITLE
Limit nested one-to-many update to only one level

### DIFF
--- a/crates/postgres-subsystem/postgres-model-builder/src/create_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/create_mutation_builder.rs
@@ -71,6 +71,7 @@ impl Builder for CreateMutationBuilder {
                     building,
                     Some(entity_type),
                     None,
+                    false,
                 )? {
                     building.mutation_types[existing_id] = expanded_type;
                 }

--- a/crates/postgres-subsystem/postgres-model-builder/src/mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/mutation_builder.rs
@@ -347,6 +347,7 @@ pub trait DataParamBuilder<D> {
         building: &SystemContextBuilding,
         top_level_type: Option<&EntityType>,
         container_type: Option<&EntityType>,
+        expanding_one_to_many: bool,
     ) -> Result<Vec<(SerializableSlabIndex<MutationType>, MutationType)>, ModelBuildingError> {
         let mut field_types: Vec<_> = vec![];
 
@@ -359,16 +360,19 @@ pub trait DataParamBuilder<D> {
             if let (PostgresType::Composite(field_type), PostgresRelation::OneToMany { .. }) =
                 (&field_type, &field.relation)
             {
-                let expanded = self.expand_one_to_many(
-                    entity_type,
-                    field,
-                    field_type,
-                    resolved_env,
-                    building,
-                    top_level_type,
-                    Some(entity_type),
-                )?;
-                field_types.extend(expanded);
+                if !expanding_one_to_many {
+                    let expanded = self.expand_one_to_many(
+                        entity_type,
+                        field,
+                        field_type,
+                        resolved_env,
+                        building,
+                        top_level_type,
+                        Some(entity_type),
+                        true,
+                    )?;
+                    field_types.extend(expanded);
+                }
             }
         }
 
@@ -426,6 +430,7 @@ pub trait DataParamBuilder<D> {
         building: &SystemContextBuilding,
         top_level_type: Option<&EntityType>,
         _container_type: Option<&EntityType>,
+        expanding_one_to_many: bool,
     ) -> Result<Vec<(SerializableSlabIndex<MutationType>, MutationType)>, ModelBuildingError> {
         let new_container_type = Some(entity_type);
 
@@ -447,6 +452,7 @@ pub trait DataParamBuilder<D> {
                 building,
                 top_level_type,
                 new_container_type,
+                expanding_one_to_many,
             )
         } else {
             Ok(vec![])

--- a/crates/postgres-subsystem/postgres-model-builder/src/update_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/update_mutation_builder.rs
@@ -76,6 +76,7 @@ impl Builder for UpdateMutationBuilder {
                     building,
                     Some(entity_type),
                     None,
+                    false,
                 )? {
                     building.mutation_types[existing_id] = expanded_type;
                 }
@@ -199,6 +200,7 @@ impl DataParamBuilder<DataParameter> for UpdateMutationBuilder {
         building: &SystemContextBuilding,
         top_level_type: Option<&EntityType>,
         container_type: Option<&EntityType>,
+        expanding_one_to_many: bool,
     ) -> Result<Vec<(SerializableSlabIndex<MutationType>, MutationType)>, ModelBuildingError> {
         let existing_type_name =
             Self::data_type_name(&field_type.name, container_type.map(|t| t.name.as_str()));
@@ -271,6 +273,7 @@ impl DataParamBuilder<DataParameter> for UpdateMutationBuilder {
                         building,
                         top_level_type,
                         container_type,
+                        expanding_one_to_many,
                     )?
                     .first()
                     .map(|tpe| {

--- a/integration-tests/relation/temp/.gitignore
+++ b/integration-tests/relation/temp/.gitignore
@@ -1,0 +1,2 @@
+target/
+generated/

--- a/integration-tests/relation/temp/src/index.exo
+++ b/integration-tests/relation/temp/src/index.exo
@@ -1,0 +1,24 @@
+@postgres
+module TodoDatabase {
+  @access(true)
+  type Venue {
+    @pk id: Int = autoIncrement()
+    name: String
+    concerts: Set<Concert>?
+  }
+
+  @access(true)
+  type Concert {
+    @pk id: Int = autoIncrement()
+    title: String
+    venue: Venue
+    prices: Set<Amount>?
+  }
+
+  @access(true)
+  type Amount {
+    @pk id: Int = autoIncrement()
+    value: Float
+    concert: Concert
+  }
+}

--- a/integration-tests/relation/temp/tests/init.gql
+++ b/integration-tests/relation/temp/tests/init.gql
@@ -1,0 +1,9 @@
+operation: |
+    mutation {
+        v1: createVenue(data: {name: "V1"}) {
+            id @bind(name: "v1id")
+        }
+        v2: createVenue(data: {name: "V2"}) {
+            id @bind(name: "v2id")
+        }        
+    }

--- a/integration-tests/relation/temp/tests/nested-update.exotest
+++ b/integration-tests/relation/temp/tests/nested-update.exotest
@@ -1,0 +1,112 @@
+stages:
+  - operation: |
+      mutation($venue1_id: Int!, $venue2_id: Int!) @unordered {
+        c1: createConcert(data: {title: "C1", venue: {id: $venue1_id}, prices: [{value: 10}, {value: 20}]}) {
+          id @bind("c1id")
+          prices @unordered {
+            id @bind("p1id")
+            value
+          }
+        }
+        c2: createConcert(data: {title: "C2", venue: {id: $venue2_id}, prices: [{value: 100}, {value: 200}]}) {
+          id @bind("c2id")
+          prices @unordered {
+            id @bind("p2id")
+            value
+          }
+        }
+      }
+    variable: |
+      {
+        "venue1_id": $.v1id,
+        "venue2_id": $.v2id
+      }
+    response: |
+      {
+        "data": {
+          "c2": {
+            "id": 2,
+            "prices": [
+              {
+                "id": 3,
+                "value": 100
+              },
+              {
+                "id": 4,
+                "value": 200
+              }
+            ]
+          },
+          "c1": {
+            "id": 1,
+            "prices": [
+              {
+                "id": 1,
+                "value": 10
+              },
+              {
+                "id": 2,
+                "value": 20
+              }
+            ]
+          }
+        }
+      }
+
+  - operation: |
+      mutation {
+        updateConcert(id: 1, data: {title: "C1-updated", prices: {update: {id: 1, value: 11}}}) {
+          id
+          title
+          prices @unordered {
+            id
+            value
+          }
+        }
+      }
+    response: |
+      {
+        "data": {
+          "updateConcert": {
+            "id": 1,
+            "title": "C1-updated",
+            "prices": [
+              {
+                "id": 1,
+                "value": 11
+              },
+              {
+                "id": 2,
+                "value": 20
+              }
+            ]
+          }
+        }
+      }
+
+  - operation: |
+      mutation {
+        updateVenue(id: 2, data: {name: "V1-updated", concerts: {update: {id: 2, title: "C2-updated"}}}) {
+          id
+          name
+          concerts @unordered {
+            id
+            title
+          }
+        }
+      }
+    response: |
+      {
+        "data": {
+          "updateVenue": {
+            "id": 2,
+            "name": "V1-updated",
+            "concerts": [
+              {
+                "id": 2,
+                "title": "C2-updated"
+              }
+            ]
+          }
+        }
+      }


### PR DESCRIPTION
If we have a model such as Venue->[Concert]->[Ticket], we allowed updating the Concert and Ticket models in the same mutation. This creates a complex API (and we had a bug where we incorrectly processed such a model leading to a model building failure).

In this commit we limit the nested update to only one nested level.

Fixes #871