### PR TITLE
Improves the user error message when a cast fails

### DIFF
--- a/crates/postgres-subsystem/postgres-resolver/src/create_data_param_mapper.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/create_data_param_mapper.rs
@@ -181,13 +181,9 @@ async fn map_self_column<'a>(
     };
 
     let value_column = cast::literal_column(argument_value, key_column).with_context(format!(
-        "While trying to get literal column for {}.{}",
-        subsystem
-            .database
-            .get_table(key_column.table_id)
-            .name
-            .fully_qualified_name(),
-        key_column.name
+        "trying to convert the '{}' field to the '{}' type",
+        field.name,
+        key_column.typ.type_string()
     ))?;
 
     Ok(InsertionElement::SelfInsert(ColumnValuePair::new(

--- a/crates/postgres-subsystem/postgres-resolver/src/postgres_execution_error.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/postgres_execution_error.rs
@@ -57,6 +57,12 @@ impl PostgresExecutionError {
         match self {
             PostgresExecutionError::Authorization => "Not authorized".to_string(),
             PostgresExecutionError::Validation(_, _) => self.to_string(),
+            PostgresExecutionError::CastError(_) => {
+                "Unable to convert input to the expected type".to_string()
+            }
+            PostgresExecutionError::WithContext(context, e) => {
+                format!("{}: {}", e.user_error_message(), context)
+            }
             // Do not reveal the underlying database error as it may expose sensitive details (such as column names or data involved in constraint violation).
             _ => {
                 error!("Postgres operation failed: {:?}", self);

--- a/integration-tests/blobs-uuids/tests/mutation-wrong-format.exotest
+++ b/integration-tests/blobs-uuids/tests/mutation-wrong-format.exotest
@@ -15,7 +15,7 @@ response: |
     {
         "errors": [
             {
-                "message": ""
+                "message": "Unable to convert input to the expected type: trying to convert the 'data' field to the 'Blob' type"
             }
         ]
     }

--- a/integration-tests/blobs-uuids/tests/uuid-populate-many-and-query.exotest
+++ b/integration-tests/blobs-uuids/tests/uuid-populate-many-and-query.exotest
@@ -1,3 +1,4 @@
+retries: 3
 stages:
     # create Blobs
     - deno: |

--- a/libs/exo-sql/src/sql/physical_column.rs
+++ b/libs/exo-sql/src/sql/physical_column.rs
@@ -116,6 +116,39 @@ pub enum FloatBits {
 }
 
 impl PhysicalColumnType {
+    pub fn type_string(&self) -> String {
+        match self {
+            PhysicalColumnType::Int { bits } => format!("Int of size {:?} bits", bits),
+            PhysicalColumnType::String { max_length } => {
+                format!("String of max length {:?}", max_length)
+            }
+            PhysicalColumnType::Boolean => "Boolean".to_string(),
+            PhysicalColumnType::Timestamp {
+                timezone,
+                precision,
+            } => {
+                format!(
+                    "Timestamp with timezone: {:?}, precision: {:?}",
+                    timezone, precision
+                )
+            }
+            PhysicalColumnType::Date => "Date".to_string(),
+            PhysicalColumnType::Time { precision } => {
+                format!("Time with precision: {:?}", precision)
+            }
+            PhysicalColumnType::Json => "Json".to_string(),
+            PhysicalColumnType::Blob => "Blob".to_string(),
+            PhysicalColumnType::Uuid => "Uuid".to_string(),
+            PhysicalColumnType::Array { typ } => format!("Array of {:?}", typ),
+            PhysicalColumnType::Float { bits } => format!("Float of size {:?} bits", bits),
+            PhysicalColumnType::Numeric { precision, scale } => {
+                format!(
+                    "Numeric with precision: {:?}, scale: {:?}",
+                    precision, scale
+                )
+            }
+        }
+    }
     /// Create a new physical column type given the SQL type string. This is used to reverse-engineer
     /// a database schema to a Exograph model.
     pub fn from_string(s: &str) -> Result<PhysicalColumnType, DatabaseError> {


### PR DESCRIPTION
Earlier, we produced a genetic "Postgres operation failed" error message when a cast failed. Now we give a more specific error message pointing to the field and the expected type.

Also, add `retries` to uuid-populate-many-and-query to make it more robust against network failures.