### PR TITLE
Replace actions-rs with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -82,7 +82,7 @@ jobs:
           7z a exograph-${{matrix.target}}.zip *
           cd ..
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: exograph-${{matrix.target}}.zip
           path: dist/exograph-${{matrix.target}}.zip
@@ -141,7 +141,7 @@ jobs:
           zip exograph-${{ env.ARCH }}.zip *
           cd ..
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: exograph-${{ env.ARCH }}.zip
           path: dist/exograph-${{ env.ARCH }}.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,20 +25,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2.3.0
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
       - name: Install deps
         run: sudo apt-get install -y protobuf-compiler
-      - uses: Swatinem/rust-cache@v2.3.0
-      - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
-      - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features -- -D warnings --no-deps
+      - name: Run linters
+        run: |
+          cargo fmt --all -- --check
+          cargo clippy --all-targets --all-features -- -D warnings --no-deps
 
   test:
     strategy:


### PR DESCRIPTION
The former, which is no longer maintained, uses Node 12, which is being deprecated by Github Actions.