### PR TITLE
Update oidc-jwt-validator to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4787,8 +4787,9 @@ dependencies = [
 
 [[package]]
 name = "oidc-jwt-validator"
-version = "0.2.0"
-source = "git+https://github.com/exograph/oidc_jwt_validator.git?branch=reqwest-no-default-features#b58cc647db179bfbd4677e514f394a05c0dd0595"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a946417e6f2bd610148c0d30f527fc84fc339b7e574ae6b54e9060a37133e5"
 dependencies = [
  "base64 0.13.1",
  "jsonwebtoken",

--- a/crates/core-subsystem/core-resolver/Cargo.toml
+++ b/crates/core-subsystem/core-resolver/Cargo.toml
@@ -18,7 +18,7 @@ futures.workspace = true
 serde_json = { workspace = true, features = ["preserve_order"] }
 jsonwebtoken.workspace = true
 reqwest.workspace = true
-oidc-jwt-validator = { git = "https://github.com/exograph/oidc_jwt_validator.git", branch = "reqwest-no-default-features"}
+oidc-jwt-validator = "0.2.1"
 serde.workspace = true
 thiserror.workspace = true
 cookie = "0.16"


### PR DESCRIPTION
In #912, we fixed the OpenSSL dependency issue using a patch. Now that a proper release is available, we use that instead.