### PR TITLE
Tidy up the tracing output

### DIFF
--- a/libs/exo-sql/src/sql/transaction.rs
+++ b/libs/exo-sql/src/sql/transaction.rs
@@ -58,7 +58,7 @@ impl<'a> TransactionScript<'a> {
     /// Returns the result of the last step
     #[instrument(
         name = "TransactionScript::execute"
-        skip(self, tx)
+        skip_all
         )]
     pub async fn execute(
         self,
@@ -101,7 +101,7 @@ impl<'a> TransactionStep<'a> {
     #[instrument(
         name = "TransactionStep::execute"
         level = "trace"
-        skip(self, client, transaction_context)
+        skip_all
         )]
     pub async fn execute(
         self,
@@ -156,7 +156,7 @@ impl<'a> ConcreteTransactionStep<'a> {
     #[instrument(
         name = "ConcreteTransactionStep::execute"
         level = "trace"
-        skip(self, client)
+        skip_all
         fields(
             operation = ?self.operation
             )

--- a/libs/exo-sql/src/transform/pg/select/select_transformer.rs
+++ b/libs/exo-sql/src/transform/pg/select/select_transformer.rs
@@ -109,7 +109,7 @@ impl SelectTransformer for Postgres {
     /// Form a [`Select`] from a given [`AbstractSelect`].
     #[instrument(
         name = "SelectTransformer::to_select for Postgres"
-        skip(self)
+        skip(self, database)
         )]
     fn to_select<'a>(&self, abstract_select: &AbstractSelect, database: &'a Database) -> Select {
         self.compute_select(abstract_select, &SelectionLevel::TopLevel, false, database)

--- a/libs/exo-sql/src/transform/pg/update/update_transformer.rs
+++ b/libs/exo-sql/src/transform/pg/update/update_transformer.rs
@@ -39,7 +39,7 @@ use super::update_strategy_chain::UpdateStrategyChain;
 impl UpdateTransformer for Postgres {
     #[instrument(
         name = "UpdateTransformer::to_transaction_script for Postgres"
-        skip(self)
+        skip(self, database, transaction_script)
         )]
     fn update_transaction_script<'a>(
         &self,

--- a/libs/exo-sql/src/transform/transformer.rs
+++ b/libs/exo-sql/src/transform/transformer.rs
@@ -70,7 +70,7 @@ pub trait SelectTransformer {
 pub trait DeleteTransformer {
     #[instrument(
         name = "DeleteTransformer::to_transaction_script for Postgres"
-        skip(self)
+        skip(self, database)
         )]
     fn to_transaction_script<'a>(
         &self,
@@ -95,7 +95,7 @@ pub trait DeleteTransformer {
 pub trait InsertTransformer {
     #[instrument(
         name = "InsertTransformer::to_transaction_script for Postgres"
-        skip(self)
+        skip(self, parent_step, database)
         )]
     fn to_transaction_script<'a>(
         &self,
@@ -127,7 +127,7 @@ pub trait InsertTransformer {
 pub trait UpdateTransformer {
     #[instrument(
         name = "UpdateTransformer::to_transaction_script for Postgres"
-        skip(self)
+        skip(self, database)
         )]
     fn to_transaction_script<'a>(
         &self,


### PR DESCRIPTION
Mostly skip the tracing of the `Database` argument from various `#instrument` decorators. The `Debug` implementation for `Database` prints columns, so that is not useful for tracing.