### PR TITLE
Support user-assignable primary keys

### DIFF
--- a/crates/postgres-subsystem/postgres-model-builder/src/mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/mutation_builder.rs
@@ -243,10 +243,10 @@ pub trait DataParamBuilder<D> {
         let optional = Self::mark_fields_optional() || field.has_default_value;
 
         match &field.relation {
-            PostgresRelation::Pk { .. } => {
+            PostgresRelation::Pk { column_id } => {
                 if Self::data_param_role() == DataParamRole::Update {
                     // A typical way clients use update mutation is to get the data along with the id,
-                    // modify the data and send it back to the server. So we should accept the id
+                    // modify the data and send it back to the server. So we accept the id
                     // as an optional field in the update mutation.
                     // See also https://github.com/exograph/exograph/issues/601
                     Some(PostgresField {
@@ -257,8 +257,25 @@ pub trait DataParamBuilder<D> {
                         dynamic_default_value: field.dynamic_default_value.clone(),
                     })
                 } else {
-                    // TODO: Make this decision based on autoIncrement/uuid etc of the id
-                    None
+                    // Make the decision to include the pk column on based on the default value for
+                    // the PK column. We assume that if the default value is autoIncrement() or
+                    // gen_uuid(), it is a system assigned field and we should not include it in the
+                    // input type.
+                    // We should revisit this after we support "readonly" fields
+                    let column = column_id.get_column(&building.database);
+                    let is_system_assigned = column.is_auto_increment
+                        || column
+                            .default_value
+                            .iter()
+                            .any(|v| v.as_str() == "gen_random_uuid()");
+
+                    (!is_system_assigned).then(|| PostgresField {
+                        name: field.name.clone(),
+                        typ: to_mutation_type(&field.typ),
+                        relation: field.relation.clone(),
+                        has_default_value: field.has_default_value,
+                        dynamic_default_value: field.dynamic_default_value.clone(),
+                    })
                 }
             }
             PostgresRelation::Scalar { .. } => Some(PostgresField {

--- a/crates/postgres-subsystem/postgres-model-builder/src/mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/mutation_builder.rs
@@ -257,7 +257,7 @@ pub trait DataParamBuilder<D> {
                         dynamic_default_value: field.dynamic_default_value.clone(),
                     })
                 } else {
-                    // Make the decision to include the pk column on based on the default value for
+                    // Make the decision to include the pk column based on the default value for
                     // the PK column. We assume that if the default value is autoIncrement() or
                     // gen_uuid(), it is a system assigned field and we should not include it in the
                     // input type.

--- a/integration-tests/user-specified-pk/.gitignore
+++ b/integration-tests/user-specified-pk/.gitignore
@@ -1,0 +1,2 @@
+target/
+generated/

--- a/integration-tests/user-specified-pk/src/index.exo
+++ b/integration-tests/user-specified-pk/src/index.exo
@@ -1,0 +1,16 @@
+@postgres
+module Product {
+  @access(true)
+  type Product {
+    @pk id: Int
+    title: String
+    department: Department
+  }
+
+  @access(true)
+  type Department {
+    @pk id: String
+    name: String
+    products: Set<Product>?
+  }
+}

--- a/integration-tests/user-specified-pk/tests/create-duplicate-key.exotest
+++ b/integration-tests/user-specified-pk/tests/create-duplicate-key.exotest
@@ -1,0 +1,15 @@
+operation: |
+  mutation {
+      createDepartment(data: {id: "d1", name: "Test Department"}) { # "d1" already exists, so this should fail
+          id
+          name
+      }
+  }
+response: |
+  {
+    "errors": [
+      {
+        "message": "Postgres operation failed"
+      }
+    ]
+  }

--- a/integration-tests/user-specified-pk/tests/create-new-key-multi.exotest
+++ b/integration-tests/user-specified-pk/tests/create-new-key-multi.exotest
@@ -1,0 +1,31 @@
+operation: |
+  mutation {
+      createProducts(data: [{id: 5, title: "New Product 1", department: {id: "d1"}}, {id: 6, title: "New Product 2", department: {id: "d2"}}]) {
+          id
+          title
+          department {
+              id
+          }
+      }
+  }
+response: |
+  {
+    "data": {
+      "createProducts": [
+        {
+          "id": 5,
+          "title": "New Product 1",
+          "department": {
+            "id": "d1"
+          }
+        },
+        {
+          "id": 6,
+          "title": "New Product 2",
+          "department": {
+            "id": "d2"
+          }
+        }
+      ]
+    }
+  }

--- a/integration-tests/user-specified-pk/tests/create-new-key.exotest
+++ b/integration-tests/user-specified-pk/tests/create-new-key.exotest
@@ -1,0 +1,22 @@
+operation: |
+  mutation {
+      createProduct(data: {id: 5, title: "New Product", department: {id: "d1"}}) {
+          id
+          title
+          department {
+              id
+          }
+      }
+  }
+response: |
+  {
+    "data": {
+      "createProduct": {
+        "id": 5,
+        "title": "New Product",
+        "department": {
+          "id": "d1"
+        }
+      }
+    }
+  }

--- a/integration-tests/user-specified-pk/tests/init.gql
+++ b/integration-tests/user-specified-pk/tests/init.gql
@@ -1,0 +1,9 @@
+operation: |
+    mutation {
+        d1: createDepartment(data: {id: "d1", name: "D1", products: [{id: 1, title: "D1P1"}, {id: 2, title: "D1P2"}]}) {
+            id
+        }
+        d2: createDepartment(data: {id: "d2", name: "D2", products: [{id: 3, title: "D3P1"}, {id: 4, title: "D2P2"}]}) {
+            id
+        }
+    }

--- a/integration-tests/user-specified-pk/tests/query-all.exotest
+++ b/integration-tests/user-specified-pk/tests/query-all.exotest
@@ -1,0 +1,46 @@
+operation: |
+  query {
+      departments(orderBy: {id: ASC}) {
+          id
+          name
+          products(orderBy: {id: DESC}) {
+            id
+            title
+          }
+      }
+  }
+response: |
+  {
+    "data": {
+      "departments": [
+        {
+          "id": "d1",
+          "name": "D1",
+          "products": [
+            {
+              "id": 2,
+              "title": "D1P2"
+            },
+            {
+              "id": 1,
+              "title": "D1P1"
+            }
+          ]
+        },
+        {
+          "id": "d2",
+          "name": "D2",
+          "products": [
+            {
+              "id": 4,
+              "title": "D2P2"
+            },
+            {
+              "id": 3,
+              "title": "D3P1"
+            }
+          ]
+        }
+      ]
+    }
+  }


### PR DESCRIPTION
Currently, we assume that the primary key is always system-assigned. However, this limits the use cases, where the user wants to assign the primary key themselves (for example, one obtained through an external auth system's). This commit adds support for user-assignable primary keys by assuming that unless the primary key is auto-incrementing or generated UUID, it is user assignable.