### PR TITLE
Fix the cardinality of nested one-to-many update

### DIFF
--- a/crates/postgres-subsystem/postgres-model-builder/src/create_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/create_mutation_builder.rs
@@ -130,6 +130,10 @@ impl DataParamBuilder<DataParameter> for CreateMutationBuilder {
         false
     }
 
+    fn use_list_for_nested_one_to_many() -> bool {
+        true
+    }
+
     fn base_data_type_name(entity_type_name: &str) -> String {
         entity_type_name.creation_type()
     }

--- a/crates/postgres-subsystem/postgres-model-builder/src/mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/mutation_builder.rs
@@ -163,6 +163,11 @@ pub trait DataParamBuilder<D> {
     // TODO: Revisit this after nested update mutation works
     fn mark_fields_optional() -> bool;
 
+    /// Should we use a list for nested one-to-many relations?
+    /// In case of creation, we should allow passing a list of nested objects, but for updates, we should not
+    /// since the "create", "update" and "delete" operations themselves are of the list type.
+    fn use_list_for_nested_one_to_many() -> bool;
+
     fn data_param_field_type_names(
         &self,
         resolved_composite_type: &ResolvedCompositeType,
@@ -321,7 +326,11 @@ pub trait DataParamBuilder<D> {
                     type_name: field_type_name,
                     type_id: TypeIndex::Composite(field_type_id),
                 });
-                let field_type = FieldType::List(Box::new(field_plain_type));
+                let field_type = if Self::use_list_for_nested_one_to_many() {
+                    FieldType::List(Box::new(field_plain_type))
+                } else {
+                    field_plain_type
+                };
 
                 match &container_type {
                     Some(value) if value == &field.typ.name() => None,

--- a/crates/postgres-subsystem/postgres-model-builder/src/update_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/update_mutation_builder.rs
@@ -144,6 +144,10 @@ impl DataParamBuilder<DataParameter> for UpdateMutationBuilder {
         true
     }
 
+    fn use_list_for_nested_one_to_many() -> bool {
+        false
+    }
+
     fn base_data_type_name(entity_type_name: &str) -> String {
         entity_type_name.update_type()
     }

--- a/integration-tests/basic-model-no-auth/tests/mutations/update/venue-nested-collection-update.exotest
+++ b/integration-tests/basic-model-no-auth/tests/mutations/update/venue-nested-collection-update.exotest
@@ -1,0 +1,38 @@
+operation: |
+    mutation {
+      updateVenue(id: 1, data: {name: "V1-updated", 
+                                concerts: {update: [{ id: 1, title: "C1-updated" }, { id: 3, title: "C3-updated" }]} }) {
+        id
+        name
+        published
+        latitude
+        concerts @unordered {
+          id
+          published
+          title
+        }
+      }
+    }
+response: |
+    {
+      "data": {
+        "updateVenue": {
+          "id": 1,
+          "name": "V1-updated",
+          "published": true,
+          "latitude": 37.7749,
+          "concerts": [
+            {
+              "id": 1,
+              "published": true,
+              "title": "C1-updated"
+            },
+            {
+              "id": 3,
+              "published": true,
+              "title": "C3-updated"
+            }
+          ]
+        }
+      }
+    }

--- a/integration-tests/basic-model-no-auth/tests/mutations/update/venue-nested-single-update.exotest
+++ b/integration-tests/basic-model-no-auth/tests/mutations/update/venue-nested-single-update.exotest
@@ -1,0 +1,37 @@
+operation: |
+    mutation {
+      updateVenue(id: 1, data: {name: "V1-updated", concerts: {update: { id: 1, title: "C1-updated" }} }) {
+        id
+        name
+        published
+        latitude
+        concerts @unordered {
+          id
+          published
+          title
+        }
+      }
+    }
+response: |
+    {
+      "data": {
+        "updateVenue": {
+          "id": 1,
+          "name": "V1-updated",
+          "published": true,
+          "latitude": 37.7749,
+          "concerts": [
+            {
+              "id": 1,
+              "published": true,
+              "title": "C1-updated"
+            },
+            {
+              "id": 3,
+              "published": true,
+              "title": "Concert3"
+            }
+          ]
+        }
+      }
+    }

--- a/integration-tests/relation/nested-one-to-many/src/index.exo
+++ b/integration-tests/relation/nested-one-to-many/src/index.exo
@@ -1,5 +1,5 @@
 @postgres
-module TodoDatabase {
+module ConcertDatabase {
   @access(true)
   type Venue {
     @pk id: Int = autoIncrement()


### PR DESCRIPTION
When creating mutations such as `updateVenue` we marked the nested `concerts` field as `List`, which is redundant, since the `UpdatedConcertFromVenue` already marks `create` and `update` as `List`. This commit removes the redundant `List` and adds a test to exercise the nested one-to-many update.