### PR TITLE
Improve Auth0 playground interaction

### DIFF
--- a/graphiql/src/auth/auth0/AuthConfigProvider.tsx
+++ b/graphiql/src/auth/auth0/AuthConfigProvider.tsx
@@ -52,7 +52,7 @@ function ContextInitializer(props: { children: React.ReactNode }) {
     useContext(AuthContext);
 
   const signOutFn = useCallback(async () => {
-    logout();
+    logout({ openUrl: false });
   }, [logout]);
 
   const getUserInfo = useCallback(() => {

--- a/graphiql/src/auth/auth0/SignInPanel.tsx
+++ b/graphiql/src/auth/auth0/SignInPanel.tsx
@@ -48,7 +48,14 @@ export function SignInPanel() {
               background: "hsla(var(--color-tertiary), 1)",
               color: "white",
             }}
-            onClick={() => loginWithRedirect()}
+            onClick={() =>
+              loginWithRedirect({
+                // Specify custom openUrl to prevent Auth0 from reopening the window (which doesn't work in Arc)
+                openUrl(url) {
+                  window.location.replace(url);
+                },
+              })
+            }
           >
             Sign in with Auth0
           </button>


### PR DESCRIPTION
- Make it work on the Arc browser (use custom `openUrl` when logging in)
- Make it work without configuring the signout url