### PR TITLE
Publish Exograph CLI Docker Image

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -17,10 +17,6 @@ on:
     tags:
       - "*"
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
   # Build and packages all the things
   build-artifacts:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -16,7 +16,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   # Build and publish Docker image
@@ -26,6 +25,13 @@ jobs:
       contents: read
       packages: write
 
+    strategy:
+      matrix:
+        # Images we need to publish
+        include:
+          - image: cli
+          - image: server
+  
     steps:
       - uses: actions/checkout@v3
 
@@ -40,7 +46,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/exograph/${{ matrix.image }}
 
       - name: Download artifacts
         run: |
@@ -50,7 +56,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          file: docker/Dockerfile.ci
+          file: docker/Dockerfile.${{ matrix.image }}.ci
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/crates/cli/src/commands/templates/Dockerfile.fly
+++ b/crates/cli/src/commands/templates/Dockerfile.fly
@@ -1,4 +1,4 @@
-FROM ghcr.io/exograph/exograph:latest
+FROM ghcr.io/exograph/server:latest
 
 COPY ./target/index.exo_ir ./target/index.exo_ir
 

--- a/docker/Dockerfile.cli.ci
+++ b/docker/Dockerfile.cli.ci
@@ -1,0 +1,34 @@
+# We must use "debian:bullseye*" (and not "debian:buster") as the base runtime image to match the libc version used while building the binaries
+
+## Create a builder image with exograph release binaries
+FROM debian:bullseye-slim as builder
+
+RUN apt-get update && apt-get -y install unzip
+
+WORKDIR /usr/src
+COPY exograph-x86_64-unknown-linux-gnu.zip ./exograph-x86_64-unknown-linux-gnu.zip
+RUN unzip ./exograph-x86_64-unknown-linux-gnu.zip
+
+
+## Build the runtime image with just the binary we need for the cli
+FROM debian:bullseye-slim
+
+### Install ca-certificates and tzdata (needed to establish TLS connections and set the timezone)
+RUN apt-get update \
+  && apt-get install -y ca-certificates tzdata \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/src/exo /usr/local/bin/exo
+
+ENV TZ=Etc/UTC
+ENV APP_USER=exo
+ENV APP_DIR=/usr/src/app
+
+### Create a non-root user to run the cli
+RUN groupadd $APP_USER \
+  && useradd -g $APP_USER $APP_USER \
+  && mkdir -p ${APP_DIR}
+RUN chown -R $APP_USER:$APP_USER ${APP_DIR}
+USER $APP_USER
+
+WORKDIR ${APP_DIR}

--- a/docker/Dockerfile.server.ci
+++ b/docker/Dockerfile.server.ci
@@ -11,7 +11,7 @@ RUN unzip ./exograph-x86_64-unknown-linux-gnu.zip
 
 
 ## Build the runtime image with just the binary we need for the server
-FROM debian:bullseye-slim as exo-server
+FROM debian:bullseye-slim
 
 ### Install ca-certificates and tzdata (needed to establish TLS connections and set the timezone)
 RUN apt-get update \


### PR DESCRIPTION
In addition to the already published exograph-server docker image, we now publish an exograph-cli docker image. This allows projects to set up a Dockerfile that builds the exo_ir file and then runs it.