### PR TITLE
Upgrade to Deno 1.36.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,18 +605,6 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7862e21c893d65a1650125d157eaeec691439379a1cee17ee49031b79236ada4"
-dependencies = [
- "proc-macro-error",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "auto_impl"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fee3da8ef1276b0bee5dd1c7258010d8fffd31801447323115a25560e1327b89"
@@ -767,21 +755,6 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -1164,17 +1137,6 @@ dependencies = [
  "tokio",
  "wasm-model-builder",
  "zip",
-]
-
-[[package]]
-name = "clipboard-win"
-version = "4.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
-dependencies = [
- "error-code",
- "str-buf",
- "winapi",
 ]
 
 [[package]]
@@ -1574,7 +1536,7 @@ dependencies = [
  "crossterm_winapi",
  "libc",
  "mio",
- "parking_lot 0.12.1",
+ "parking_lot",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1679,7 +1641,7 @@ dependencies = [
  "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.7",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1731,7 +1693,7 @@ dependencies = [
 [[package]]
 name = "deno"
 version = "1.36.3"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2c878cd6c82c3f49da3a8166f54abc433a1261e6"
 dependencies = [
  "async-trait",
  "atty",
@@ -1749,23 +1711,14 @@ dependencies = [
  "deno_cache_dir",
  "deno_config",
  "deno_core",
- "deno_doc",
- "deno_emit",
  "deno_graph",
- "deno_lint",
  "deno_lockfile",
  "deno_npm",
  "deno_runtime",
  "deno_semver",
- "deno_task_shell",
  "dissimilar",
- "dprint-plugin-json",
- "dprint-plugin-markdown",
- "dprint-plugin-typescript",
  "encoding_rs",
  "env_logger 0.9.0",
- "eszip",
- "fancy-regex",
  "fastwebsockets",
  "flate2",
  "fs3",
@@ -1781,33 +1734,24 @@ dependencies = [
  "lazy-regex",
  "libc",
  "log",
- "lsp-types",
  "monch",
  "napi_sym",
  "nix 0.24.2",
  "notify",
  "once_cell",
- "os_pipe",
  "percent-encoding",
  "pin-project",
  "quick-junit",
  "rand",
  "regex",
  "ring",
- "rustyline",
- "rustyline-derive",
  "serde",
  "serde_json",
- "serde_repr",
- "shell-escape",
  "tar",
- "tempfile",
- "text-size",
  "text_lines",
  "thiserror",
  "tokio",
  "tokio-util",
- "tower-lsp",
  "twox-hash",
  "typed-arena",
  "uuid",
@@ -1953,7 +1897,7 @@ dependencies = [
 [[package]]
 name = "deno_broadcast_channel"
 version = "0.111.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2c878cd6c82c3f49da3a8166f54abc433a1261e6"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1964,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "deno_cache"
 version = "0.49.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2c878cd6c82c3f49da3a8166f54abc433a1261e6"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1985,7 +1929,7 @@ dependencies = [
  "indexmap 2.0.0",
  "log",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "ring",
  "serde",
  "serde_json",
@@ -2014,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "deno_console"
 version = "0.117.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2c878cd6c82c3f49da3a8166f54abc433a1261e6"
 dependencies = [
  "deno_core",
 ]
@@ -2034,7 +1978,7 @@ dependencies = [
  "libc",
  "log",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pin-project",
  "serde",
  "serde_json",
@@ -2049,7 +1993,7 @@ dependencies = [
 [[package]]
 name = "deno_crypto"
 version = "0.131.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2c878cd6c82c3f49da3a8166f54abc433a1261e6"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2082,44 +2026,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "deno_doc"
-version = "0.65.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10bb7c24a702ae82d8eaee95a325a9853b951dd0e01bb4950dd427e61e4fd0fe"
-dependencies = [
- "cfg-if 1.0.0",
- "deno_ast",
- "deno_graph",
- "futures",
- "import_map",
- "lazy_static",
- "regex",
- "serde",
- "serde_json",
- "termcolor",
-]
-
-[[package]]
-name = "deno_emit"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10663feb7be359aa447e7be4bc76a25a2d470fc9dfa8cd1b09a0a3916e0586e0"
-dependencies = [
- "anyhow",
- "base64 0.13.1",
- "deno_ast",
- "deno_graph",
- "escape8259",
- "futures",
- "import_map",
- "parking_lot 0.11.2",
- "url",
-]
-
-[[package]]
 name = "deno_fetch"
 version = "0.141.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2c878cd6c82c3f49da3a8166f54abc433a1261e6"
 dependencies = [
  "bytes",
  "data-url",
@@ -2136,7 +2045,7 @@ dependencies = [
 [[package]]
 name = "deno_ffi"
 version = "0.104.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2c878cd6c82c3f49da3a8166f54abc433a1261e6"
 dependencies = [
  "deno_core",
  "dlopen",
@@ -2153,7 +2062,7 @@ dependencies = [
 [[package]]
 name = "deno_fs"
 version = "0.27.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2c878cd6c82c3f49da3a8166f54abc433a1261e6"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -2183,7 +2092,7 @@ dependencies = [
  "indexmap 1.9.3",
  "monch",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "regex",
  "serde",
  "serde_json",
@@ -2194,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "deno_http"
 version = "0.112.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2c878cd6c82c3f49da3a8166f54abc433a1261e6"
 dependencies = [
  "async-compression",
  "async-trait",
@@ -2229,7 +2138,7 @@ dependencies = [
 [[package]]
 name = "deno_io"
 version = "0.27.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2c878cd6c82c3f49da3a8166f54abc433a1261e6"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -2243,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "deno_kv"
 version = "0.25.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2c878cd6c82c3f49da3a8166f54abc433a1261e6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2263,23 +2172,6 @@ dependencies = [
  "tokio",
  "url",
  "uuid",
-]
-
-[[package]]
-name = "deno_lint"
-version = "0.50.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f9885a21010c312e84bc6f276a4c97047c3c734bde5f71cb4a71e8121fbe74"
-dependencies = [
- "anyhow",
- "deno_ast",
- "derive_more",
- "if_chain",
- "log",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2308,7 +2200,7 @@ dependencies = [
 [[package]]
 name = "deno_napi"
 version = "0.47.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2c878cd6c82c3f49da3a8166f54abc433a1261e6"
 dependencies = [
  "deno_core",
  "libloading",
@@ -2317,7 +2209,7 @@ dependencies = [
 [[package]]
 name = "deno_net"
 version = "0.109.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2c878cd6c82c3f49da3a8166f54abc433a1261e6"
 dependencies = [
  "deno_core",
  "deno_tls",
@@ -2334,7 +2226,7 @@ dependencies = [
 [[package]]
 name = "deno_node"
 version = "0.54.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2c878cd6c82c3f49da3a8166f54abc433a1261e6"
 dependencies = [
  "aes",
  "brotli",
@@ -2431,7 +2323,7 @@ dependencies = [
 [[package]]
 name = "deno_runtime"
 version = "0.125.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2c878cd6c82c3f49da3a8166f54abc433a1261e6"
 dependencies = [
  "atty",
  "console_static_text",
@@ -2497,25 +2389,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "deno_task_shell"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dbbad0a7ba06a961df3cd638ab117f5d67787607f627defa65629a4ef29d576"
-dependencies = [
- "anyhow",
- "futures",
- "glob",
- "monch",
- "os_pipe",
- "path-dedot",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
 name = "deno_tls"
 version = "0.104.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2c878cd6c82c3f49da3a8166f54abc433a1261e6"
 dependencies = [
  "deno_core",
  "once_cell",
@@ -2539,7 +2415,7 @@ dependencies = [
 [[package]]
 name = "deno_url"
 version = "0.117.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2c878cd6c82c3f49da3a8166f54abc433a1261e6"
 dependencies = [
  "deno_core",
  "serde",
@@ -2549,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "deno_web"
 version = "0.148.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2c878cd6c82c3f49da3a8166f54abc433a1261e6"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -2567,7 +2443,7 @@ dependencies = [
 [[package]]
 name = "deno_webidl"
 version = "0.117.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2c878cd6c82c3f49da3a8166f54abc433a1261e6"
 dependencies = [
  "deno_core",
 ]
@@ -2575,7 +2451,7 @@ dependencies = [
 [[package]]
 name = "deno_websocket"
 version = "0.122.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2c878cd6c82c3f49da3a8166f54abc433a1261e6"
 dependencies = [
  "bytes",
  "deno_core",
@@ -2593,7 +2469,7 @@ dependencies = [
 [[package]]
 name = "deno_webstorage"
 version = "0.112.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2c878cd6c82c3f49da3a8166f54abc433a1261e6"
 dependencies = [
  "deno_core",
  "deno_web",
@@ -2794,60 +2670,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dprint-core"
-version = "0.62.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6563addfa2b6c6fa96acdda0341090beba2c5c4ff6ef91f3a232a6d4dd34156"
-dependencies = [
- "anyhow",
- "bumpalo",
- "indexmap 1.9.3",
- "rustc-hash",
- "serde",
- "unicode-width",
-]
-
-[[package]]
-name = "dprint-plugin-json"
-version = "0.17.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63039b53a600a7dc078cf9d76d6b5aad9bdb665e5a107ecdb06aef7bcc2e345"
-dependencies = [
- "anyhow",
- "dprint-core",
- "jsonc-parser",
- "serde",
- "text_lines",
-]
-
-[[package]]
-name = "dprint-plugin-markdown"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f20e5763efd89925412ac0f525a25bbba9066b2ba924eae87ab8a7120df0744c"
-dependencies = [
- "anyhow",
- "dprint-core",
- "pulldown-cmark 0.9.3",
- "regex",
- "serde",
- "unicode-width",
-]
-
-[[package]]
-name = "dprint-plugin-typescript"
-version = "0.86.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b423bfa289e57a0fab8eadc5ced6a0890ccc3570258daf4a12b1d0412cfb9"
-dependencies = [
- "anyhow",
- "deno_ast",
- "dprint-core",
- "rustc-hash",
- "serde",
-]
-
-[[package]]
 name = "dprint-swc-ext"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3019,12 +2841,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
 name = "enum-as-inner"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3098,46 +2914,6 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
-]
-
-[[package]]
-name = "error-code"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
-dependencies = [
- "libc",
- "str-buf",
-]
-
-[[package]]
-name = "escape8259"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4911e3666fcd7826997b4745c8224295a6f3072f1418c3067b97a67557ee"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
-name = "eszip"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e254fcba0a6481f44fa41f41cb9027d811072e7e7fa94780ade4a7fa43b34c4b"
-dependencies = [
- "anyhow",
- "base64 0.21.0",
- "deno_ast",
- "deno_graph",
- "deno_npm",
- "deno_semver",
- "futures",
- "hashlink",
- "serde",
- "serde_json",
- "sha2",
- "thiserror",
- "url",
 ]
 
 [[package]]
@@ -3216,16 +2992,6 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
-name = "fancy-regex"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0678ab2d46fa5195aaf59ad034c083d351377d4af57f3e073c074d0da3e3c766"
-dependencies = [
- "bit-set",
- "regex",
-]
 
 [[package]]
 name = "fastrand"
@@ -4530,19 +4296,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lsp-types"
-version = "0.93.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be6e9c7e2d18f651974370d7aff703f9513e0df6e464fd795660edc77e6ca51"
-dependencies = [
- "bitflags 1.3.2",
- "serde",
- "serde_json",
- "serde_repr",
- "url",
-]
-
-[[package]]
 name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4723,7 +4476,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "napi_sym"
 version = "0.47.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2c878cd6c82c3f49da3a8166f54abc433a1261e6"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.32",
@@ -4768,15 +4521,6 @@ name = "nextest-workspace-hack"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d906846a98739ed9d73d66e62c2641eef8321f1734b7a1156ab045a0248fb2b3"
-
-[[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
-]
 
 [[package]]
 name = "nix"
@@ -5205,16 +4949,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_pipe"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c92f2b54f081d635c77e7120862d48db8e91f7f21cef23ab1b4fe9971c59f55"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5286,37 +5020,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.7",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -5365,15 +5074,6 @@ name = "path-clean"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecba01bf2678719532c5e3059e0b5f0811273d94b397088b82e3bd0a78c78fdd"
-
-[[package]]
-name = "path-dedot"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d55e486337acb9973cdea3ec5638c1b3bcb22e573b2b7b41969e0c744d5a15e"
-dependencies = [
- "once_cell",
-]
 
 [[package]]
 name = "pathdiff"
@@ -5974,17 +5674,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulldown-cmark"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
-dependencies = [
- "bitflags 1.3.2",
- "memchr",
- "unicase",
-]
-
-[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6036,16 +5725,6 @@ name = "radix_fmt"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce082a9940a7ace2ad4a8b7d0b1eac6aa378895f18be598230c5f2284ac05426"
-
-[[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
-]
 
 [[package]]
 name = "rand"
@@ -6502,39 +6181,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
-name = "rustyline"
-version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1cd5ae51d3f7bf65d7969d579d502168ef578f289452bd8ccc91de28fda20e"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if 1.0.0",
- "clipboard-win",
- "fd-lock",
- "libc",
- "log",
- "memchr",
- "nix 0.24.2",
- "radix_trie",
- "scopeguard",
- "unicode-segmentation",
- "unicode-width",
- "utf8parse",
- "winapi",
-]
-
-[[package]]
-name = "rustyline-derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "107c3d5d7f370ac09efa62a78375f94d94b8a33c61d8c278b96683fb4dbf2d8d"
-dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6757,17 +6403,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_repr"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
-dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6911,12 +6546,6 @@ checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "shell-escape"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
 name = "shellexpand"
@@ -7122,12 +6751,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "str-buf"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
-
-[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7135,7 +6758,7 @@ checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "phf_shared 0.10.0",
  "precomputed-hash",
  "serde",
@@ -7273,7 +6896,7 @@ dependencies = [
  "indexmap 1.9.3",
  "is-macro",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "petgraph",
  "radix_fmt",
  "relative-path",
@@ -7634,7 +7257,7 @@ version = "0.20.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2126bce41c5c755f649bc5fc74fbd5e1ea01306acbf26b49f8aab2bd53f8025f"
 dependencies = [
- "auto_impl 1.1.0",
+ "auto_impl",
  "petgraph",
  "swc_common",
  "swc_fast_graph",
@@ -7817,12 +7440,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "text-size"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "288cb548dbe72b652243ea797201f3d481a0609a967980fcc5b2315ea811560a"
-
-[[package]]
 name = "text_lines"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7969,7 +7586,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -8023,7 +7640,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "log",
- "parking_lot 0.12.1",
+ "parking_lot",
  "percent-encoding",
  "phf 0.11.2",
  "pin-project-lite",
@@ -8222,40 +7839,6 @@ name = "tower-layer"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
-
-[[package]]
-name = "tower-lsp"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e094780b4447366c59f79acfd65b1375ecaa84e61dddbde1421aa506334024"
-dependencies = [
- "async-trait",
- "auto_impl 0.5.0",
- "bytes",
- "dashmap",
- "futures",
- "httparse",
- "log",
- "lsp-types",
- "memchr",
- "serde",
- "serde_json",
- "tokio",
- "tokio-util",
- "tower",
- "tower-lsp-macros",
-]
-
-[[package]]
-name = "tower-lsp-macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebd99eec668d0a450c177acbc4d05e0d0d13b1f8d3db13cd706c52cbec4ac04"
-dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "tower-service"
@@ -8509,7 +8092,7 @@ dependencies = [
  "ipconfig",
  "lazy_static",
  "lru-cache",
- "parking_lot 0.12.1",
+ "parking_lot",
  "resolv-conf",
  "serde",
  "smallvec",
@@ -9699,7 +9282,7 @@ dependencies = [
  "id-arena",
  "indexmap 1.9.3",
  "log",
- "pulldown-cmark 0.8.0",
+ "pulldown-cmark",
  "unicode-xid 0.2.4",
  "url",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1731,6 +1731,7 @@ dependencies = [
 [[package]]
 name = "deno"
 version = "1.36.3"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
 dependencies = [
  "async-trait",
  "atty",
@@ -1952,6 +1953,7 @@ dependencies = [
 [[package]]
 name = "deno_broadcast_channel"
 version = "0.111.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1962,6 +1964,7 @@ dependencies = [
 [[package]]
 name = "deno_cache"
 version = "0.49.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -2011,6 +2014,7 @@ dependencies = [
 [[package]]
 name = "deno_console"
 version = "0.117.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
 dependencies = [
  "deno_core",
 ]
@@ -2045,6 +2049,7 @@ dependencies = [
 [[package]]
 name = "deno_crypto"
 version = "0.131.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2114,6 +2119,7 @@ dependencies = [
 [[package]]
 name = "deno_fetch"
 version = "0.141.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
 dependencies = [
  "bytes",
  "data-url",
@@ -2130,6 +2136,7 @@ dependencies = [
 [[package]]
 name = "deno_ffi"
 version = "0.104.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
 dependencies = [
  "deno_core",
  "dlopen",
@@ -2146,6 +2153,7 @@ dependencies = [
 [[package]]
 name = "deno_fs"
 version = "0.27.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -2186,6 +2194,7 @@ dependencies = [
 [[package]]
 name = "deno_http"
 version = "0.112.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
 dependencies = [
  "async-compression",
  "async-trait",
@@ -2220,6 +2229,7 @@ dependencies = [
 [[package]]
 name = "deno_io"
 version = "0.27.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -2233,6 +2243,7 @@ dependencies = [
 [[package]]
 name = "deno_kv"
 version = "0.25.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2297,6 +2308,7 @@ dependencies = [
 [[package]]
 name = "deno_napi"
 version = "0.47.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
 dependencies = [
  "deno_core",
  "libloading",
@@ -2305,6 +2317,7 @@ dependencies = [
 [[package]]
 name = "deno_net"
 version = "0.109.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
 dependencies = [
  "deno_core",
  "deno_tls",
@@ -2321,6 +2334,7 @@ dependencies = [
 [[package]]
 name = "deno_node"
 version = "0.54.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
 dependencies = [
  "aes",
  "brotli",
@@ -2417,6 +2431,7 @@ dependencies = [
 [[package]]
 name = "deno_runtime"
 version = "0.125.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
 dependencies = [
  "atty",
  "console_static_text",
@@ -2500,6 +2515,7 @@ dependencies = [
 [[package]]
 name = "deno_tls"
 version = "0.104.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
 dependencies = [
  "deno_core",
  "once_cell",
@@ -2523,6 +2539,7 @@ dependencies = [
 [[package]]
 name = "deno_url"
 version = "0.117.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
 dependencies = [
  "deno_core",
  "serde",
@@ -2532,6 +2549,7 @@ dependencies = [
 [[package]]
 name = "deno_web"
 version = "0.148.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -2549,6 +2567,7 @@ dependencies = [
 [[package]]
 name = "deno_webidl"
 version = "0.117.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
 dependencies = [
  "deno_core",
 ]
@@ -2556,6 +2575,7 @@ dependencies = [
 [[package]]
 name = "deno_websocket"
 version = "0.122.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
 dependencies = [
  "bytes",
  "deno_core",
@@ -2573,6 +2593,7 @@ dependencies = [
 [[package]]
 name = "deno_webstorage"
 version = "0.112.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
 dependencies = [
  "deno_core",
  "deno_web",
@@ -4702,6 +4723,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "napi_sym"
 version = "0.47.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_36_3#2a7d077c2bd462d29a9ceca75065736f79025174"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2",
- "time",
+ "time 0.3.20",
  "url",
 ]
 
@@ -344,6 +344,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "ambient-authority"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +360,12 @@ name = "ambient-authority"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -374,10 +386,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.70"
+name = "anstream"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
 name = "arrayvec"
@@ -410,7 +471,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -438,29 +499,15 @@ dependencies = [
 
 [[package]]
 name = "ast_node"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f7fd7740c5752c16281a1c1f9442b1e69ba41738acde85dc604aaf3ce41890"
+checksum = "c09c69dffe06d222d072c878c3afe86eee2179806f20503faec97250268b4c24"
 dependencies = [
  "pmutil",
  "proc-macro2 1.0.66",
  "quote 1.0.32",
  "swc_macros_common",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "async-compression"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
-dependencies = [
- "brotli",
- "flate2",
- "futures-core",
- "memchr",
- "pin-project-lite",
- "tokio",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -569,6 +616,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto_impl"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fee3da8ef1276b0bee5dd1c7258010d8fffd31801447323115a25560e1327b89"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2 1.0.66",
+ "quote 1.0.32",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,7 +688,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide 0.7.1",
+ "miniz_oxide",
  "object 0.31.1",
  "rustc-demangle",
 ]
@@ -682,9 +741,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "better_scoped_tls"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73e8ecdec39e98aa3b19e8cd0b8ed8f77ccb86a6b0b2dc7cd86d105438a2123"
+checksum = "794edcc9b3fb07bb4aecaa11f093fd45663b4feadb782d68303a2268bc2701de"
 dependencies = [
  "scoped-tls",
 ]
@@ -710,6 +769,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,9 +791,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.1.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70beb79cbb5ce9c4f8e20849978f34225931f665bb49efa6982875a4d5facb3"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block-buffer"
@@ -729,12 +803,6 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array 0.14.6",
 ]
-
-[[package]]
-name = "block-modes"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2211b0817f061502a8dd9f11a37e879e79763e3c698d2418cf824d8cb2f21e"
 
 [[package]]
 name = "block-padding"
@@ -800,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byteorder"
@@ -968,13 +1036,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
- "num-integer",
+ "js-sys",
  "num-traits",
+ "serde",
+ "time 0.1.45",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -1011,44 +1083,50 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.10"
+version = "4.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce38afc168d8665cfc75c7b1dd9672e50716a137f433f070991619744a67342a"
+checksum = "ca8f255e4b8027970e78db75e78831229c9815fdbfa67eb1a1b777a62e24b4a0"
 dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acd4f3c17c83b0ba34ffbc4f8bbd74f079413f747f84a6f89292f138057e36ab"
+dependencies = [
+ "anstream",
+ "anstyle",
  "bitflags 1.3.2",
  "clap_lex",
- "is-terminal",
  "strsim 0.10.0",
- "termcolor",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "4.1.5"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37686beaba5ac9f3ab01ee3172f792fc6ffdd685bfb9e63cfef02c0571a4e8e1"
+checksum = "7f6b5c519bab3ea61843a7923d074b04245624bb84a64a8c150f5deb014e388b"
 dependencies = [
- "clap 4.1.10",
+ "clap 4.3.3",
 ]
 
 [[package]]
 name = "clap_complete_fig"
-version = "4.1.2"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2171bc6242ad7a1801422bff039574449b5bd832b715222e500714ce10f91a54"
+checksum = "99fee1d30a51305a6c2ed3fc5709be3c8af626c9c958e04dd9ae94e27bcbce9f"
 dependencies = [
- "clap 4.1.10",
+ "clap 4.3.3",
  "clap_complete",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.3.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "cli"
@@ -1058,7 +1136,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "builder",
- "clap 4.1.10",
+ "clap 4.3.3",
  "colored",
  "core-model",
  "core-model-builder",
@@ -1089,6 +1167,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
+dependencies = [
+ "error-code",
+ "str-buf",
+ "winapi",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "codemap"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,6 +1201,12 @@ dependencies = [
  "codemap",
  "termcolor",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
@@ -1179,7 +1283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
- "time",
+ "time 0.3.20",
  "version_check",
 ]
 
@@ -1470,7 +1574,7 @@ dependencies = [
  "crossterm_winapi",
  "libc",
  "mio",
- "parking_lot",
+ "parking_lot 0.12.1",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1575,7 +1679,7 @@ dependencies = [
  "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
- "parking_lot_core",
+ "parking_lot_core 0.9.7",
 ]
 
 [[package]]
@@ -1626,30 +1730,41 @@ dependencies = [
 
 [[package]]
 name = "deno"
-version = "1.34.1"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "1.36.3"
 dependencies = [
  "async-trait",
  "atty",
  "base32",
  "base64 0.13.1",
+ "bincode",
  "cache_control",
  "chrono",
- "clap 4.1.10",
+ "clap 4.3.3",
  "clap_complete",
  "clap_complete_fig",
  "console_static_text",
  "data-url",
  "deno_ast",
+ "deno_cache_dir",
+ "deno_config",
  "deno_core",
+ "deno_doc",
+ "deno_emit",
  "deno_graph",
+ "deno_lint",
  "deno_lockfile",
  "deno_npm",
  "deno_runtime",
  "deno_semver",
+ "deno_task_shell",
  "dissimilar",
+ "dprint-plugin-json",
+ "dprint-plugin-markdown",
+ "dprint-plugin-typescript",
  "encoding_rs",
  "env_logger 0.9.0",
+ "eszip",
+ "fancy-regex",
  "fastwebsockets",
  "flate2",
  "fs3",
@@ -1665,23 +1780,33 @@ dependencies = [
  "lazy-regex",
  "libc",
  "log",
+ "lsp-types",
  "monch",
  "napi_sym",
  "nix 0.24.2",
  "notify",
  "once_cell",
+ "os_pipe",
  "percent-encoding",
  "pin-project",
+ "quick-junit",
  "rand",
  "regex",
  "ring",
+ "rustyline",
+ "rustyline-derive",
  "serde",
  "serde_json",
+ "serde_repr",
+ "shell-escape",
  "tar",
+ "tempfile",
+ "text-size",
  "text_lines",
  "thiserror",
  "tokio",
  "tokio-util",
+ "tower-lsp",
  "twox-hash",
  "typed-arena",
  "uuid",
@@ -1732,6 +1857,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "deno-proc-macro-rules"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c65c2ffdafc1564565200967edc4851c7b55422d3913466688907efd05ea26f"
+dependencies = [
+ "deno-proc-macro-rules-macros",
+ "proc-macro2 1.0.66",
+ "syn 2.0.28",
+]
+
+[[package]]
+name = "deno-proc-macro-rules-macros"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3047b312b7451e3190865713a4dd6e1f821aed614ada219766ebc3024a690435"
+dependencies = [
+ "once_cell",
+ "proc-macro2 1.0.66",
+ "quote 1.0.32",
+ "syn 2.0.28",
+]
+
+[[package]]
 name = "deno-resolver"
 version = "0.2.5"
 dependencies = [
@@ -1763,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ast"
-version = "0.26.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b4db18773938f4613617d384b6579983c46fbe9962da7390a9fc7525ccbe9c"
+checksum = "00c93119b1c487a85603406a988a0ca9a1d0e5315404cccc5c158fb484b1f5a2"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -1775,6 +1923,8 @@ dependencies = [
  "swc_atoms",
  "swc_bundler",
  "swc_common",
+ "swc_config",
+ "swc_config_macro",
  "swc_ecma_ast",
  "swc_ecma_codegen",
  "swc_ecma_codegen_macros",
@@ -1784,19 +1934,24 @@ dependencies = [
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
+ "swc_ecma_transforms_optimization",
  "swc_ecma_transforms_proposal",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_typescript",
  "swc_ecma_utils",
  "swc_ecma_visit",
+ "swc_eq_ignore_macros",
+ "swc_graph_analyzer",
+ "swc_macros_common",
+ "swc_visit",
+ "swc_visit_macros",
  "text_lines",
  "url",
 ]
 
 [[package]]
 name = "deno_broadcast_channel"
-version = "0.101.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.111.0"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1806,8 +1961,7 @@ dependencies = [
 
 [[package]]
 name = "deno_cache"
-version = "0.39.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.49.0"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1818,27 +1972,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "deno_cache_dir"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e4ee308992ed5bd4977d251c0ce4bdfa4cc59efa4ee93d17ebe46eae1e4563"
+dependencies = [
+ "anyhow",
+ "deno_media_type",
+ "indexmap 2.0.0",
+ "log",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "ring",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "deno_config"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a42ff2a01961c72ef883375399677ccf046dba607dc14169b313e4a95bd26da2"
+dependencies = [
+ "anyhow",
+ "deno_semver",
+ "indexmap 1.9.3",
+ "jsonc-parser",
+ "log",
+ "percent-encoding",
+ "pretty_assertions",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "deno_console"
-version = "0.107.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.117.0"
 dependencies = [
  "deno_core",
 ]
 
 [[package]]
 name = "deno_core"
-version = "0.189.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.204.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ddf51deb9a3bb60a4ab74784414b3f2f89de83a77d6d90a64c6447f7765d68"
 dependencies = [
  "anyhow",
  "bytes",
  "deno_ops",
+ "deno_unsync",
  "futures",
  "indexmap 1.9.3",
  "libc",
  "log",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pin-project",
  "serde",
  "serde_json",
@@ -1852,14 +2044,12 @@ dependencies = [
 
 [[package]]
 name = "deno_crypto"
-version = "0.121.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.131.0"
 dependencies = [
  "aes",
  "aes-gcm",
  "aes-kw",
  "base64 0.13.1",
- "block-modes",
  "cbc",
  "const-oid",
  "ctr",
@@ -1887,9 +2077,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "deno_doc"
+version = "0.65.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10bb7c24a702ae82d8eaee95a325a9853b951dd0e01bb4950dd427e61e4fd0fe"
+dependencies = [
+ "cfg-if 1.0.0",
+ "deno_ast",
+ "deno_graph",
+ "futures",
+ "import_map",
+ "lazy_static",
+ "regex",
+ "serde",
+ "serde_json",
+ "termcolor",
+]
+
+[[package]]
+name = "deno_emit"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10663feb7be359aa447e7be4bc76a25a2d470fc9dfa8cd1b09a0a3916e0586e0"
+dependencies = [
+ "anyhow",
+ "base64 0.13.1",
+ "deno_ast",
+ "deno_graph",
+ "escape8259",
+ "futures",
+ "import_map",
+ "parking_lot 0.11.2",
+ "url",
+]
+
+[[package]]
 name = "deno_fetch"
-version = "0.131.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.141.0"
 dependencies = [
  "bytes",
  "data-url",
@@ -1900,19 +2124,18 @@ dependencies = [
  "reqwest",
  "serde",
  "tokio",
- "tokio-stream",
  "tokio-util",
 ]
 
 [[package]]
 name = "deno_ffi"
-version = "0.94.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.104.0"
 dependencies = [
  "deno_core",
  "dlopen",
  "dynasmrt",
  "libffi",
+ "libffi-sys",
  "serde",
  "serde-value",
  "serde_json",
@@ -1922,8 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "deno_fs"
-version = "0.17.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1941,9 +2163,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.48.1"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcdbc17bfe49a41dd596ba2a96106b3eae3bd0812e1b63a6fe5883166c1b6fef"
+checksum = "6acc743895f5e83c985d632998e58af1395c862b28acabd3d290540ef4d57354"
 dependencies = [
  "anyhow",
  "data-url",
@@ -1953,7 +2175,7 @@ dependencies = [
  "indexmap 1.9.3",
  "monch",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "regex",
  "serde",
  "serde_json",
@@ -1963,10 +2185,9 @@ dependencies = [
 
 [[package]]
 name = "deno_http"
-version = "0.102.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.112.0"
 dependencies = [
- "async-compression 0.3.15",
+ "async-compression",
  "async-trait",
  "base64 0.13.1",
  "brotli",
@@ -1980,7 +2201,7 @@ dependencies = [
  "http",
  "httparse",
  "hyper 0.14.26",
- "hyper 1.0.0-rc.3",
+ "hyper 1.0.0-rc.4",
  "memmem",
  "mime",
  "once_cell",
@@ -1990,6 +2211,7 @@ dependencies = [
  "ring",
  "serde",
  "slab",
+ "smallvec",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -1997,14 +2219,12 @@ dependencies = [
 
 [[package]]
 name = "deno_io"
-version = "0.17.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "deno_core",
  "filetime",
  "fs3",
- "nix 0.24.2",
  "once_cell",
  "tokio",
  "winapi",
@@ -2012,24 +2232,50 @@ dependencies = [
 
 [[package]]
 name = "deno_kv"
-version = "0.15.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.13.1",
+ "chrono",
  "deno_core",
  "hex",
+ "log",
  "num-bigint",
+ "prost",
+ "prost-build",
+ "rand",
+ "reqwest",
  "rusqlite",
  "serde",
+ "serde_json",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "deno_lint"
+version = "0.50.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f9885a21010c312e84bc6f276a4c97047c3c734bde5f71cb4a71e8121fbe74"
+dependencies = [
+ "anyhow",
+ "deno_ast",
+ "derive_more",
+ "if_chain",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "deno_lockfile"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa35b176a415501662244f99846b3d0dd1a7792b2135bf7f80007f8eca8b24ac"
+checksum = "3e1fcc91fa4e18c3e0574965d7133709e76eda665cb589de703219f0819dfaec"
 dependencies = [
  "ring",
  "serde",
@@ -2039,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "deno_media_type"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63772a60d740a41d97fbffb4788fc3779e6df47289e01892c12be38f4a5beded"
+checksum = "001d69b833ed4d244b608bab9c07069bfb570f631b763b58e73f82a020bf84ef"
 dependencies = [
  "data-url",
  "serde",
@@ -2050,8 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "deno_napi"
-version = "0.37.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.47.0"
 dependencies = [
  "deno_core",
  "libloading",
@@ -2059,8 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "deno_net"
-version = "0.99.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.109.0"
 dependencies = [
  "deno_core",
  "deno_tls",
@@ -2076,10 +2320,10 @@ dependencies = [
 
 [[package]]
 name = "deno_node"
-version = "0.44.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.54.0"
 dependencies = [
  "aes",
+ "brotli",
  "cbc",
  "data-encoding",
  "deno_core",
@@ -2092,11 +2336,13 @@ dependencies = [
  "dsa",
  "ecb",
  "elliptic-curve 0.13.4",
+ "errno 0.2.8",
  "hex",
  "hkdf",
  "idna 0.3.0",
  "indexmap 1.9.3",
  "lazy-regex",
+ "libc",
  "libz-sys",
  "md-5",
  "md4",
@@ -2121,36 +2367,39 @@ dependencies = [
  "serde",
  "sha-1",
  "sha2",
- "sha3",
  "signature 1.6.4",
  "tokio",
  "typenum",
+ "whoami",
+ "winapi",
  "x25519-dalek",
  "x509-parser",
 ]
 
 [[package]]
 name = "deno_npm"
-version = "0.6.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54607b69689ab1e778e5e00545456e6f0c2310205e1bdae01af601c2dace0121"
+checksum = "c90198ae433bf22ac9b39fe5e18748d9d5b36db042ef1c24637f43d3b5e101e0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "deno_lockfile",
  "deno_semver",
  "futures",
  "log",
  "monch",
- "once_cell",
  "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "deno_ops"
-version = "0.67.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.82.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b660872f9a9737d3424470483dd6730d2129481af5055449a2a37ab5bc2145e"
 dependencies = [
+ "deno-proc-macro-rules",
  "lazy-regex",
  "once_cell",
  "pmutil",
@@ -2158,13 +2407,16 @@ dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.32",
  "regex",
+ "strum",
+ "strum_macros",
  "syn 1.0.109",
+ "syn 2.0.28",
+ "thiserror",
 ]
 
 [[package]]
 name = "deno_runtime"
-version = "0.115.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.125.0"
 dependencies = [
  "atty",
  "console_static_text",
@@ -2210,6 +2462,7 @@ dependencies = [
  "signal-hook-registry",
  "termcolor",
  "tokio",
+ "tokio-metrics",
  "uuid",
  "winapi",
  "winres",
@@ -2217,20 +2470,36 @@ dependencies = [
 
 [[package]]
 name = "deno_semver"
-version = "0.2.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "242c8ad9f4ce614ec0fa2e6b3d834f2662ce024ca78e9ed4c58d812cbfc3e41d"
+checksum = "6f739a9d90c47e2af7e2fcbae0976360f3fb5292f7288a084d035ed44d12a288"
 dependencies = [
  "monch",
+ "once_cell",
  "serde",
  "thiserror",
  "url",
 ]
 
 [[package]]
+name = "deno_task_shell"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dbbad0a7ba06a961df3cd638ab117f5d67787607f627defa65629a4ef29d576"
+dependencies = [
+ "anyhow",
+ "futures",
+ "glob",
+ "monch",
+ "os_pipe",
+ "path-dedot",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "deno_tls"
-version = "0.94.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.104.0"
 dependencies = [
  "deno_core",
  "once_cell",
@@ -2243,26 +2512,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "deno_unsync"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac0984205f25e71ddd1be603d76e70255953c12ff864707359ab195d26dfc7b3"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "deno_url"
-version = "0.107.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.117.0"
 dependencies = [
  "deno_core",
  "serde",
- "serde_repr",
  "urlpattern",
 ]
 
 [[package]]
 name = "deno_web"
-version = "0.138.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.148.0"
 dependencies = [
  "async-trait",
  "base64-simd",
+ "bytes",
  "deno_core",
  "encoding_rs",
  "flate2",
+ "futures",
  "serde",
  "tokio",
  "uuid",
@@ -2271,16 +2548,14 @@ dependencies = [
 
 [[package]]
 name = "deno_webidl"
-version = "0.107.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.117.0"
 dependencies = [
  "deno_core",
 ]
 
 [[package]]
 name = "deno_websocket"
-version = "0.112.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.122.0"
 dependencies = [
  "bytes",
  "deno_core",
@@ -2289,6 +2564,7 @@ dependencies = [
  "fastwebsockets",
  "http",
  "hyper 0.14.26",
+ "once_cell",
  "serde",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -2296,8 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "deno_webstorage"
-version = "0.102.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.112.0"
 dependencies = [
  "deno_core",
  "deno_web",
@@ -2364,6 +2639,12 @@ dependencies = [
  "rustc_version 0.4.0",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "difference"
@@ -2492,10 +2773,64 @@ dependencies = [
 ]
 
 [[package]]
-name = "dprint-swc-ext"
-version = "0.9.0"
+name = "dprint-core"
+version = "0.62.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3359a644cca781aece7d7c16bfa80fb35ac83da4e1014a28600debd1ef2a7e"
+checksum = "e6563addfa2b6c6fa96acdda0341090beba2c5c4ff6ef91f3a232a6d4dd34156"
+dependencies = [
+ "anyhow",
+ "bumpalo",
+ "indexmap 1.9.3",
+ "rustc-hash",
+ "serde",
+ "unicode-width",
+]
+
+[[package]]
+name = "dprint-plugin-json"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63039b53a600a7dc078cf9d76d6b5aad9bdb665e5a107ecdb06aef7bcc2e345"
+dependencies = [
+ "anyhow",
+ "dprint-core",
+ "jsonc-parser",
+ "serde",
+ "text_lines",
+]
+
+[[package]]
+name = "dprint-plugin-markdown"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f20e5763efd89925412ac0f525a25bbba9066b2ba924eae87ab8a7120df0744c"
+dependencies = [
+ "anyhow",
+ "dprint-core",
+ "pulldown-cmark 0.9.3",
+ "regex",
+ "serde",
+ "unicode-width",
+]
+
+[[package]]
+name = "dprint-plugin-typescript"
+version = "0.86.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b423bfa289e57a0fab8eadc5ced6a0890ccc3570258daf4a12b1d0412cfb9"
+dependencies = [
+ "anyhow",
+ "deno_ast",
+ "dprint-core",
+ "rustc-hash",
+ "serde",
+]
+
+[[package]]
+name = "dprint-swc-ext"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f115ea5b6f5d0d02a25a9364f41b8c4f857452c299309dcfd29a694724d0566"
 dependencies = [
  "bumpalo",
  "num-bigint",
@@ -2663,6 +2998,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "enum-as-inner"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2739,6 +3080,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
+dependencies = [
+ "libc",
+ "str-buf",
+]
+
+[[package]]
+name = "escape8259"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba4f4911e3666fcd7826997b4745c8224295a6f3072f1418c3067b97a67557ee"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "eszip"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e254fcba0a6481f44fa41f41cb9027d811072e7e7fa94780ade4a7fa43b34c4b"
+dependencies = [
+ "anyhow",
+ "base64 0.21.0",
+ "deno_ast",
+ "deno_graph",
+ "deno_npm",
+ "deno_semver",
+ "futures",
+ "hashlink",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "url",
+]
+
+[[package]]
 name = "exo-deno"
 version = "0.2.5"
 dependencies = [
@@ -2753,7 +3134,6 @@ dependencies = [
  "lazy_static",
  "serde",
  "serde_json",
- "serde_v8",
  "thiserror",
  "tokio",
  "tracing",
@@ -2817,6 +3197,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0678ab2d46fa5195aaf59ad034c083d351377d4af57f3e073c074d0da3e3c766"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2827,15 +3217,17 @@ dependencies = [
 
 [[package]]
 name = "fastwebsockets"
-version = "0.3.1"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1925eb5ee48fffa504a9edce24b3b4d43e2809d1cc713a1df2b13a46e661b3c6"
+checksum = "9e6185b6dc9dddc4db0dedd2e213047e93bcbf7a0fb092abc4c4e4f3195efdb4"
 dependencies = [
  "base64 0.21.0",
  "hyper 0.14.26",
  "pin-project",
  "rand",
  "sha1",
+ "simdutf8",
+ "thiserror",
  "tokio",
  "utf-8",
 ]
@@ -2901,12 +3293,13 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.5.4",
+ "libz-ng-sys",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -2928,23 +3321,23 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
 name = "from_variant"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d449976075322384507443937df2f1d5577afbf4282f12a5a66ef29fa3e6307"
+checksum = "03ec5dc38ee19078d84a692b1c41181ff9f94331c76cee66ff0208c770b5e54f"
 dependencies = [
  "pmutil",
  "proc-macro2 1.0.66",
  "swc_macros_common",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3246,14 +3639,18 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash 0.8.3",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
+checksum = "312f66718a2d7789ffef4f4b7b213138ed9f1eb3aa1d0d82fc99f88fb3ffd26f"
 dependencies = [
- "hashbrown 0.12.3",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -3433,13 +3830,12 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75264b2003a3913f118d35c586e535293b3e22e41f074930762929d071e092"
+checksum = "d280a71f348bcc670fc55b02b63c53a04ac0bf2daff2980795aeaf53edae10e6"
 dependencies = [
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "h2",
  "http",
@@ -3530,6 +3926,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "if_chain"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3587,6 +3993,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -3736,15 +4143,15 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-macro"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7d079e129b77477a49c5c4f1cfe9ce6c2c909ef52520693e8e811a714c7b20"
+checksum = "f4467ed1321b310c2625c5aa6c1b1ffc5de4d9e42668cf697a08fb033ee8265e"
 dependencies = [
  "Inflector",
  "pmutil",
  "proc-macro2 1.0.66",
  "quote 1.0.32",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3868,15 +4275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "keccak"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
-dependencies = [
- "cpufeatures",
-]
-
-[[package]]
 name = "kqueue"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3973,79 +4371,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
-name = "lexical"
-version = "6.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7aefb36fd43fef7003334742cbf77b243fcd36418a1d1bdd480d613a67968f6"
-dependencies = [
- "lexical-core",
-]
-
-[[package]]
-name = "lexical-core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
-dependencies = [
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "lexical-write-float",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-parse-float"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
-dependencies = [
- "lexical-parse-integer",
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-parse-integer"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-util"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-float"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
-dependencies = [
- "lexical-util",
- "lexical-write-integer",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-integer"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4053,9 +4378,9 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libffi"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb06d5b4c428f3cd682943741c39ed4157ae989fffe1094a08eaf7c4014cf60"
+checksum = "ce826c243048e3d5cec441799724de52e2d42f820468431fc3fceee2341871e2"
 dependencies = [
  "libc",
  "libffi-sys",
@@ -4063,9 +4388,9 @@ dependencies = [
 
 [[package]]
 name = "libffi-sys"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c6f11e063a27ffe040a9d15f0b661bf41edc2383b7ae0e0ad5a7e7d53d9da3"
+checksum = "f36115160c57e8529781b4183c2bb51fdc1f6d6d1ed345591d84be7703befb3c"
 dependencies = [
  "cc",
 ]
@@ -4088,13 +4413,23 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.25.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
+checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
 dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libz-ng-sys"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dd9f43e75536a46ee0f92b758f6b63846e594e86638c61a9251338a65baea63"
+dependencies = [
+ "cmake",
+ "libc",
 ]
 
 [[package]]
@@ -4157,11 +4492,10 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 dependencies = [
- "cfg-if 1.0.0",
  "serde",
 ]
 
@@ -4172,6 +4506,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "lsp-types"
+version = "0.93.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be6e9c7e2d18f651974370d7aff703f9513e0df6e464fd795660edc77e6ca51"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
 ]
 
 [[package]]
@@ -4321,15 +4668,6 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
@@ -4351,9 +4689,9 @@ dependencies = [
 
 [[package]]
 name = "monch"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb73e1dc7d232e1ab47ef27f45fa1d173a0979b370e763a9d0584556011150e0"
+checksum = "4519a88847ba2d5ead3dc53f1060ec6a571de93f325d9c5c4968147382b1cbc3"
 
 [[package]]
 name = "multimap"
@@ -4363,8 +4701,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "napi_sym"
-version = "0.37.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.47.0"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.32",
@@ -4402,6 +4739,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f71d09d5c87634207f894c6b31b6a2b2c64ea3bdcf71bd5599fdbbe1600c00f"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "nextest-workspace-hack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d906846a98739ed9d73d66e62c2641eef8321f1734b7a1156ab045a0248fb2b3"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -4659,9 +5011,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "opaque-debug"
@@ -4831,10 +5183,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.4.1"
+name = "os_pipe"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "2c92f2b54f081d635c77e7120862d48db8e91f7f21cef23ab1b4fe9971c59f55"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "outref"
@@ -4908,12 +5264,37 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.7",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -4962,6 +5343,15 @@ name = "path-clean"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecba01bf2678719532c5e3059e0b5f0811273d94b397088b82e3bd0a78c78fdd"
+
+[[package]]
+name = "path-dedot"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d55e486337acb9973cdea3ec5638c1b3bcb22e573b2b7b41969e0c744d5a15e"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "pathdiff"
@@ -5020,9 +5410,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
@@ -5225,13 +5615,13 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "pmutil"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3894e5d549cccbe44afecf72922f277f603cd4bb0219c8342631ef18fffbe004"
+checksum = "52a40bc70c2c58040d2d8b167ba9a5ff59fc9dab7ad44771cfde3dcfde7a09c6"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.32",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -5401,6 +5791,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5552,10 +5952,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
+dependencies = [
+ "bitflags 1.3.2",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-junit"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf780b59d590c25f8c59b44c124166a2a93587868b619fb8f5b47fb15e9ed6d"
+dependencies = [
+ "chrono",
+ "indexmap 2.0.0",
+ "nextest-workspace-hack",
+ "quick-xml",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b9228215d82c7b61490fec1de287136b5de6f5700f6e58ea9ad61a7964ca51"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quote"
@@ -5580,6 +6014,16 @@ name = "radix_fmt"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce082a9940a7ace2ad4a8b7d0b1eac6aa378895f18be598230c5f2284ac05426"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"
@@ -5718,7 +6162,7 @@ version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "async-compression 0.4.1",
+ "async-compression",
  "base64 0.21.0",
  "bytes",
  "encoding_rs",
@@ -5880,11 +6324,11 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a"
+checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -6034,6 +6478,39 @@ name = "rustversion"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
+name = "rustyline"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1cd5ae51d3f7bf65d7969d579d502168ef578f289452bd8ccc91de28fda20e"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if 1.0.0",
+ "clipboard-win",
+ "fd-lock",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.24.2",
+ "radix_trie",
+ "scopeguard",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "winapi",
+]
+
+[[package]]
+name = "rustyline-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "107c3d5d7f370ac09efa62a78375f94d94b8a33c61d8c278b96683fb4dbf2d8d"
+dependencies = [
+ "proc-macro2 1.0.66",
+ "quote 1.0.32",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "ryu"
@@ -6208,9 +6685,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.157"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707de5fcf5df2b5788fca98dd7eab490bc2fd9b7ef1404defc462833b83f25ca"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
 ]
@@ -6236,9 +6713,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.157"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78997f4555c22a7971214540c4a661291970619afd56de19f77e0de86296e1e5"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.32",
@@ -6247,11 +6724,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.94"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "itoa",
  "ryu",
  "serde",
@@ -6291,8 +6768,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.100.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_34_1#f6fc48acc08d4283df659d878985a75907dc1d73"
+version = "0.115.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f6cc041512391aabdae4dd11d51e370824ea35bfe896fb2585b6792e28c9bf"
 dependencies = [
  "bytes",
  "derive_more",
@@ -6404,16 +6882,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha3"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
-dependencies = [
- "digest 0.10.6",
- "keccak",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6421,6 +6889,12 @@ checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-escape"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
 name = "shellexpand"
@@ -6482,6 +6956,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
 name = "similar"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6496,7 +6976,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -6620,6 +7100,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str-buf"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
+
+[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6627,7 +7113,7 @@ checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "phf_shared 0.10.0",
  "precomputed-hash",
  "serde",
@@ -6647,15 +7133,15 @@ dependencies = [
 
 [[package]]
 name = "string_enum"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0090512bdfee4b56d82480d66c0fd8a6f53f0fe0f97e075e949b252acdd482e0"
+checksum = "8fa4d4f81d7c05b9161f8de839975d3326328b8ba2831164b465524cc2f55252"
 dependencies = [
  "pmutil",
  "proc-macro2 1.0.66",
  "quote 1.0.32",
  "swc_macros_common",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -6685,6 +7171,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.66",
+ "quote 1.0.32",
+ "rustversion",
+ "syn 2.0.28",
+]
 
 [[package]]
 name = "subsystem-model-builder-util"
@@ -6720,9 +7228,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "swc_atoms"
-version = "0.5.3"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "593c2f3e4cea60ddc4179ed731cabebe7eacec209d9e76a3bbcff4b2b020e3f5"
+checksum = "b8066e17abb484602da673e2d35138ab32ce53f26368d9c92113510e1659220b"
 dependencies = [
  "once_cell",
  "rustc-hash",
@@ -6734,17 +7242,16 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.213.23"
+version = "0.217.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6153a93eeb264274dfdf6aff3d73fdd098a5b9ef85f85241bdbd8e4149afdcb7"
+checksum = "ce78d316b33559330cb4348144bbd03181369aa62049f540d792c220ed389570"
 dependencies = [
- "ahash 0.7.6",
  "anyhow",
  "crc",
  "indexmap 1.9.3",
  "is-macro",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "petgraph",
  "radix_fmt",
  "relative-path",
@@ -6765,11 +7272,10 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.31.4"
+version = "0.31.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b557014d62318e08070c2a3d5eb0278ff73749dd69db53c39a4de4bcd301d6a"
+checksum = "de5823ef063f116ad281cde9700f5be6dfb182e543ce3f62c42cee1c03ffbc6b"
 dependencies = [
- "ahash 0.7.6",
  "ast_node",
  "better_scoped_tls",
  "cfg-if 1.0.0",
@@ -6793,9 +7299,9 @@ dependencies = [
 
 [[package]]
 name = "swc_config"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89c8fc2c12bb1634c7c32fc3c9b6b963ad8f034cc62c4ecddcf215dc4f6f959d"
+checksum = "9ba1c7a40d38f9dd4e9a046975d3faf95af42937b34b2b963be4d8f01239584b"
 dependencies = [
  "indexmap 1.9.3",
  "serde",
@@ -6805,24 +7311,24 @@ dependencies = [
 
 [[package]]
 name = "swc_config_macro"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dadb9998d4f5fc36ef558ed5a092579441579ee8c6fcce84a5228cca9df4004"
+checksum = "e5b5aaca9a0082be4515f0fbbecc191bf5829cd25b5b9c0a2810f6a2bb0d6829"
 dependencies = [
  "pmutil",
  "proc-macro2 1.0.66",
  "quote 1.0.32",
  "swc_macros_common",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.103.4"
+version = "0.107.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5206233430a6763e2759da76cfc596a64250793f70cd94cace1f82fdcc4d702c"
+checksum = "b7191c8c57af059b75a2aadc927a2608c3962d19e4d09ce8f9c3f03739ddf833"
 dependencies = [
- "bitflags 2.1.0",
+ "bitflags 2.4.0",
  "is-macro",
  "num-bigint",
  "scoped-tls",
@@ -6835,9 +7341,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.138.11"
+version = "0.142.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf45c899625d5132f2993a464a79f2ec7c79854b74fd3c55d1408b76d7d7750c"
+checksum = "1e4e3ee8a1f0bfaf630febbe0f6a03f2c28d66d373a9bbdb3f500f6bfb536b43"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -6854,22 +7360,22 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen_macros"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ee0caee1018808d94ecd09490cb7affd3d504b19aa11c49238f5fc4b54901"
+checksum = "dcdff076dccca6cc6a0e0b2a2c8acfb066014382bc6df98ec99e755484814384"
 dependencies = [
  "pmutil",
  "proc-macro2 1.0.66",
  "quote 1.0.32",
  "swc_macros_common",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "swc_ecma_dep_graph"
-version = "0.105.10"
+version = "0.109.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92813e2f77cdf4ad870f0474eee6574f4aba10504dd3730e694d03684a7a68ab"
+checksum = "1295557b5960eb97ec63fc2008be0a101d1ff7d2163a1031b3d31d3c898d5bb3"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6879,11 +7385,10 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.43.6"
+version = "0.43.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d985c6e7111fef3c0103b0414db0d792cb04b492601c94ccae2d494ffdf764"
+checksum = "82f47bb1ab686f603da93a8b6e559d69b42369ab47d5dee6bdda38ae5902dc2a"
 dependencies = [
- "ahash 0.7.6",
  "anyhow",
  "pathdiff",
  "serde",
@@ -6893,13 +7398,13 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.133.10"
+version = "0.137.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce724a8fdc90548d882dec3b0288c0698059ce12a59bbfdeea0384f3d52f009"
+checksum = "29c0d554865a63bfa58cf1c433fa91d7d4adf40030fa8e4530e8065d0578166a"
 dependencies = [
  "either",
- "lexical",
  "num-bigint",
+ "num-traits",
  "serde",
  "smallvec",
  "smartstring",
@@ -6913,12 +7418,12 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.126.13"
+version = "0.130.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c4236f8b9bea9d3d43cacab34b6e3c925c3f12585382b8f661cb994b987b688"
+checksum = "d8d8ca5dd849cea79e6a9792d725f4082ad3ade7a9541fba960c42d55ae778f2"
 dependencies = [
  "better_scoped_tls",
- "bitflags 2.1.0",
+ "bitflags 2.4.0",
  "indexmap 1.9.3",
  "once_cell",
  "phf 0.10.1",
@@ -6936,9 +7441,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.115.13"
+version = "0.119.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5b13763feba98586887a92801603c413897805c70ed82e49e4acc1f90683c2"
+checksum = "a09d0e350963d4fb14bf9dc31c85eb28e58a88614e779c75f49296710f9cb381"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6950,24 +7455,23 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_macros"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984d5ac69b681fc5438f9abf82b0fda34fe04e119bc75f8213b7e01128c7c9a2"
+checksum = "f59c4b6ed5d78d3ad9fc7c6f8ab4f85bba99573d31d9a2c0a712077a6b45efd2"
 dependencies = [
  "pmutil",
  "proc-macro2 1.0.66",
  "quote 1.0.32",
  "swc_macros_common",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.186.20"
+version = "0.190.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456966f04224d2125551e0e35c164abe45183cbdd5238753294343814be102d3"
+checksum = "93c2801884a19a5d35dd6ac6f7e7a3147502325337f3f7fd11cda7c7b4202007"
 dependencies = [
- "ahash 0.7.6",
  "dashmap",
  "indexmap 1.9.3",
  "once_cell",
@@ -6988,9 +7492,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.160.16"
+version = "0.164.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d21de731e3ff1ea451ac8c377a7130ebf6dbf6ffd18e744c15f86e685e0abd9a"
+checksum = "62d3a04de35f6c79d8f343822138e7313934d3530cc4e4f891a079f7e2415c1a"
 dependencies = [
  "either",
  "rustc-hash",
@@ -7008,11 +7512,10 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.172.19"
+version = "0.176.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0df18263e6c0804a1a08abd29e87af763dce1bec4b500497a0b62c22df07b2d"
+checksum = "607017e6fbfe3229b69ffce7b47383eb9b62025ea93a50cd1cc1788d2a29a4ca"
 dependencies = [
- "ahash 0.7.6",
  "base64 0.13.1",
  "dashmap",
  "indexmap 1.9.3",
@@ -7033,9 +7536,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.176.19"
+version = "0.180.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a3f356bc2b902c13fc1e39bb66c10f350c46bfe93bae5c05402863d94bd307"
+checksum = "ea349e787a62af0dcf1b8b52d507045345871571c18cb78a2f892912f7d6b753"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7049,9 +7552,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.116.10"
+version = "0.120.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b462a1b6fc788ee956479adcbb05c282cb142a66a3b016b571fff0538a381196"
+checksum = "2cb60e20e1eb9e9f7c88d99ac8659fd0561d70abd27853f550fbd907a448c878"
 dependencies = [
  "indexmap 1.9.3",
  "num_cpus",
@@ -7067,9 +7570,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.89.4"
+version = "0.93.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb23a4a1d77997f54e9b3a4e68d1441e5e8a25ad1a476bbb3b5a620d6562a86"
+checksum = "bb23a48abd9f5731b6275dbf4ea89f6e03dc60b7c8e3e1e383bb4a6c39fd7e25"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -7081,21 +7584,21 @@ dependencies = [
 
 [[package]]
 name = "swc_eq_ignore_macros"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c20468634668c2bbab581947bb8c75c97158d5a6959f4ba33df20983b20b4f6"
+checksum = "05a95d367e228d52484c53336991fdcf47b6b553ef835d9159db4ba40efb0ee8"
 dependencies = [
  "pmutil",
  "proc-macro2 1.0.66",
  "quote 1.0.32",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.19.4"
+version = "0.19.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "992a92e087f7b2dc9aa626a6bee26530abbffba3572adf3894ccb55d2480f596"
+checksum = "b07b6c9a4d1659b7e6826fb384b3994b47c5ac35cb76a98a15ca483dd0a5d7b7"
 dependencies = [
  "indexmap 1.9.3",
  "petgraph",
@@ -7105,34 +7608,34 @@ dependencies = [
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "0.20.5"
+version = "0.20.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e02ee852ffd7eb1ee42c081b615c2fb40a2876c4631637486207f493d806c6"
+checksum = "2126bce41c5c755f649bc5fc74fbd5e1ea01306acbf26b49f8aab2bd53f8025f"
 dependencies = [
- "ahash 0.7.6",
- "auto_impl",
+ "auto_impl 1.1.0",
  "petgraph",
+ "swc_common",
  "swc_fast_graph",
  "tracing",
 ]
 
 [[package]]
 name = "swc_macros_common"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e582c3e3c2269238524923781df5be49e011dbe29cf7683a2215d600a562ea6"
+checksum = "7a273205ccb09b51fabe88c49f3b34c5a4631c4c00a16ae20e03111d6a42e832"
 dependencies = [
  "pmutil",
  "proc-macro2 1.0.66",
  "quote 1.0.32",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "swc_visit"
-version = "0.5.5"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1d5999f23421c8e21a0f2bc53a0b9e8244f3b421de89471561af2fbe40b9cca"
+checksum = "e87c337fbb2d191bf371173dea6a957f01899adb8f189c6c31b122a6cfc98fc3"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -7140,16 +7643,16 @@ dependencies = [
 
 [[package]]
 name = "swc_visit_macros"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebeed7eb0f545f48ad30f5aab314e5208b735bcea1d1464f26e20f06db904989"
+checksum = "0f322730fb82f3930a450ac24de8c98523af7d34ab8cb2f46bcb405839891a99"
 dependencies = [
  "Inflector",
  "pmutil",
  "proc-macro2 1.0.66",
  "quote 1.0.32",
  "swc_macros_common",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -7292,6 +7795,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "text-size"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "288cb548dbe72b652243ea797201f3d481a0609a967980fcc5b2315ea811560a"
+
+[[package]]
 name = "text_lines"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7363,6 +7872,17 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "time"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
@@ -7427,7 +7947,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -7457,6 +7977,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-metrics"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b60ac6224d622f71d0b80546558eedf8ff6c2d3817517a9d3ed87ce24fccf6a6"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "tokio-postgres"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7469,7 +8001,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "log",
- "parking_lot",
+ "parking_lot 0.12.1",
  "percent-encoding",
  "phf 0.11.2",
  "pin-project-lite",
@@ -7668,6 +8200,40 @@ name = "tower-layer"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
+name = "tower-lsp"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43e094780b4447366c59f79acfd65b1375ecaa84e61dddbde1421aa506334024"
+dependencies = [
+ "async-trait",
+ "auto_impl 0.5.0",
+ "bytes",
+ "dashmap",
+ "futures",
+ "httparse",
+ "log",
+ "lsp-types",
+ "memchr",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-lsp-macros",
+]
+
+[[package]]
+name = "tower-lsp-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebd99eec668d0a450c177acbc4d05e0d0d13b1f8d3db13cd706c52cbec4ac04"
+dependencies = [
+ "proc-macro2 1.0.66",
+ "quote 1.0.32",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "tower-service"
@@ -7921,7 +8487,7 @@ dependencies = [
  "ipconfig",
  "lazy_static",
  "lru-cache",
- "parking_lot",
+ "parking_lot 0.12.1",
  "resolv-conf",
  "serde",
  "smallvec",
@@ -8110,12 +8676,12 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
- "idna 0.3.0",
+ "idna 0.4.0",
  "percent-encoding",
  "serde",
 ]
@@ -8159,9 +8725,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
  "getrandom 0.2.8",
  "serde",
@@ -8169,9 +8735,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.73.0"
+version = "0.74.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1bd3f04ba5065795dae6e3db668ff0b628920fbd2e39c1755e9b62d93660c3c"
+checksum = "2eedac634b8dd39b889c5b62349cbc55913780226239166435c5cf66771792ea"
 dependencies = [
  "bitflags 1.3.2",
  "fslock",
@@ -8256,6 +8822,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -8807,6 +9379,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "whoami"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "widestring"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9095,7 +9677,7 @@ dependencies = [
  "id-arena",
  "indexmap 1.9.3",
  "log",
- "pulldown-cmark",
+ "pulldown-cmark 0.8.0",
  "unicode-xid 0.2.4",
  "url",
 ]
@@ -9137,7 +9719,7 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -9157,6 +9739,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zeroize"
@@ -9195,7 +9783,7 @@ dependencies = [
  "hmac",
  "pbkdf2 0.11.0",
  "sha1",
- "time",
+ "time 0.3.20",
  "zstd",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,12 +57,12 @@ bytes = "1"
 chrono = { version = "0.4.22", default-features = false, features = ["clock"] }
 codemap = "0.1.3"
 codemap-diagnostic = "0.1.1"
-deno = "1.36.3"
+deno = { git = "https://github.com/exograph/deno.git", branch = "patched_1_36_3", default-features = false  }
 deno_ast = "0.28.0"
 deno_core = "0.204.0"
-deno_fs = "0.27.0"
+deno_fs = { git = "https://github.com/exograph/deno.git", branch = "patched_1_36_3" }
 deno_graph = "=0.52.0"
-deno_runtime = "0.125.0"
+deno_runtime = { git = "https://github.com/exograph/deno.git", branch = "patched_1_36_3" }
 futures = "0.3"
 heck = "0.4.0"
 include_dir = "0.7.2"
@@ -99,8 +99,3 @@ debug = 1
 lto = "thin"
 codegen-units = 1
 strip = true
-
-[patch.crates-io]
-deno_fs = { path = '../deno/ext/fs' }
-deno_runtime = { path = '../deno/runtime' }
-deno = { path = '../deno/cli' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,13 +57,12 @@ bytes = "1"
 chrono = { version = "0.4.22", default-features = false, features = ["clock"] }
 codemap = "0.1.3"
 codemap-diagnostic = "0.1.1"
-deno = { git = "https://github.com/exograph/deno.git", branch = "patched_1_34_1", default-features = false  }
-deno_ast = "0.26.0"
-deno_core = { git = "https://github.com/exograph/deno.git", branch = "patched_1_34_1" }
-deno_fs = { git = "https://github.com/exograph/deno.git", branch = "patched_1_34_1" }
-deno_graph = "=0.48.1"
-deno_runtime = { git = "https://github.com/exograph/deno.git", branch = "patched_1_34_1" }
-serde_v8 = { git = "https://github.com/exograph/deno.git", branch = "patched_1_34_1" }
+deno = "1.36.3"
+deno_ast = "0.28.0"
+deno_core = "0.204.0"
+deno_fs = "0.27.0"
+deno_graph = "=0.52.0"
+deno_runtime = "0.125.0"
 futures = "0.3"
 heck = "0.4.0"
 include_dir = "0.7.2"
@@ -101,3 +100,7 @@ lto = "thin"
 codegen-units = 1
 strip = true
 
+[patch.crates-io]
+deno_fs = { path = '../deno/ext/fs' }
+deno_runtime = { path = '../deno/runtime' }
+deno = { path = '../deno/cli' }

--- a/crates/deno-subsystem/deno-model-builder/src/system_builder.rs
+++ b/crates/deno-subsystem/deno-model-builder/src/system_builder.rs
@@ -133,7 +133,11 @@ fn process_script(
             })?;
             let mut loader = module_graph_builder.create_graph_loader();
             let graph = module_graph_builder
-                .create_graph_with_loader(vec![root_clone], &mut loader)
+                .create_graph_with_loader(
+                    deno_graph::GraphKind::CodeOnly,
+                    vec![root_clone],
+                    &mut loader,
+                )
                 .await
                 .map_err(|e| {
                     ModelBuildingError::Generic(format!(

--- a/crates/deno-subsystem/deno-resolver/src/exo_execution.rs
+++ b/crates/deno-subsystem/deno-resolver/src/exo_execution.rs
@@ -127,9 +127,9 @@ pub fn exo_config() -> DenoExecutorConfig<Option<InterceptedOperationInfo>> {
                 super::exograph_ops::op_operation_query,
                 super::exograph_ops::op_operation_proceed,
             ],
-            customizer = |ext: &mut deno_core::ExtensionBuilder| {
-                ext.force_op_registration();
-            }
+            // customizer = |ext: &mut deno_core::ExtensionBuilder| {
+            //     ext.force_op_registration();
+            // }
         );
         vec![exograph::init_ops()]
     }

--- a/crates/deno-subsystem/deno-resolver/src/exo_execution.rs
+++ b/crates/deno-subsystem/deno-resolver/src/exo_execution.rs
@@ -127,9 +127,6 @@ pub fn exo_config() -> DenoExecutorConfig<Option<InterceptedOperationInfo>> {
                 super::exograph_ops::op_operation_query,
                 super::exograph_ops::op_operation_proceed,
             ],
-            // customizer = |ext: &mut deno_core::ExtensionBuilder| {
-            //     ext.force_op_registration();
-            // }
         );
         vec![exograph::init_ops()]
     }

--- a/libs/exo-deno/Cargo.toml
+++ b/libs/exo-deno/Cargo.toml
@@ -12,7 +12,7 @@ default = []
 typescript-loader = ["dep:deno_ast"]
 cross = [
   "deno_runtime/dont_create_runtime_snapshot",
-  "deno_runtime/launch_without_snapshot"
+  "deno_runtime/__runtime_js_sources",
 ]
 not_cross = ["deno_runtime/include_js_files_for_snapshotting"]
 
@@ -28,7 +28,6 @@ http_req  = {version="0.9.1", default-features = false, features = ["rust-tls"]}
 futures.workspace = true
 lazy_static.workspace = true
 serde = { workspace = true, features = ["derive"] }
-serde_v8.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 include_dir.workspace = true

--- a/libs/exo-deno/src/deno_error.rs
+++ b/libs/exo-deno/src/deno_error.rs
@@ -54,7 +54,7 @@ pub enum DenoInternalError {
     #[error("{0}")]
     Any(#[from] AnyError),
     #[error("{0}")]
-    Serde(#[from] serde_v8::Error),
+    Serde(#[from] deno_core::serde_v8::Error),
     #[error("{0}")]
     DataError(#[from] DataError),
 }

--- a/libs/exo-deno/src/deno_module.rs
+++ b/libs/exo-deno/src/deno_module.rs
@@ -631,13 +631,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_register_sync_ops() {
-        deno_core::extension!(
-            test,
-            ops = [rust_impl],
-            // customizer = |ext: &mut deno_core::ExtensionBuilder| {
-            //     ext.force_op_registration();
-            // }
-        );
+        deno_core::extension!(test, ops = [rust_impl],);
         let mut deno_module = DenoModule::new(
             UserCode::LoadFromFs(
                 Path::new("src")
@@ -669,13 +663,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_register_async_ops() {
-        deno_core::extension!(
-            test,
-            ops = [async_rust_impl],
-            // customizer = |ext: &mut deno_core::ExtensionBuilder| {
-            //     ext.force_op_registration();
-            // }
-        );
+        deno_core::extension!(test, ops = [async_rust_impl],);
         let mut deno_module = DenoModule::new(
             UserCode::LoadFromFs(
                 Path::new("src")


### PR DESCRIPTION
Builds against our fork `patched_1_36_3` branch. This will probably fail on the "cross" build since using the `deno_runtime/__runtime_js_sources` doesn't seem to work correctly, giving a type error in `runtime/worker.rs`.