### PR TITLE
Fix aws-lambda build in CI by installing cmake

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -106,7 +106,7 @@ jobs:
     steps:
       - name: Install packages for building
         run: |
-          yum install -y tar gzip zip unzip gcc make cmake
+          yum install -y tar gzip zip unzip gcc make cmake3
 
           # Install protoc (the yum install version is 2.x, which is too old for grpc needed by opentelemetry)
           curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protoc-3.15.8-linux-x86_64.zip
@@ -117,6 +117,8 @@ jobs:
           # and since it doesn't install rustup, it doesn't respect rust-toolchain.toml settings)
           curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain none --profile minimal -y
           echo "/github/home/.cargo/bin" >> $GITHUB_PATH
+
+          ln -s /usr/bin/cmake /usr/bin/cmake3
 
       - uses: actions/checkout@v3
       - name: Setup Node

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -16,6 +16,7 @@ on:
     branches: ["main"]
     tags:
       - "*"
+  pull_request: # Temporary to allow experimenting in CI
 
 env:
   REGISTRY: ghcr.io
@@ -105,7 +106,7 @@ jobs:
     steps:
       - name: Install packages for building
         run: |
-          yum install -y tar gzip zip unzip gcc make
+          yum install -y tar gzip zip unzip gcc make cmake
 
           # Install protoc (the yum install version is 2.x, which is too old for grpc needed by opentelemetry)
           curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protoc-3.15.8-linux-x86_64.zip

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -16,7 +16,6 @@ on:
     branches: ["main"]
     tags:
       - "*"
-  pull_request: # Temporary to allow experimenting in CI
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -118,7 +118,7 @@ jobs:
           curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain none --profile minimal -y
           echo "/github/home/.cargo/bin" >> $GITHUB_PATH
 
-          ln -s /usr/bin/cmake /usr/bin/cmake3
+          ln -s /usr/bin/cmake3 /usr/bin/cmake
 
       - uses: actions/checkout@v3
       - name: Setup Node


### PR DESCRIPTION
Building `libz-ng-sys v1.1.12` (a dependency of Deno) requires `cmake` to be installed (version > 3.5). So we install `cmake3` (`yum install cmake` installs `cmake` 2, which is not sufficient).