### PR TITLE
Replace "Payload" with "Claims" in playground

### DIFF
--- a/graphiql/src/auth/secret/AuthConfigProvider.tsx
+++ b/graphiql/src/auth/secret/AuthConfigProvider.tsx
@@ -38,16 +38,16 @@ function ContextInitializer(props: { children: React.ReactNode }) {
 
   useEffect(() => {
     const secret = config.secret;
-    const payload = config.payload;
+    const claims = config.claims;
 
     setTokenFn &&
       setTokenFn(
         signedIn
-          ? () => Promise.resolve(createJwtToken(JSON.parse(payload), secret))
+          ? () => Promise.resolve(createJwtToken(JSON.parse(claims), secret))
           : undefined
       );
     setIsSignedIn && setIsSignedIn(signedIn);
-    setUserInfo && setUserInfo(payload);
+    setUserInfo && setUserInfo(claims);
     setSignOutFn &&
       setSignOutFn(() => {
         setSignedIn(!signedIn);
@@ -67,7 +67,7 @@ function ContextInitializer(props: { children: React.ReactNode }) {
 }
 
 async function createJwtToken(
-  payload: Record<string, unknown>,
+  claims: Record<string, unknown>,
   secret: string
 ): Promise<string | null> {
   if (secret === "") {
@@ -77,7 +77,7 @@ async function createJwtToken(
   const encodedSecret = new TextEncoder().encode(secret);
   const alg = "HS256";
 
-  return await new jose.SignJWT(payload)
+  return await new jose.SignJWT(claims)
     .setProtectedHeader({ alg })
     .setIssuedAt()
     .setExpirationTime("10m")

--- a/graphiql/src/auth/secret/SecretConfig.tsx
+++ b/graphiql/src/auth/secret/SecretConfig.tsx
@@ -1,4 +1,4 @@
-const defaultPayload = `{
+const defaultClaims = `{
   "sub": "1234567890",
   "name": "Jordan Taylor"
 }`;
@@ -9,21 +9,21 @@ export class SecretConfig {
     return this._secret;
   }
 
-  private _payload: string;
-  get payload(): string {
-    return this._payload;
+  private _claims: string;
+  get claims(): string {
+    return this._claims;
   }
 
-  constructor(secret: string, payload: string) {
+  constructor(secret: string, claims: string) {
     this._secret = secret;
-    this._payload = payload;
+    this._claims = claims;
   }
 
   canSignIn(): boolean {
-    return !!this.secret && !!this.payload;
+    return !!this.secret && !!this.claims;
   }
 
   static loadConfig(): SecretConfig {
-    return new SecretConfig("", defaultPayload);
+    return new SecretConfig("", defaultClaims);
   }
 }

--- a/graphiql/src/auth/secret/SignInPanel.tsx
+++ b/graphiql/src/auth/secret/SignInPanel.tsx
@@ -18,25 +18,25 @@ export function SignInPanel(props: { onDone: () => void }) {
   const { setSignedIn } = useContext(SecretAuthContext);
 
   const [jwtSecret, setJwtSecret] = useState(config.secret);
-  const [payload, setPayload] = useState(config.payload || "");
-  const [payloadError, setPayloadError] = useState<string | undefined>(
+  const [claims, setClaims] = useState(config.claims || "");
+  const [claimsError, setClaimsError] = useState<string | undefined>(
     undefined
   );
 
   useEffect(() => {
     try {
-      JSON.parse(payload);
-      setPayloadError(undefined);
+      JSON.parse(claims);
+      setClaimsError(undefined);
     } catch (e) {
-      setPayloadError((e as Error).message);
+      setClaimsError((e as Error).message);
       return;
     }
-  }, [payload]);
+  }, [claims]);
 
-  const enableSignIn = !payloadError && jwtSecret && payload ? true : false;
+  const enableSignIn = !claimsError && jwtSecret && claims ? true : false;
 
   function onSignIn() {
-    setConfig(new SecretConfig(jwtSecret, payload));
+    setConfig(new SecretConfig(jwtSecret, claims));
     setSignedIn(true);
     props.onDone();
   }
@@ -64,10 +64,10 @@ export function SignInPanel(props: { onDone: () => void }) {
         theme={exoTheme}
         onChange={setJwtSecret}
       />
-      <div style={labelStyle}>Payload</div>
+      <div style={labelStyle}>Claims</div>
       <CodeMirror
         style={codeMirrorStyle}
-        value={payload}
+        value={claims}
         minHeight="5rem"
         basicSetup={{
           lineNumbers: false,
@@ -81,7 +81,7 @@ export function SignInPanel(props: { onDone: () => void }) {
           jsonLinterExtension,
         ]}
         theme={exoTheme}
-        onChange={setPayload}
+        onChange={setClaims}
       />
       {
         <div
@@ -91,7 +91,7 @@ export function SignInPanel(props: { onDone: () => void }) {
             height: "2rem",
           }}
         >
-          {payloadError}
+          {claimsError}
         </div>
       }
       <div style={{ display: "flex", gap: "1rem", justifyContent: "end" }}>


### PR DESCRIPTION
Payload isn't quite the correct term to describe user claims (payload in a JWT token includes additional information such as the "exp" and "iat" fields). So, in this commit, we replace "Payload" with "Claims" in the playground.