### PR TITLE
Generate JWT secret in yolo mode only if the env is not set

### DIFF
--- a/crates/cli/src/util/watcher.rs
+++ b/crates/cli/src/util/watcher.rs
@@ -128,7 +128,7 @@ where
 
                 if let Ok(events) = events {
                         if events.iter().map(|event| &event.path).any(|p| should_restart(p)) {
-                            println!("Change detected, rebuilding and restarting...");
+                            println!("\nChange detected, rebuilding and restarting...");
                             server = build_and_start_server().await?;
                         }
                     };


### PR DESCRIPTION
This allows to use a custom secret in yolo mode, which is useful with external auth providers.

Also, make it clear that the database will be wiped in yolo mode upon server restart.