### PR TITLE
Fix coercion of null values in context expressions

### DIFF
--- a/crates/core-subsystem/core-resolver/src/access_solver.rs
+++ b/crates/core-subsystem/core-resolver/src/access_solver.rs
@@ -45,8 +45,8 @@ pub enum AccessSolverError {
 #[async_trait]
 pub trait AccessSolver<'a, PrimExpr, Res>
 where
-    PrimExpr: Send + Sync,
-    Res: AccessPredicate<'a>,
+    PrimExpr: Send + Sync + std::fmt::Debug,
+    Res: AccessPredicate<'a> + std::fmt::Debug,
 {
     /// Solve access control logic.
     ///

--- a/crates/core-subsystem/core-resolver/src/context_extractor.rs
+++ b/crates/core-subsystem/core-resolver/src/context_extractor.rs
@@ -137,10 +137,10 @@ fn coerce(value: Val, typ: &ContextFieldType) -> Result<Val, ContextExtractionEr
 fn coerce_primitive(value: Val, typ: &PrimitiveType) -> Result<Val, ContextExtractionError> {
     match (value, typ) {
         // Special case for null values.
-        // If the context value is null, we can return it as is for any type. This allows to
-        // correctly handle expressions such as `<something> || SomeContext.role == "admin"`, and
-        // the `SomeContext.role` isn't supplied. In this case, the `SomeContext.role == "admin"`
-        // will evaluate to `false`, and the `||` operator will return the value of `<something>`.
+        // If the context value is null, we can return it as is for any type. This allows correct
+        // handling of expressions such as `<something> || SomeContext.role == "admin"` when
+        // `SomeContext.role` isn't supplied. In this case, the `SomeContext.role == "admin"` will
+        // evaluate to `false`, and the `||` operator will return the value of `<something>`.
         (value, _) if value == Val::Null => Ok(value),
         (value @ Val::String(_), PrimitiveType::String) => Ok(value),
         (value @ Val::Number(_), PrimitiveType::Int) => Ok(value),

--- a/crates/core-subsystem/core-resolver/src/context_extractor.rs
+++ b/crates/core-subsystem/core-resolver/src/context_extractor.rs
@@ -136,6 +136,12 @@ fn coerce(value: Val, typ: &ContextFieldType) -> Result<Val, ContextExtractionEr
 
 fn coerce_primitive(value: Val, typ: &PrimitiveType) -> Result<Val, ContextExtractionError> {
     match (value, typ) {
+        // Special case for null values.
+        // If the context value is null, we can return it as is for any type. This allows to
+        // correctly handle expressions such as `<something> || SomeContext.role == "admin"`, and
+        // the `SomeContext.role` isn't supplied. In this case, the `SomeContext.role == "admin"`
+        // will evaluate to `false`, and the `||` operator will return the value of `<something>`.
+        (value, _) if value == Val::Null => Ok(value),
         (value @ Val::String(_), PrimitiveType::String) => Ok(value),
         (value @ Val::Number(_), PrimitiveType::Int) => Ok(value),
         (value @ Val::Number(_), PrimitiveType::Float) => Ok(value),

--- a/crates/deno-subsystem/deno-resolver/src/access_solver.rs
+++ b/crates/deno-subsystem/deno-resolver/src/access_solver.rs
@@ -28,6 +28,7 @@ use deno_model::{access::ModuleAccessPrimitiveExpression, subsystem::DenoSubsyst
 use crate::module_access_predicate::ModuleAccessPredicate;
 
 // Only to get around the orphan rule while implementing AccessSolver
+#[derive(Debug)]
 pub struct ModuleAccessPredicateWrapper(pub ModuleAccessPredicate);
 
 impl std::ops::Not for ModuleAccessPredicateWrapper {

--- a/crates/deno-subsystem/deno-resolver/src/module_access_predicate.rs
+++ b/crates/deno-subsystem/deno-resolver/src/module_access_predicate.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#[derive(Debug)]
 pub enum ModuleAccessPredicate {
     True,
     False,

--- a/integration-tests/todo/.gitignore
+++ b/integration-tests/todo/.gitignore
@@ -1,0 +1,2 @@
+target/
+generated/

--- a/integration-tests/todo/src/index.exo
+++ b/integration-tests/todo/src/index.exo
@@ -1,0 +1,26 @@
+context AuthContext {
+  @jwt("sub") id: Int
+  @jwt("role") role: String = "user"
+}
+
+@postgres
+module TodoDatabase {
+  @access(self.user.id == AuthContext.id || AuthContext.role == "admin")
+  type Todo {
+    @pk id: Int = autoIncrement()
+    title: String
+    completed: Boolean
+    user: User = AuthContext.id
+  }
+
+  @access(AuthContext.role == "admin")
+  type User {
+    @pk id: Int = autoIncrement()
+    @unique email: String
+    firstName: String
+    lastName: String
+    profileImageUrl: String
+    role: String = "user"
+    todos: Set<Todo>?
+  }
+}

--- a/integration-tests/todo/tests/create-todo-admin.exotest
+++ b/integration-tests/todo/tests/create-todo-admin.exotest
@@ -1,0 +1,67 @@
+
+stages:
+  - operation: |
+        mutation createTodo($title: String!, $completed: Boolean!, $userId: Int!) {
+          createTodo(data: { title: $title, completed: $completed, user: {id: $userId} }) {
+            id
+            title
+            completed
+          }
+        }
+    variable: |
+      {
+        "title": "U1-T3-by-admin",
+        "completed": true,
+        "userId": 1
+      }
+    auth: |
+      {
+          "role": "admin",
+          "sub": null
+      } 
+    response: |
+      {
+        "data": {
+          "createTodo": {
+            "id": 5,
+            "title": "U1-T3-by-admin",
+            "completed": true
+          }
+        }
+      }
+      
+  - operation: |
+      query {
+        todos(orderBy: {id: ASC}) {
+          id
+          title
+          completed
+        }
+      }
+    auth: |
+      {
+          "sub": 1,
+          "role": null
+      } 
+    response: |
+      {
+        "data": {
+          "todos": [
+            {
+              "id": 1,
+              "title": "U1-T1",
+              "completed": false
+            },
+            {
+              "id": 2,
+              "title": "U1-T2",
+              "completed": true
+            },
+            {
+              "id": 5,
+              "title": "U1-T3-by-admin",
+              "completed": true
+            }
+          ]
+        }
+      }

--- a/integration-tests/todo/tests/create-todo-user.exotest
+++ b/integration-tests/todo/tests/create-todo-user.exotest
@@ -1,0 +1,66 @@
+
+stages:
+  - operation: |
+        mutation createTodo($title: String!, $completed: Boolean) {
+          createTodo(data: { title: $title, completed: $completed }) {
+            id
+            title
+            completed
+          }
+        }
+    variable: |
+      {
+        "title": "U1-T3",
+        "completed": true
+      }
+    auth: |
+      {
+          "sub": 1,
+          "role": null
+      } 
+    response: |
+      {
+        "data": {
+          "createTodo": {
+            "id": 5,
+            "title": "U1-T3",
+            "completed": true
+          }
+        }
+      }
+      
+  - operation: |
+      query {
+        todos(orderBy: {id: ASC}) {
+          id
+          title
+          completed
+        }
+      }
+    auth: |
+      {
+          "sub": 1,
+          "role": null
+      } 
+    response: |
+      {
+        "data": {
+          "todos": [
+            {
+              "id": 1,
+              "title": "U1-T1",
+              "completed": false
+            },
+            {
+              "id": 2,
+              "title": "U1-T2",
+              "completed": true
+            },
+            {
+              "id": 5,
+              "title": "U1-T3",
+              "completed": true
+            }
+          ]
+        }
+      }

--- a/integration-tests/todo/tests/delete-todo-admin.exotest
+++ b/integration-tests/todo/tests/delete-todo-admin.exotest
@@ -1,0 +1,56 @@
+
+stages:
+  # First try to delete a todo with a user that owns it
+  - operation: |
+        mutation($id: Int!) {
+          deleteTodo(id: $id) {
+            id
+            title
+            completed
+          }
+        }
+    variable: |
+      {
+        "id": 2
+      }
+    auth: |
+      {
+          "role": "admin",
+          "sub": null
+      } 
+    response: |
+      {
+        "data": {
+          "deleteTodo": {
+            "id": 2,
+            "title": "U1-T2",
+            "completed": true
+          }
+        }
+      }
+   
+  - operation: |
+      query {
+        todos(orderBy: {id: ASC}) {
+          id
+          title
+          completed
+        }
+      }
+    auth: |
+      {
+          "sub": 1,
+          "role": null
+      } 
+    response: |
+      {
+        "data": {
+          "todos": [
+            {
+              "id": 1,
+              "title": "U1-T1",
+              "completed": false
+            }
+          ]
+        }
+      }

--- a/integration-tests/todo/tests/delete-todo-user.exotest
+++ b/integration-tests/todo/tests/delete-todo-user.exotest
@@ -1,0 +1,80 @@
+
+stages:
+  # First try to delete a todo with a user that owns it
+  - operation: |
+        mutation($id: Int!) {
+          deleteTodo(id: $id) {
+            id
+            title
+            completed
+          }
+        }
+    variable: |
+      {
+        "id": 2
+      }
+    auth: |
+      {
+          "sub": 1,
+          "role": null
+      } 
+    response: |
+      {
+        "data": {
+          "deleteTodo": {
+            "id": 2,
+            "title": "U1-T2",
+            "completed": true
+          }
+        }
+      }
+      
+  # Now try to delete a todo that does not belong to the user
+  - operation: |
+        mutation($id: Int!) {
+          deleteTodo(id: $id) {
+            id
+            title
+            completed
+          }
+        }
+    variable: |
+      {
+        "id": 2
+      }
+    auth: |
+      {
+          "sub": 2,
+          "role": null
+      } 
+    response: |
+      {
+        "data": {
+          "deleteTodo": null
+        }
+      }      
+  - operation: |
+      query {
+        todos(orderBy: {id: ASC}) {
+          id
+          title
+          completed
+        }
+      }
+    auth: |
+      {
+          "sub": 1,
+          "role": null
+      } 
+    response: |
+      {
+        "data": {
+          "todos": [
+            {
+              "id": 1,
+              "title": "U1-T1",
+              "completed": false
+            }
+          ]
+        }
+      }

--- a/integration-tests/todo/tests/init.gql
+++ b/integration-tests/todo/tests/init.gql
@@ -1,0 +1,17 @@
+# Create two users with a completed and an incomplete todo each
+operation: |
+    mutation {
+        u1: createUser(data: {email: "one@example.com", firstName: "F1", lastName: "L1", profileImageUrl: "https://example.com/1.jpg",
+                              todos: [{title: "U1-T1", completed: false}, {title: "U1-T2", completed: true}]}) {
+            id
+        }
+        u2: createUser(data: {email: "two@example.com", firstName: "F2", lastName: "L2", profileImageUrl: "https://example.com/2.jpg",
+                              todos: [{title: "U2-T1", completed: false}, {title: "U2-T2", completed: true}]}) {
+            id
+        }
+    }
+auth: |
+  {
+      "role": "admin",
+      "sub": null
+  }     

--- a/integration-tests/todo/tests/update-todo-admin.exotest
+++ b/integration-tests/todo/tests/update-todo-admin.exotest
@@ -1,0 +1,62 @@
+
+stages:
+  - operation: |
+        mutation($id: Int!, $title: String!) {
+          updateTodo(id: $id, data: { title: $title }) {
+            id
+            title
+            completed
+          }
+        }
+    variable: |
+      {
+        "id": 2,
+        "title": "U1-T2-updated",
+        "completed": true
+      }
+    auth: |
+      {
+          "role": "admin",
+          "sub": null
+      } 
+    response: |
+      {
+        "data": {
+          "updateTodo": {
+            "id": 2,
+            "title": "U1-T2-updated",
+            "completed": true
+          }
+        }
+      }
+         
+  - operation: |
+      query {
+        todos(orderBy: {id: ASC}) {
+          id
+          title
+          completed
+        }
+      }
+    auth: |
+      {
+          "sub": 1,
+          "role": null
+      } 
+    response: |
+      {
+        "data": {
+          "todos": [
+            {
+              "id": 1,
+              "title": "U1-T1",
+              "completed": false
+            },
+            {
+              "id": 2,
+              "title": "U1-T2-updated",
+              "completed": true
+            }
+          ]
+        }
+      }

--- a/integration-tests/todo/tests/update-todo-user.exotest
+++ b/integration-tests/todo/tests/update-todo-user.exotest
@@ -1,0 +1,88 @@
+
+stages:
+  # First try to update a todo with a user that owns it
+  - operation: |
+        mutation($id: Int!, $title: String!) {
+          updateTodo(id: $id, data: { title: $title }) {
+            id
+            title
+            completed
+          }
+        }
+    variable: |
+      {
+        "id": 2,
+        "title": "U1-T2-updated",
+        "completed": true
+      }
+    auth: |
+      {
+          "sub": 1,
+          "role": null
+      } 
+    response: |
+      {
+        "data": {
+          "updateTodo": {
+            "id": 2,
+            "title": "U1-T2-updated",
+            "completed": true
+          }
+        }
+      }
+  # Now try to update a todo that does not belong to the user
+  - operation: |
+        mutation($id: Int!, $title: String!) {
+          updateTodo(id: $id, data: { title: $title }) {
+            id
+            title
+            completed
+          }
+        }
+    variable: |
+      {
+        "id": 2,
+        "title": "U1-T2-updated",
+        "completed": true
+      }
+    auth: |
+      {
+          "sub": 2,
+          "role": null
+      } 
+    response: |
+      {
+        "data": {
+          "updateTodo": null
+        }
+      }      
+  - operation: |
+      query {
+        todos(orderBy: {id: ASC}) {
+          id
+          title
+          completed
+        }
+      }
+    auth: |
+      {
+          "sub": 1,
+          "role": null
+      } 
+    response: |
+      {
+        "data": {
+          "todos": [
+            {
+              "id": 1,
+              "title": "U1-T1",
+              "completed": false
+            },
+            {
+              "id": 2,
+              "title": "U1-T2-updated",
+              "completed": true
+            }
+          ]
+        }
+      }


### PR DESCRIPTION
If the context value is `null` (for example, due to a missing JWT claim or missing header), we can return it as is for any type. This allows to correctly handle expressions such as `<something> || SomeContext.role == "admin"`, and the `SomeContext.role` is null. In this case, the `SomeContext.role == "admin"` will evaluate to `false`, and the `||` operator will return the value of `<something>`.

This will also make it work correctly in the presence of a short-circuiting logic for || and &&.