### PR TITLE
Support access control with higher-order function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ futures = "0.3"
 heck = "0.4.0"
 include_dir = "0.7.2"
 indexmap = "2.0.1"
-insta = { version = "1.31.0", features = ["redactions"] }
+insta = { version = "1.31.0", features = ["redactions", "yaml"] }
 jsonwebtoken = "8.3.0"
 lazy_static = "1.4.0"
 maybe-owned = "0.3.4"

--- a/crates/builder/grammar/grammar.js
+++ b/crates/builder/grammar/grammar.js
@@ -150,11 +150,11 @@ module.exports = grammar({
     // macros for the form `name(term, expr)` such as `exists(du, du.userId == AuthContext.id && du.read)`
     // Note, we do not support macros such as has(<expr>)
     macro: $ => seq(
-      field("name", $.term),
+      field("name", $.term), // "exists"
       "(",
-      $.term,
+      field("elem_name", $.term), // "du"
       ",",
-      field("args", $.expression),
+      field("expr", $.expression), // "du.userId == AuthContext.id && du.read"
       ")"
     ),
     logical_op: $ => choice(

--- a/crates/builder/grammar/grammar.js
+++ b/crates/builder/grammar/grammar.js
@@ -141,7 +141,21 @@ module.exports = grammar({
     selection_select: $ => seq(
       field("prefix", $.selection),
       ".",
-      field("term", $.term)
+      field("selection_element", $.selection_element)
+    ),
+    selection_element: $ => choice(
+      $.term,
+      $.macro,
+    ),
+    // macros for the form `name(term, expr)` such as `exists(du, du.userId == AuthContext.id && du.read)`
+    // Note, we do not support macros such as has(<expr>)
+    macro: $ => seq(
+      field("name", $.term),
+      "(",
+      $.term,
+      ",",
+      field("args", $.expression),
+      ")"
     ),
     logical_op: $ => choice(
       $.logical_or,

--- a/crates/builder/grammar/grammar.js
+++ b/crates/builder/grammar/grammar.js
@@ -145,17 +145,18 @@ module.exports = grammar({
     ),
     selection_element: $ => choice(
       $.term,
-      $.macro,
+      $.hof_call,
     ),
-    // macros for the form `name(parameter_name, expr)` such as `some((du) => du.userId == AuthContext.id && du.read)`
-    // or `some(du => du.userId == AuthContext.id && du.read)`
-    // Note, we do not support macros such as `every(<expr>)`
-    macro: $ => seq(
+    // High-order function call of the `name(param_name, expr)` such as: 
+    // - `some((du) => du.userId == AuthContext.id && du.read)`
+    // - `some(du => du.userId == AuthContext.id && du.read)`
+    // (note `du` vs `(du)`)
+    hof_call: $ => seq(
       field("name", $.term), // "some"
       "(",
       choice(
-        field("elem_name", $.term), // "du"
-        seq("(", field("elem_name", $.term), ")") // "(du)"
+        field("param_name", $.term), // "du"
+        seq("(", field("param_name", $.term), ")") // "(du)"
       ),
       "=>",
       field("expr", $.expression), // "du.userId == AuthContext.id && du.read"

--- a/crates/builder/grammar/grammar.js
+++ b/crates/builder/grammar/grammar.js
@@ -147,13 +147,17 @@ module.exports = grammar({
       $.term,
       $.macro,
     ),
-    // macros for the form `name(term, expr)` such as `exists(du, du.userId == AuthContext.id && du.read)`
-    // Note, we do not support macros such as has(<expr>)
+    // macros for the form `name(parameter_name, expr)` such as `some((du) => du.userId == AuthContext.id && du.read)`
+    // or `some(du => du.userId == AuthContext.id && du.read)`
+    // Note, we do not support macros such as `every(<expr>)`
     macro: $ => seq(
-      field("name", $.term), // "exists"
+      field("name", $.term), // "some"
       "(",
-      field("elem_name", $.term), // "du"
-      ",",
+      choice(
+        field("elem_name", $.term), // "du"
+        seq("(", field("elem_name", $.term), ")") // "(du)"
+      ),
+      "=>",
       field("expr", $.expression), // "du.userId == AuthContext.id && du.read"
       ")"
     ),

--- a/crates/builder/src/parser/converter.rs
+++ b/crates/builder/src/parser/converter.rs
@@ -648,13 +648,13 @@ fn convert_selection_elem(
 
             let expr_field = first_child.child_by_field_name("expr").unwrap();
             let expr = convert_expression(expr_field, source, source_span);
-            FieldSelectionElement::Macro(
-                span_from_node(source_span, first_child),
-                Identifier(name, span_from_node(source_span, name_field)),
-                Identifier(elem_name, span_from_node(source_span, elem_name_field)),
-                Box::new(expr),
-                (),
-            )
+            FieldSelectionElement::Macro {
+                span: span_from_node(source_span, first_child),
+                name: Identifier(name, span_from_node(source_span, name_field)),
+                elem_name: Identifier(elem_name, span_from_node(source_span, elem_name_field)),
+                expr: Box::new(expr),
+                typ: (),
+            }
         }
         o => panic!("unsupported selection element kind: {o}"),
     }

--- a/crates/builder/src/parser/converter.rs
+++ b/crates/builder/src/parser/converter.rs
@@ -753,12 +753,32 @@ mod tests {
     }
 
     #[test]
-    fn access_control_function() {
+    fn access_control_function_without_paren() {
         parsing_test!(
             r#"
             @postgres
             module TestModule {
-                @access(self.concerts.exists(c, c.id == 1))
+                @access(self.concerts.some(c => c.id == 1))
+                type Venue {
+                    concerts: Set<Concert>?
+                }
+
+                type Concert {
+                    @pk id: Int = autoIncrement()
+                    venue: Venue
+                }
+            }
+        "#
+        );
+    }
+
+    #[test]
+    fn access_control_function_with_paren() {
+        parsing_test!(
+            r#"
+            @postgres
+            module TestModule {
+                @access(self.concerts.some((c) => c.id == 1))
                 type Venue {
                     concerts: Set<Concert>?
                 }

--- a/crates/builder/src/parser/converter.rs
+++ b/crates/builder/src/parser/converter.rs
@@ -639,19 +639,19 @@ fn convert_selection_elem(
             span_from_node(source_span, first_child),
             (),
         ),
-        "macro" => {
+        "hof_call" => {
             let name_field = first_child.child_by_field_name("name").unwrap();
             let name = name_field.utf8_text(source).unwrap().to_string();
 
-            let elem_name_field = first_child.child_by_field_name("elem_name").unwrap();
-            let elem_name = elem_name_field.utf8_text(source).unwrap().to_string();
+            let param_name_field = first_child.child_by_field_name("param_name").unwrap();
+            let param_name = param_name_field.utf8_text(source).unwrap().to_string();
 
             let expr_field = first_child.child_by_field_name("expr").unwrap();
             let expr = convert_expression(expr_field, source, source_span);
-            FieldSelectionElement::Macro {
+            FieldSelectionElement::HofCall {
                 span: span_from_node(source_span, first_child),
                 name: Identifier(name, span_from_node(source_span, name_field)),
-                elem_name: Identifier(elem_name, span_from_node(source_span, elem_name_field)),
+                param_name: Identifier(param_name, span_from_node(source_span, param_name_field)),
                 expr: Box::new(expr),
                 typ: (),
             }

--- a/crates/builder/src/parser/snapshots/builder__parser__converter__tests__access_control_function.snap
+++ b/crates/builder/src/parser/snapshots/builder__parser__converter__tests__access_control_function.snap
@@ -41,9 +41,12 @@ modules:
                               - ~
                           - ~
                       - Macro:
-                          - - exists
-                          - - c
-                          - RelationalOp:
+                          name:
+                            - exists
+                          elem_name:
+                            - c
+                          expr:
+                            RelationalOp:
                               Eq:
                                 - FieldSelection:
                                     Select:
@@ -59,7 +62,7 @@ modules:
                                 - NumberLiteral:
                                     - 1
                                 - ~
-                          - ~
+                          typ: ~
                       - ~
       - name: Concert
         kind: Type

--- a/crates/builder/src/parser/snapshots/builder__parser__converter__tests__access_control_function.snap
+++ b/crates/builder/src/parser/snapshots/builder__parser__converter__tests__access_control_function.snap
@@ -1,0 +1,94 @@
+---
+source: crates/builder/src/parser/converter.rs
+expression: "convert_root(parsed.root_node(),\n        r#\"\n            @postgres\n            module TestModule {\n                @access(self.concerts.exists(c, c.id == 1))\n                type Venue {\n                    concerts: Set<Concert>?\n                }\n\n                type Concert {\n                    @pk id: Int = autoIncrement()\n                    venue: Venue\n                }\n            }\n        \"#.as_bytes(),\n        file_span, Path::new(\"input.exo\")).unwrap()"
+---
+types: []
+modules:
+  - name: TestModule
+    annotations:
+      - name: postgres
+        params: None
+    types:
+      - name: Venue
+        kind: Type
+        fields:
+          - name: concerts
+            typ:
+              Optional:
+                Plain:
+                  - Set
+                  - - Plain:
+                        - Concert
+                        - []
+                        - ~
+                  - ~
+            annotations: []
+            default_value: ~
+        annotations:
+          - name: access
+            params:
+              Single:
+                - FieldSelection:
+                    Select:
+                      - Select:
+                          - Single:
+                              - Identifier:
+                                  - self
+                                  - ~
+                              - ~
+                          - Identifier:
+                              - concerts
+                              - ~
+                          - ~
+                      - Macro:
+                          - - exists
+                          - - c
+                          - RelationalOp:
+                              Eq:
+                                - FieldSelection:
+                                    Select:
+                                      - Single:
+                                          - Identifier:
+                                              - c
+                                              - ~
+                                          - ~
+                                      - Identifier:
+                                          - id
+                                          - ~
+                                      - ~
+                                - NumberLiteral:
+                                    - 1
+                                - ~
+                          - ~
+                      - ~
+      - name: Concert
+        kind: Type
+        fields:
+          - name: id
+            typ:
+              Plain:
+                - Int
+                - []
+                - ~
+            annotations:
+              - name: pk
+                params: None
+            default_value:
+              kind:
+                Function:
+                  - autoIncrement
+                  - []
+          - name: venue
+            typ:
+              Plain:
+                - Venue
+                - []
+                - ~
+            annotations: []
+            default_value: ~
+        annotations: []
+    methods: []
+    interceptors: []
+    base_exofile: input.exo
+imports: []
+

--- a/crates/builder/src/parser/snapshots/builder__parser__converter__tests__access_control_function_with_paren.snap
+++ b/crates/builder/src/parser/snapshots/builder__parser__converter__tests__access_control_function_with_paren.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/builder/src/parser/converter.rs
-expression: "convert_root(parsed.root_node(),\n        r#\"\n            @postgres\n            module TestModule {\n                @access(self.concerts.exists(c, c.id == 1))\n                type Venue {\n                    concerts: Set<Concert>?\n                }\n\n                type Concert {\n                    @pk id: Int = autoIncrement()\n                    venue: Venue\n                }\n            }\n        \"#.as_bytes(),\n        file_span, Path::new(\"input.exo\")).unwrap()"
+expression: "convert_root(parsed.root_node(),\n        r#\"\n            @postgres\n            module TestModule {\n                @access(self.concerts.some(c, c.id == 1))\n                type Venue {\n                    concerts: Set<Concert>?\n                }\n\n                type Concert {\n                    @pk id: Int = autoIncrement()\n                    venue: Venue\n                }\n            }\n        \"#.as_bytes(),\n        file_span, Path::new(\"input.exo\")).unwrap()"
 ---
 types: []
 modules:
@@ -42,7 +42,7 @@ modules:
                           - ~
                       - Macro:
                           name:
-                            - exists
+                            - some
                           elem_name:
                             - c
                           expr:

--- a/crates/builder/src/parser/snapshots/builder__parser__converter__tests__access_control_function_with_paren.snap
+++ b/crates/builder/src/parser/snapshots/builder__parser__converter__tests__access_control_function_with_paren.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/builder/src/parser/converter.rs
-expression: "convert_root(parsed.root_node(),\n        r#\"\n            @postgres\n            module TestModule {\n                @access(self.concerts.some(c, c.id == 1))\n                type Venue {\n                    concerts: Set<Concert>?\n                }\n\n                type Concert {\n                    @pk id: Int = autoIncrement()\n                    venue: Venue\n                }\n            }\n        \"#.as_bytes(),\n        file_span, Path::new(\"input.exo\")).unwrap()"
+expression: "convert_root(parsed.root_node(),\n        r#\"\n            @postgres\n            module TestModule {\n                @access(self.concerts.some((c) => c.id == 1))\n                type Venue {\n                    concerts: Set<Concert>?\n                }\n\n                type Concert {\n                    @pk id: Int = autoIncrement()\n                    venue: Venue\n                }\n            }\n        \"#.as_bytes(),\n        file_span, Path::new(\"input.exo\")).unwrap()"
 ---
 types: []
 modules:
@@ -40,10 +40,10 @@ modules:
                               - concerts
                               - ~
                           - ~
-                      - Macro:
+                      - HofCall:
                           name:
                             - some
-                          elem_name:
+                          param_name:
                             - c
                           expr:
                             RelationalOp:

--- a/crates/builder/src/parser/snapshots/builder__parser__converter__tests__access_control_function_without_paren.snap
+++ b/crates/builder/src/parser/snapshots/builder__parser__converter__tests__access_control_function_without_paren.snap
@@ -1,0 +1,97 @@
+---
+source: crates/builder/src/parser/converter.rs
+expression: "convert_root(parsed.root_node(),\n        r#\"\n            @postgres\n            module TestModule {\n                @access(self.concerts.some(c, c.id == 1))\n                type Venue {\n                    concerts: Set<Concert>?\n                }\n\n                type Concert {\n                    @pk id: Int = autoIncrement()\n                    venue: Venue\n                }\n            }\n        \"#.as_bytes(),\n        file_span, Path::new(\"input.exo\")).unwrap()"
+---
+types: []
+modules:
+  - name: TestModule
+    annotations:
+      - name: postgres
+        params: None
+    types:
+      - name: Venue
+        kind: Type
+        fields:
+          - name: concerts
+            typ:
+              Optional:
+                Plain:
+                  - Set
+                  - - Plain:
+                        - Concert
+                        - []
+                        - ~
+                  - ~
+            annotations: []
+            default_value: ~
+        annotations:
+          - name: access
+            params:
+              Single:
+                - FieldSelection:
+                    Select:
+                      - Select:
+                          - Single:
+                              - Identifier:
+                                  - self
+                                  - ~
+                              - ~
+                          - Identifier:
+                              - concerts
+                              - ~
+                          - ~
+                      - Macro:
+                          name:
+                            - some
+                          elem_name:
+                            - c
+                          expr:
+                            RelationalOp:
+                              Eq:
+                                - FieldSelection:
+                                    Select:
+                                      - Single:
+                                          - Identifier:
+                                              - c
+                                              - ~
+                                          - ~
+                                      - Identifier:
+                                          - id
+                                          - ~
+                                      - ~
+                                - NumberLiteral:
+                                    - 1
+                                - ~
+                          typ: ~
+                      - ~
+      - name: Concert
+        kind: Type
+        fields:
+          - name: id
+            typ:
+              Plain:
+                - Int
+                - []
+                - ~
+            annotations:
+              - name: pk
+                params: None
+            default_value:
+              kind:
+                Function:
+                  - autoIncrement
+                  - []
+          - name: venue
+            typ:
+              Plain:
+                - Venue
+                - []
+                - ~
+            annotations: []
+            default_value: ~
+        annotations: []
+    methods: []
+    interceptors: []
+    base_exofile: input.exo
+imports: []
+

--- a/crates/builder/src/parser/snapshots/builder__parser__converter__tests__access_control_function_without_paren.snap
+++ b/crates/builder/src/parser/snapshots/builder__parser__converter__tests__access_control_function_without_paren.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/builder/src/parser/converter.rs
-expression: "convert_root(parsed.root_node(),\n        r#\"\n            @postgres\n            module TestModule {\n                @access(self.concerts.some(c, c.id == 1))\n                type Venue {\n                    concerts: Set<Concert>?\n                }\n\n                type Concert {\n                    @pk id: Int = autoIncrement()\n                    venue: Venue\n                }\n            }\n        \"#.as_bytes(),\n        file_span, Path::new(\"input.exo\")).unwrap()"
+expression: "convert_root(parsed.root_node(),\n        r#\"\n            @postgres\n            module TestModule {\n                @access(self.concerts.some(c => c.id == 1))\n                type Venue {\n                    concerts: Set<Concert>?\n                }\n\n                type Concert {\n                    @pk id: Int = autoIncrement()\n                    venue: Venue\n                }\n            }\n        \"#.as_bytes(),\n        file_span, Path::new(\"input.exo\")).unwrap()"
 ---
 types: []
 modules:
@@ -40,10 +40,10 @@ modules:
                               - concerts
                               - ~
                           - ~
-                      - Macro:
+                      - HofCall:
                           name:
                             - some
-                          elem_name:
+                          param_name:
                             - c
                           expr:
                             RelationalOp:

--- a/crates/builder/src/parser/snapshots/builder__parser__converter__tests__expression_precedence.snap
+++ b/crates/builder/src/parser/snapshots/builder__parser__converter__tests__expression_precedence.snap
@@ -36,9 +36,13 @@ modules:
                                       - FieldSelection:
                                           Select:
                                             - Single:
-                                                - - self
+                                                - Identifier:
+                                                    - self
+                                                    - ~
                                                 - ~
-                                            - - role
+                                            - Identifier:
+                                                - role
+                                                - ~
                                             - ~
                                       - ~
                                 - StringLiteral:
@@ -49,9 +53,13 @@ modules:
                                 - FieldSelection:
                                     Select:
                                       - Single:
-                                          - - self
+                                          - Identifier:
+                                              - self
+                                              - ~
                                           - ~
-                                      - - role
+                                      - Identifier:
+                                          - role
+                                          - ~
                                       - ~
                                 - StringLiteral:
                                     - role_superuser

--- a/crates/builder/src/typechecker/mod.rs
+++ b/crates/builder/src/typechecker/mod.rs
@@ -540,6 +540,39 @@ mod tests {
     }
 
     #[test]
+    fn with_macros() {
+        let src = r#"
+        context AuthContext {
+          @jwt("sub") id: String
+          @jwt role: String
+        }
+
+        @postgres
+        module DocsDatabase {
+          @access(
+            query = AuthContext.role == "admin"|| self.documentUsers.exists(du, du.userId == AuthContext.id && du.read),
+            mutation = AuthContext.role == "admin" || self.documentUsers.exists(du, du.userId == AuthContext.id && du.write)
+          )
+          type Document {
+            @pk id: Int = autoIncrement()
+            content: String
+            documentUsers: Set<DocumentUser>
+          }
+        
+          type DocumentUser {
+            @pk id: Int = autoIncrement()
+            document: Document
+            userId: String
+            read: Boolean
+            write: Boolean
+          }
+        }
+        "#;
+
+        assert_typechecking!(src);
+    }
+
+    #[test]
     fn insignificant_whitespace() {
         let typical = r#"
         @postgres

--- a/crates/builder/src/typechecker/mod.rs
+++ b/crates/builder/src/typechecker/mod.rs
@@ -548,8 +548,8 @@ mod tests {
         @postgres
         module DocsDatabase {
           @access(
-            query = self.documentUsers.exists(du, AuthContext.role == "admin"|| du.userId == AuthContext.id && du.read),
-            mutation = self.documentUsers.exists(du, AuthContext.role == "admin"|| du.userId == AuthContext.id && du.write)
+            query = self.documentUsers.some(du => AuthContext.role == "admin"|| du.userId == AuthContext.id && du.read),
+            mutation = self.documentUsers.some(du => AuthContext.role == "admin"|| du.userId == AuthContext.id && du.write)
           )
           type Document {
             @pk id: Int = autoIncrement()

--- a/crates/builder/src/typechecker/mod.rs
+++ b/crates/builder/src/typechecker/mod.rs
@@ -272,9 +272,7 @@ pub fn build(
 
     loop {
         let mut did_change = false;
-        let init_scope = Scope {
-            enclosing_type: None,
-        };
+        let init_scope = Scope::default();
 
         let mut errors = Vec::new();
 
@@ -550,8 +548,8 @@ mod tests {
         @postgres
         module DocsDatabase {
           @access(
-            query = AuthContext.role == "admin"|| self.documentUsers.exists(du, du.userId == AuthContext.id && du.read),
-            mutation = AuthContext.role == "admin" || self.documentUsers.exists(du, du.userId == AuthContext.id && du.write)
+            query = self.documentUsers.exists(du, AuthContext.role == "admin"|| du.userId == AuthContext.id && du.read),
+            mutation = self.documentUsers.exists(du, AuthContext.role == "admin"|| du.userId == AuthContext.id && du.write)
           )
           type Document {
             @pk id: Int = autoIncrement()

--- a/crates/builder/src/typechecker/mod.rs
+++ b/crates/builder/src/typechecker/mod.rs
@@ -538,7 +538,7 @@ mod tests {
     }
 
     #[test]
-    fn with_macros() {
+    fn with_function_calls() {
         let src = r#"
         context AuthContext {
           @jwt("sub") id: String

--- a/crates/builder/src/typechecker/model.rs
+++ b/crates/builder/src/typechecker/model.rs
@@ -41,9 +41,7 @@ impl TypecheckFrom<AstModel<Untyped>> for AstModel<Typed> {
         _scope: &Scope,
         errors: &mut Vec<Diagnostic>,
     ) -> bool {
-        let model_scope = Scope {
-            enclosing_type: Some(self.name.clone()),
-        };
+        let model_scope = Scope::with_enclosing_type(self.name.clone());
 
         let fields_changed = self
             .fields

--- a/crates/builder/src/typechecker/module.rs
+++ b/crates/builder/src/typechecker/module.rs
@@ -53,9 +53,7 @@ impl TypecheckFrom<AstModule<Untyped>> for AstModule<Typed> {
             .types
             .iter_mut()
             .map(|m| {
-                let model_scope = Scope {
-                    enclosing_type: Some(m.name.clone()),
-                };
+                let model_scope = Scope::with_enclosing_type(m.name.clone());
 
                 m.pass(type_env, annotation_env, &model_scope, errors)
             })

--- a/crates/builder/src/typechecker/selection.rs
+++ b/crates/builder/src/typechecker/selection.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
 use core_model::mapped_arena::MappedArena;
 use core_model_builder::{
-    ast::ast_types::FieldSelectionElement,
+    ast::ast_types::{AstExpr, FieldSelectionElement},
     typechecker::{annotation::AnnotationSpec, Typed},
 };
 
@@ -26,21 +26,80 @@ impl TypecheckFrom<FieldSelectionElement<Untyped>> for FieldSelectionElement<Typ
             FieldSelectionElement::Identifier(i, s, _) => {
                 FieldSelectionElement::Identifier(i.clone(), *s, Type::Defer)
             }
-            FieldSelectionElement::Macro(_, _, _, _, _) => {
-                // FieldSelectionElement::Macro(i.clone(), *s, Type::Defer, None, None)
-                todo!()
+            FieldSelectionElement::Macro(s, name, elem_name, expr, _) => {
+                FieldSelectionElement::Macro(
+                    *s,
+                    name.clone(),
+                    elem_name.clone(),
+                    Box::new(AstExpr::shallow(expr)),
+                    Type::Defer,
+                )
             }
         }
     }
 
     fn pass(
         &mut self,
-        _type_env: &MappedArena<Type>,
+        type_env: &MappedArena<Type>,
         _annotation_env: &HashMap<String, AnnotationSpec>,
-        _scope: &Scope,
-        _errors: &mut Vec<Diagnostic>,
+        scope: &Scope,
+        errors: &mut Vec<Diagnostic>,
     ) -> bool {
-        false
+        match self {
+            FieldSelectionElement::Identifier(value, s, typ) => {
+                if typ.is_incomplete() {
+                    if value.as_str() == "self" {
+                        if let Some(enclosing) = &scope.enclosing_type {
+                            *typ = Type::Reference(type_env.get_id(enclosing).unwrap());
+                            true
+                        } else {
+                            *typ = Type::Error;
+
+                            errors.push(Diagnostic {
+                                level: Level::Error,
+                                message: "Cannot use self outside a model".to_string(),
+                                code: Some("C000".to_string()),
+                                spans: vec![SpanLabel {
+                                    span: *s,
+                                    style: SpanStyle::Primary,
+                                    label: Some("self not allowed".to_string()),
+                                }],
+                            });
+
+                            false
+                        }
+                    } else {
+                        let context_type = type_env.get_by_key(value).and_then(|t| match t {
+                            Type::Composite(c) if c.kind == AstModelKind::Context => Some(c),
+                            _ => None,
+                        });
+
+                        if let Some(context_type) = context_type {
+                            *typ = Type::Reference(type_env.get_id(&context_type.name).unwrap());
+                        } else {
+                            *typ = Type::Error;
+
+                            errors.push(Diagnostic {
+                                level: Level::Error,
+                                message: format!("Reference to unknown context: {value}"),
+                                code: Some("C000".to_string()),
+                                spans: vec![SpanLabel {
+                                    span: *s,
+                                    style: SpanStyle::Primary,
+                                    label: Some("unknown context".to_string()),
+                                }],
+                            });
+                        }
+                        false
+                    }
+                } else {
+                    false
+                }
+            }
+            FieldSelectionElement::Macro(_, _, _, _, _) => {
+                todo!()
+            }
+        }
     }
 }
 
@@ -62,66 +121,23 @@ impl TypecheckFrom<FieldSelection<Untyped>> for FieldSelection<Typed> {
     fn pass(
         &mut self,
         type_env: &MappedArena<Type>,
-        _annotation_env: &HashMap<String, AnnotationSpec>,
+        annotation_env: &HashMap<String, AnnotationSpec>,
         scope: &Scope,
         errors: &mut Vec<Diagnostic>,
     ) -> bool {
         match self {
-            FieldSelection::Single(FieldSelectionElement::Macro(_, _, _, _, _), _) => {
-                todo!("macro")
-            }
-            FieldSelection::Single(FieldSelectionElement::Identifier(i, s, _), typ) => {
-                if typ.is_incomplete() {
-                    if i.as_str() == "self" {
-                        if let Some(enclosing) = &scope.enclosing_type {
-                            *typ = Type::Reference(type_env.get_id(enclosing).unwrap());
-                            true
-                        } else {
-                            *typ = Type::Error;
-
-                            errors.push(Diagnostic {
-                                level: Level::Error,
-                                message: "Cannot use self outside a model".to_string(),
-                                code: Some("C000".to_string()),
-                                spans: vec![SpanLabel {
-                                    span: *s,
-                                    style: SpanStyle::Primary,
-                                    label: Some("self not allowed".to_string()),
-                                }],
-                            });
-
-                            false
-                        }
-                    } else {
-                        let context_type = type_env.get_by_key(i).and_then(|t| match t {
-                            Type::Composite(c) if c.kind == AstModelKind::Context => Some(c),
-                            _ => None,
-                        });
-
-                        if let Some(context_type) = context_type {
-                            *typ = Type::Reference(type_env.get_id(&context_type.name).unwrap());
-                        } else {
-                            *typ = Type::Error;
-
-                            errors.push(Diagnostic {
-                                level: Level::Error,
-                                message: format!("Reference to unknown context: {i}"),
-                                code: Some("C000".to_string()),
-                                spans: vec![SpanLabel {
-                                    span: *s,
-                                    style: SpanStyle::Primary,
-                                    label: Some("unknown context".to_string()),
-                                }],
-                            });
-                        }
-                        false
+            FieldSelection::Single(selection_elem, typ) => {
+                let updated = selection_elem.pass(type_env, annotation_env, scope, errors);
+                match selection_elem {
+                    FieldSelectionElement::Identifier(_, _, resolved_typ) => {
+                        *typ = resolved_typ.clone();
                     }
-                } else {
-                    false
+                    FieldSelectionElement::Macro(_, _, _, _, _) => todo!(),
                 }
+                updated
             }
             FieldSelection::Select(prefix, i, _, typ) => {
-                let in_updated = prefix.pass(type_env, _annotation_env, scope, errors);
+                let in_updated = prefix.pass(type_env, annotation_env, scope, errors);
                 let out_updated = if typ.is_incomplete() {
                     if let Type::Composite(c) = prefix.typ().deref(type_env) {
                         let i = match i {
@@ -157,7 +173,9 @@ impl TypecheckFrom<FieldSelection<Untyped>> for FieldSelection<Typed> {
 
                         let i = match i {
                             FieldSelectionElement::Identifier(i, s, _) => (i, *s),
-                            FieldSelectionElement::Macro(_, _, _, _, _) => todo!(),
+                            FieldSelectionElement::Macro(_, _, _, _, _) => {
+                                todo!()
+                            }
                         };
 
                         if !prefix.typ().is_error() {

--- a/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__simple.snap
+++ b/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__simple.snap
@@ -63,7 +63,9 @@ types:
                                                 - Single:
                                                     - Identifier:
                                                         - self
-                                                        - Defer
+                                                        - Reference:
+                                                            index: 15
+                                                            generation: ~
                                                     - Reference:
                                                         index: 15
                                                         generation: ~
@@ -83,7 +85,9 @@ types:
                                                 - Single:
                                                     - Identifier:
                                                         - self
-                                                        - Defer
+                                                        - Reference:
+                                                            index: 15
+                                                            generation: ~
                                                     - Reference:
                                                         index: 15
                                                         generation: ~
@@ -103,7 +107,9 @@ types:
                                         - Single:
                                             - Identifier:
                                                 - self
-                                                - Defer
+                                                - Reference:
+                                                    index: 15
+                                                    generation: ~
                                             - Reference:
                                                 index: 15
                                                 generation: ~
@@ -257,7 +263,9 @@ modules:
                                                   - Single:
                                                       - Identifier:
                                                           - self
-                                                          - Defer
+                                                          - Reference:
+                                                              index: 15
+                                                              generation: ~
                                                       - Reference:
                                                           index: 15
                                                           generation: ~
@@ -277,7 +285,9 @@ modules:
                                                   - Single:
                                                       - Identifier:
                                                           - self
-                                                          - Defer
+                                                          - Reference:
+                                                              index: 15
+                                                              generation: ~
                                                       - Reference:
                                                           index: 15
                                                           generation: ~
@@ -297,7 +307,9 @@ modules:
                                           - Single:
                                               - Identifier:
                                                   - self
-                                                  - Defer
+                                                  - Reference:
+                                                      index: 15
+                                                      generation: ~
                                               - Reference:
                                                   index: 15
                                                   generation: ~

--- a/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__simple.snap
+++ b/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__simple.snap
@@ -61,11 +61,15 @@ types:
                                           - FieldSelection:
                                               Select:
                                                 - Single:
-                                                    - - self
+                                                    - Identifier:
+                                                        - self
+                                                        - Defer
                                                     - Reference:
                                                         index: 15
                                                         generation: ~
-                                                - - role
+                                                - Identifier:
+                                                    - role
+                                                    - Defer
                                                 - Reference:
                                                     index: 4
                                                     generation: ~
@@ -77,11 +81,15 @@ types:
                                           - FieldSelection:
                                               Select:
                                                 - Single:
-                                                    - - self
+                                                    - Identifier:
+                                                        - self
+                                                        - Defer
                                                     - Reference:
                                                         index: 15
                                                         generation: ~
-                                                - - role
+                                                - Identifier:
+                                                    - role
+                                                    - Defer
                                                 - Reference:
                                                     index: 4
                                                     generation: ~
@@ -93,15 +101,21 @@ types:
                                   Select:
                                     - Select:
                                         - Single:
-                                            - - self
+                                            - Identifier:
+                                                - self
+                                                - Defer
                                             - Reference:
                                                 index: 15
                                                 generation: ~
-                                        - - doc
+                                        - Identifier:
+                                            - doc
+                                            - Defer
                                         - Reference:
                                             index: 16
                                             generation: ~
-                                    - - is_public
+                                    - Identifier:
+                                        - is_public
+                                        - Defer
                                     - Reference:
                                         index: 0
                                         generation: ~
@@ -241,11 +255,15 @@ modules:
                                             - FieldSelection:
                                                 Select:
                                                   - Single:
-                                                      - - self
+                                                      - Identifier:
+                                                          - self
+                                                          - Defer
                                                       - Reference:
                                                           index: 15
                                                           generation: ~
-                                                  - - role
+                                                  - Identifier:
+                                                      - role
+                                                      - Defer
                                                   - Reference:
                                                       index: 4
                                                       generation: ~
@@ -257,11 +275,15 @@ modules:
                                             - FieldSelection:
                                                 Select:
                                                   - Single:
-                                                      - - self
+                                                      - Identifier:
+                                                          - self
+                                                          - Defer
                                                       - Reference:
                                                           index: 15
                                                           generation: ~
-                                                  - - role
+                                                  - Identifier:
+                                                      - role
+                                                      - Defer
                                                   - Reference:
                                                       index: 4
                                                       generation: ~
@@ -273,15 +295,21 @@ modules:
                                     Select:
                                       - Select:
                                           - Single:
-                                              - - self
+                                              - Identifier:
+                                                  - self
+                                                  - Defer
                                               - Reference:
                                                   index: 15
                                                   generation: ~
-                                          - - doc
+                                          - Identifier:
+                                              - doc
+                                              - Defer
                                           - Reference:
                                               index: 16
                                               generation: ~
-                                      - - is_public
+                                      - Identifier:
+                                          - is_public
+                                          - Defer
                                       - Reference:
                                           index: 0
                                           generation: ~

--- a/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__with_array_in_operator.snap
+++ b/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__with_array_in_operator.snap
@@ -83,7 +83,9 @@ types:
                                     - Single:
                                         - Identifier:
                                             - AuthContext
-                                            - Defer
+                                            - Reference:
+                                                index: 15
+                                                generation: ~
                                         - Reference:
                                             index: 15
                                             generation: ~
@@ -199,7 +201,9 @@ modules:
                                       - Single:
                                           - Identifier:
                                               - AuthContext
-                                              - Defer
+                                              - Reference:
+                                                  index: 15
+                                                  generation: ~
                                           - Reference:
                                               index: 15
                                               generation: ~

--- a/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__with_array_in_operator.snap
+++ b/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__with_array_in_operator.snap
@@ -81,11 +81,15 @@ types:
                               - FieldSelection:
                                   Select:
                                     - Single:
-                                        - - AuthContext
+                                        - Identifier:
+                                            - AuthContext
+                                            - Defer
                                         - Reference:
                                             index: 15
                                             generation: ~
-                                    - - roles
+                                    - Identifier:
+                                        - roles
+                                        - Defer
                                     - Array:
                                         Reference:
                                           index: 4
@@ -193,11 +197,15 @@ modules:
                                 - FieldSelection:
                                     Select:
                                       - Single:
-                                          - - AuthContext
+                                          - Identifier:
+                                              - AuthContext
+                                              - Defer
                                           - Reference:
                                               index: 15
                                               generation: ~
-                                      - - roles
+                                      - Identifier:
+                                          - roles
+                                          - Defer
                                       - Array:
                                           Reference:
                                             index: 4

--- a/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__with_auth_context_use_in_field_annotation.snap
+++ b/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__with_auth_context_use_in_field_annotation.snap
@@ -87,11 +87,15 @@ types:
                                     - FieldSelection:
                                         Select:
                                           - Single:
-                                              - - AuthContext
+                                              - Identifier:
+                                                  - AuthContext
+                                                  - Defer
                                               - Reference:
                                                   index: 15
                                                   generation: ~
-                                          - - role
+                                          - Identifier:
+                                              - role
+                                              - Defer
                                           - Reference:
                                               index: 4
                                               generation: ~
@@ -101,11 +105,15 @@ types:
                               - FieldSelection:
                                   Select:
                                     - Single:
-                                        - - self
+                                        - Identifier:
+                                            - self
+                                            - Defer
                                         - Reference:
                                             index: 16
                                             generation: ~
-                                    - - is_public
+                                    - Identifier:
+                                        - is_public
+                                        - Defer
                                     - Reference:
                                         index: 0
                                         generation: ~
@@ -221,11 +229,15 @@ modules:
                                       - FieldSelection:
                                           Select:
                                             - Single:
-                                                - - AuthContext
+                                                - Identifier:
+                                                    - AuthContext
+                                                    - Defer
                                                 - Reference:
                                                     index: 15
                                                     generation: ~
-                                            - - role
+                                            - Identifier:
+                                                - role
+                                                - Defer
                                             - Reference:
                                                 index: 4
                                                 generation: ~
@@ -235,11 +247,15 @@ modules:
                                 - FieldSelection:
                                     Select:
                                       - Single:
-                                          - - self
+                                          - Identifier:
+                                              - self
+                                              - Defer
                                           - Reference:
                                               index: 16
                                               generation: ~
-                                      - - is_public
+                                      - Identifier:
+                                          - is_public
+                                          - Defer
                                       - Reference:
                                           index: 0
                                           generation: ~

--- a/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__with_auth_context_use_in_field_annotation.snap
+++ b/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__with_auth_context_use_in_field_annotation.snap
@@ -89,7 +89,9 @@ types:
                                           - Single:
                                               - Identifier:
                                                   - AuthContext
-                                                  - Defer
+                                                  - Reference:
+                                                      index: 15
+                                                      generation: ~
                                               - Reference:
                                                   index: 15
                                                   generation: ~
@@ -107,7 +109,9 @@ types:
                                     - Single:
                                         - Identifier:
                                             - self
-                                            - Defer
+                                            - Reference:
+                                                index: 16
+                                                generation: ~
                                         - Reference:
                                             index: 16
                                             generation: ~
@@ -231,7 +235,9 @@ modules:
                                             - Single:
                                                 - Identifier:
                                                     - AuthContext
-                                                    - Defer
+                                                    - Reference:
+                                                        index: 15
+                                                        generation: ~
                                                 - Reference:
                                                     index: 15
                                                     generation: ~
@@ -249,7 +255,9 @@ modules:
                                       - Single:
                                           - Identifier:
                                               - self
-                                              - Defer
+                                              - Reference:
+                                                  index: 16
+                                                  generation: ~
                                           - Reference:
                                               index: 16
                                               generation: ~

--- a/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__with_auth_context_use_in_type_annotation.snap
+++ b/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__with_auth_context_use_in_type_annotation.snap
@@ -92,7 +92,9 @@ types:
                                       - Single:
                                           - Identifier:
                                               - AuthContext
-                                              - Defer
+                                              - Reference:
+                                                  index: 15
+                                                  generation: ~
                                           - Reference:
                                               index: 15
                                               generation: ~
@@ -110,7 +112,9 @@ types:
                                 - Single:
                                     - Identifier:
                                         - self
-                                        - Defer
+                                        - Reference:
+                                            index: 16
+                                            generation: ~
                                     - Reference:
                                         index: 16
                                         generation: ~
@@ -234,7 +238,9 @@ modules:
                                         - Single:
                                             - Identifier:
                                                 - AuthContext
-                                                - Defer
+                                                - Reference:
+                                                    index: 15
+                                                    generation: ~
                                             - Reference:
                                                 index: 15
                                                 generation: ~
@@ -252,7 +258,9 @@ modules:
                                   - Single:
                                       - Identifier:
                                           - self
-                                          - Defer
+                                          - Reference:
+                                              index: 16
+                                              generation: ~
                                       - Reference:
                                           index: 16
                                           generation: ~

--- a/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__with_auth_context_use_in_type_annotation.snap
+++ b/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__with_auth_context_use_in_type_annotation.snap
@@ -90,11 +90,15 @@ types:
                                 - FieldSelection:
                                     Select:
                                       - Single:
-                                          - - AuthContext
+                                          - Identifier:
+                                              - AuthContext
+                                              - Defer
                                           - Reference:
                                               index: 15
                                               generation: ~
-                                      - - role
+                                      - Identifier:
+                                          - role
+                                          - Defer
                                       - Reference:
                                           index: 4
                                           generation: ~
@@ -104,11 +108,15 @@ types:
                           - FieldSelection:
                               Select:
                                 - Single:
-                                    - - self
+                                    - Identifier:
+                                        - self
+                                        - Defer
                                     - Reference:
                                         index: 16
                                         generation: ~
-                                - - is_public
+                                - Identifier:
+                                    - is_public
+                                    - Defer
                                 - Reference:
                                     index: 0
                                     generation: ~
@@ -224,11 +232,15 @@ modules:
                                   - FieldSelection:
                                       Select:
                                         - Single:
-                                            - - AuthContext
+                                            - Identifier:
+                                                - AuthContext
+                                                - Defer
                                             - Reference:
                                                 index: 15
                                                 generation: ~
-                                        - - role
+                                        - Identifier:
+                                            - role
+                                            - Defer
                                         - Reference:
                                             index: 4
                                             generation: ~
@@ -238,11 +250,15 @@ modules:
                             - FieldSelection:
                                 Select:
                                   - Single:
-                                      - - self
+                                      - Identifier:
+                                          - self
+                                          - Defer
                                       - Reference:
                                           index: 16
                                           generation: ~
-                                  - - is_public
+                                  - Identifier:
+                                      - is_public
+                                      - Defer
                                   - Reference:
                                       index: 0
                                       generation: ~

--- a/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__with_function_calls.snap
+++ b/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__with_function_calls.snap
@@ -137,10 +137,10 @@ types:
                                     Reference:
                                       index: 17
                                       generation: ~
-                            - Macro:
+                            - HofCall:
                                 name:
                                   - some
-                                elem_name:
+                                param_name:
                                   - du
                                 expr:
                                   LogicalOp:
@@ -248,10 +248,10 @@ types:
                                     Reference:
                                       index: 17
                                       generation: ~
-                            - Macro:
+                            - HofCall:
                                 name:
                                   - some
-                                elem_name:
+                                param_name:
                                   - du
                                 expr:
                                   LogicalOp:
@@ -543,10 +543,10 @@ modules:
                                       Reference:
                                         index: 17
                                         generation: ~
-                              - Macro:
+                              - HofCall:
                                   name:
                                     - some
-                                  elem_name:
+                                  param_name:
                                     - du
                                   expr:
                                     LogicalOp:
@@ -654,10 +654,10 @@ modules:
                                       Reference:
                                         index: 17
                                         generation: ~
-                              - Macro:
+                              - HofCall:
                                   name:
                                     - some
-                                  elem_name:
+                                  param_name:
                                     - du
                                   expr:
                                     LogicalOp:

--- a/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__with_macros.snap
+++ b/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__with_macros.snap
@@ -1,0 +1,811 @@
+---
+source: crates/builder/src/typechecker/mod.rs
+expression: build(src).unwrap()
+---
+types:
+  values:
+    - - ~
+      - Primitive: Boolean
+    - - ~
+      - Primitive: Int
+    - - ~
+      - Primitive: Float
+    - - ~
+      - Primitive: Decimal
+    - - ~
+      - Primitive: String
+    - - ~
+      - Primitive: LocalTime
+    - - ~
+      - Primitive: LocalDateTime
+    - - ~
+      - Primitive: LocalDate
+    - - ~
+      - Primitive: Instant
+    - - ~
+      - Primitive: Json
+    - - ~
+      - Primitive: Blob
+    - - ~
+      - Primitive: Uuid
+    - - ~
+      - Primitive: Exograph
+    - - ~
+      - Primitive: ExographPriv
+    - - ~
+      - Primitive:
+          Interception: Operation
+    - - ~
+      - Composite:
+          name: AuthContext
+          kind: Context
+          fields:
+            - name: id
+              typ:
+                Plain:
+                  - String
+                  - []
+                  - true
+              annotations:
+                annotations:
+                  jwt:
+                    name: jwt
+                    params:
+                      Single:
+                        - StringLiteral:
+                            - sub
+              default_value: ~
+            - name: role
+              typ:
+                Plain:
+                  - String
+                  - []
+                  - true
+              annotations:
+                annotations:
+                  jwt:
+                    name: jwt
+                    params: None
+              default_value: ~
+          annotations:
+            annotations: {}
+    - - ~
+      - Composite:
+          name: Document
+          kind: Type
+          fields:
+            - name: id
+              typ:
+                Plain:
+                  - Int
+                  - []
+                  - true
+              annotations:
+                annotations:
+                  pk:
+                    name: pk
+                    params: None
+              default_value:
+                kind:
+                  Function:
+                    - autoIncrement
+                    - []
+            - name: content
+              typ:
+                Plain:
+                  - String
+                  - []
+                  - true
+              annotations:
+                annotations: {}
+              default_value: ~
+            - name: documentUsers
+              typ:
+                Plain:
+                  - Set
+                  - - Plain:
+                        - DocumentUser
+                        - []
+                        - true
+                  - true
+              annotations:
+                annotations: {}
+              default_value: ~
+          annotations:
+            annotations:
+              access:
+                name: access
+                params:
+                  Map:
+                    - mutation:
+                        FieldSelection:
+                          Select:
+                            - Select:
+                                - Single:
+                                    - Identifier:
+                                        - self
+                                        - Reference:
+                                            index: 16
+                                            generation: ~
+                                    - Reference:
+                                        index: 16
+                                        generation: ~
+                                - Identifier:
+                                    - documentUsers
+                                    - Defer
+                                - Set:
+                                    Reference:
+                                      index: 17
+                                      generation: ~
+                            - Macro:
+                                name:
+                                  - exists
+                                elem_name:
+                                  - du
+                                expr:
+                                  LogicalOp:
+                                    And:
+                                      - LogicalOp:
+                                          Or:
+                                            - RelationalOp:
+                                                Eq:
+                                                  - FieldSelection:
+                                                      Select:
+                                                        - Single:
+                                                            - Identifier:
+                                                                - AuthContext
+                                                                - Reference:
+                                                                    index: 15
+                                                                    generation: ~
+                                                            - Reference:
+                                                                index: 15
+                                                                generation: ~
+                                                        - Identifier:
+                                                            - role
+                                                            - Defer
+                                                        - Reference:
+                                                            index: 4
+                                                            generation: ~
+                                                  - StringLiteral:
+                                                      - admin
+                                                  - Primitive: Boolean
+                                            - RelationalOp:
+                                                Eq:
+                                                  - FieldSelection:
+                                                      Select:
+                                                        - Single:
+                                                            - Identifier:
+                                                                - du
+                                                                - Reference:
+                                                                    index: 17
+                                                                    generation: ~
+                                                            - Reference:
+                                                                index: 17
+                                                                generation: ~
+                                                        - Identifier:
+                                                            - userId
+                                                            - Defer
+                                                        - Reference:
+                                                            index: 4
+                                                            generation: ~
+                                                  - FieldSelection:
+                                                      Select:
+                                                        - Single:
+                                                            - Identifier:
+                                                                - AuthContext
+                                                                - Reference:
+                                                                    index: 15
+                                                                    generation: ~
+                                                            - Reference:
+                                                                index: 15
+                                                                generation: ~
+                                                        - Identifier:
+                                                            - id
+                                                            - Defer
+                                                        - Reference:
+                                                            index: 4
+                                                            generation: ~
+                                                  - Primitive: Boolean
+                                            - Primitive: Boolean
+                                      - FieldSelection:
+                                          Select:
+                                            - Single:
+                                                - Identifier:
+                                                    - du
+                                                    - Reference:
+                                                        index: 17
+                                                        generation: ~
+                                                - Reference:
+                                                    index: 17
+                                                    generation: ~
+                                            - Identifier:
+                                                - write
+                                                - Defer
+                                            - Reference:
+                                                index: 0
+                                                generation: ~
+                                      - Primitive: Boolean
+                                typ: Defer
+                            - Error
+                      query:
+                        FieldSelection:
+                          Select:
+                            - Select:
+                                - Single:
+                                    - Identifier:
+                                        - self
+                                        - Reference:
+                                            index: 16
+                                            generation: ~
+                                    - Reference:
+                                        index: 16
+                                        generation: ~
+                                - Identifier:
+                                    - documentUsers
+                                    - Defer
+                                - Set:
+                                    Reference:
+                                      index: 17
+                                      generation: ~
+                            - Macro:
+                                name:
+                                  - exists
+                                elem_name:
+                                  - du
+                                expr:
+                                  LogicalOp:
+                                    And:
+                                      - LogicalOp:
+                                          Or:
+                                            - RelationalOp:
+                                                Eq:
+                                                  - FieldSelection:
+                                                      Select:
+                                                        - Single:
+                                                            - Identifier:
+                                                                - AuthContext
+                                                                - Reference:
+                                                                    index: 15
+                                                                    generation: ~
+                                                            - Reference:
+                                                                index: 15
+                                                                generation: ~
+                                                        - Identifier:
+                                                            - role
+                                                            - Defer
+                                                        - Reference:
+                                                            index: 4
+                                                            generation: ~
+                                                  - StringLiteral:
+                                                      - admin
+                                                  - Primitive: Boolean
+                                            - RelationalOp:
+                                                Eq:
+                                                  - FieldSelection:
+                                                      Select:
+                                                        - Single:
+                                                            - Identifier:
+                                                                - du
+                                                                - Reference:
+                                                                    index: 17
+                                                                    generation: ~
+                                                            - Reference:
+                                                                index: 17
+                                                                generation: ~
+                                                        - Identifier:
+                                                            - userId
+                                                            - Defer
+                                                        - Reference:
+                                                            index: 4
+                                                            generation: ~
+                                                  - FieldSelection:
+                                                      Select:
+                                                        - Single:
+                                                            - Identifier:
+                                                                - AuthContext
+                                                                - Reference:
+                                                                    index: 15
+                                                                    generation: ~
+                                                            - Reference:
+                                                                index: 15
+                                                                generation: ~
+                                                        - Identifier:
+                                                            - id
+                                                            - Defer
+                                                        - Reference:
+                                                            index: 4
+                                                            generation: ~
+                                                  - Primitive: Boolean
+                                            - Primitive: Boolean
+                                      - FieldSelection:
+                                          Select:
+                                            - Single:
+                                                - Identifier:
+                                                    - du
+                                                    - Reference:
+                                                        index: 17
+                                                        generation: ~
+                                                - Reference:
+                                                    index: 17
+                                                    generation: ~
+                                            - Identifier:
+                                                - read
+                                                - Defer
+                                            - Reference:
+                                                index: 0
+                                                generation: ~
+                                      - Primitive: Boolean
+                                typ: Defer
+                            - Error
+    - - ~
+      - Composite:
+          name: DocumentUser
+          kind: Type
+          fields:
+            - name: id
+              typ:
+                Plain:
+                  - Int
+                  - []
+                  - true
+              annotations:
+                annotations:
+                  pk:
+                    name: pk
+                    params: None
+              default_value:
+                kind:
+                  Function:
+                    - autoIncrement
+                    - []
+            - name: document
+              typ:
+                Plain:
+                  - Document
+                  - []
+                  - true
+              annotations:
+                annotations: {}
+              default_value: ~
+            - name: userId
+              typ:
+                Plain:
+                  - String
+                  - []
+                  - true
+              annotations:
+                annotations: {}
+              default_value: ~
+            - name: read
+              typ:
+                Plain:
+                  - Boolean
+                  - []
+                  - true
+              annotations:
+                annotations: {}
+              default_value: ~
+            - name: write
+              typ:
+                Plain:
+                  - Boolean
+                  - []
+                  - true
+              annotations:
+                annotations: {}
+              default_value: ~
+          annotations:
+            annotations: {}
+    - ~
+    - ~
+    - ~
+    - ~
+    - ~
+    - ~
+    - ~
+    - ~
+    - ~
+    - ~
+    - ~
+    - ~
+    - ~
+    - ~
+  map:
+    AuthContext:
+      index: 15
+      generation: ~
+    Blob:
+      index: 10
+      generation: ~
+    Boolean:
+      index: 0
+      generation: ~
+    Decimal:
+      index: 3
+      generation: ~
+    Document:
+      index: 16
+      generation: ~
+    DocumentUser:
+      index: 17
+      generation: ~
+    Exograph:
+      index: 12
+      generation: ~
+    ExographPriv:
+      index: 13
+      generation: ~
+    Float:
+      index: 2
+      generation: ~
+    Instant:
+      index: 8
+      generation: ~
+    Int:
+      index: 1
+      generation: ~
+    Json:
+      index: 9
+      generation: ~
+    LocalDate:
+      index: 7
+      generation: ~
+    LocalDateTime:
+      index: 6
+      generation: ~
+    LocalTime:
+      index: 5
+      generation: ~
+    Operation:
+      index: 14
+      generation: ~
+    String:
+      index: 4
+      generation: ~
+    Uuid:
+      index: 11
+      generation: ~
+modules:
+  values:
+    - - ~
+      - name: DocsDatabase
+        annotations:
+          annotations:
+            postgres:
+              name: postgres
+              params: None
+        types:
+          - name: Document
+            kind: Type
+            fields:
+              - name: id
+                typ:
+                  Plain:
+                    - Int
+                    - []
+                    - true
+                annotations:
+                  annotations:
+                    pk:
+                      name: pk
+                      params: None
+                default_value:
+                  kind:
+                    Function:
+                      - autoIncrement
+                      - []
+              - name: content
+                typ:
+                  Plain:
+                    - String
+                    - []
+                    - true
+                annotations:
+                  annotations: {}
+                default_value: ~
+              - name: documentUsers
+                typ:
+                  Plain:
+                    - Set
+                    - - Plain:
+                          - DocumentUser
+                          - []
+                          - true
+                    - true
+                annotations:
+                  annotations: {}
+                default_value: ~
+            annotations:
+              annotations:
+                access:
+                  name: access
+                  params:
+                    Map:
+                      - mutation:
+                          FieldSelection:
+                            Select:
+                              - Select:
+                                  - Single:
+                                      - Identifier:
+                                          - self
+                                          - Reference:
+                                              index: 16
+                                              generation: ~
+                                      - Reference:
+                                          index: 16
+                                          generation: ~
+                                  - Identifier:
+                                      - documentUsers
+                                      - Defer
+                                  - Set:
+                                      Reference:
+                                        index: 17
+                                        generation: ~
+                              - Macro:
+                                  name:
+                                    - exists
+                                  elem_name:
+                                    - du
+                                  expr:
+                                    LogicalOp:
+                                      And:
+                                        - LogicalOp:
+                                            Or:
+                                              - RelationalOp:
+                                                  Eq:
+                                                    - FieldSelection:
+                                                        Select:
+                                                          - Single:
+                                                              - Identifier:
+                                                                  - AuthContext
+                                                                  - Reference:
+                                                                      index: 15
+                                                                      generation: ~
+                                                              - Reference:
+                                                                  index: 15
+                                                                  generation: ~
+                                                          - Identifier:
+                                                              - role
+                                                              - Defer
+                                                          - Reference:
+                                                              index: 4
+                                                              generation: ~
+                                                    - StringLiteral:
+                                                        - admin
+                                                    - Primitive: Boolean
+                                              - RelationalOp:
+                                                  Eq:
+                                                    - FieldSelection:
+                                                        Select:
+                                                          - Single:
+                                                              - Identifier:
+                                                                  - du
+                                                                  - Reference:
+                                                                      index: 17
+                                                                      generation: ~
+                                                              - Reference:
+                                                                  index: 17
+                                                                  generation: ~
+                                                          - Identifier:
+                                                              - userId
+                                                              - Defer
+                                                          - Reference:
+                                                              index: 4
+                                                              generation: ~
+                                                    - FieldSelection:
+                                                        Select:
+                                                          - Single:
+                                                              - Identifier:
+                                                                  - AuthContext
+                                                                  - Reference:
+                                                                      index: 15
+                                                                      generation: ~
+                                                              - Reference:
+                                                                  index: 15
+                                                                  generation: ~
+                                                          - Identifier:
+                                                              - id
+                                                              - Defer
+                                                          - Reference:
+                                                              index: 4
+                                                              generation: ~
+                                                    - Primitive: Boolean
+                                              - Primitive: Boolean
+                                        - FieldSelection:
+                                            Select:
+                                              - Single:
+                                                  - Identifier:
+                                                      - du
+                                                      - Reference:
+                                                          index: 17
+                                                          generation: ~
+                                                  - Reference:
+                                                      index: 17
+                                                      generation: ~
+                                              - Identifier:
+                                                  - write
+                                                  - Defer
+                                              - Reference:
+                                                  index: 0
+                                                  generation: ~
+                                        - Primitive: Boolean
+                                  typ: Defer
+                              - Defer
+                        query:
+                          FieldSelection:
+                            Select:
+                              - Select:
+                                  - Single:
+                                      - Identifier:
+                                          - self
+                                          - Reference:
+                                              index: 16
+                                              generation: ~
+                                      - Reference:
+                                          index: 16
+                                          generation: ~
+                                  - Identifier:
+                                      - documentUsers
+                                      - Defer
+                                  - Set:
+                                      Reference:
+                                        index: 17
+                                        generation: ~
+                              - Macro:
+                                  name:
+                                    - exists
+                                  elem_name:
+                                    - du
+                                  expr:
+                                    LogicalOp:
+                                      And:
+                                        - LogicalOp:
+                                            Or:
+                                              - RelationalOp:
+                                                  Eq:
+                                                    - FieldSelection:
+                                                        Select:
+                                                          - Single:
+                                                              - Identifier:
+                                                                  - AuthContext
+                                                                  - Reference:
+                                                                      index: 15
+                                                                      generation: ~
+                                                              - Reference:
+                                                                  index: 15
+                                                                  generation: ~
+                                                          - Identifier:
+                                                              - role
+                                                              - Defer
+                                                          - Reference:
+                                                              index: 4
+                                                              generation: ~
+                                                    - StringLiteral:
+                                                        - admin
+                                                    - Primitive: Boolean
+                                              - RelationalOp:
+                                                  Eq:
+                                                    - FieldSelection:
+                                                        Select:
+                                                          - Single:
+                                                              - Identifier:
+                                                                  - du
+                                                                  - Reference:
+                                                                      index: 17
+                                                                      generation: ~
+                                                              - Reference:
+                                                                  index: 17
+                                                                  generation: ~
+                                                          - Identifier:
+                                                              - userId
+                                                              - Defer
+                                                          - Reference:
+                                                              index: 4
+                                                              generation: ~
+                                                    - FieldSelection:
+                                                        Select:
+                                                          - Single:
+                                                              - Identifier:
+                                                                  - AuthContext
+                                                                  - Reference:
+                                                                      index: 15
+                                                                      generation: ~
+                                                              - Reference:
+                                                                  index: 15
+                                                                  generation: ~
+                                                          - Identifier:
+                                                              - id
+                                                              - Defer
+                                                          - Reference:
+                                                              index: 4
+                                                              generation: ~
+                                                    - Primitive: Boolean
+                                              - Primitive: Boolean
+                                        - FieldSelection:
+                                            Select:
+                                              - Single:
+                                                  - Identifier:
+                                                      - du
+                                                      - Reference:
+                                                          index: 17
+                                                          generation: ~
+                                                  - Reference:
+                                                      index: 17
+                                                      generation: ~
+                                              - Identifier:
+                                                  - read
+                                                  - Defer
+                                              - Reference:
+                                                  index: 0
+                                                  generation: ~
+                                        - Primitive: Boolean
+                                  typ: Defer
+                              - Defer
+          - name: DocumentUser
+            kind: Type
+            fields:
+              - name: id
+                typ:
+                  Plain:
+                    - Int
+                    - []
+                    - true
+                annotations:
+                  annotations:
+                    pk:
+                      name: pk
+                      params: None
+                default_value:
+                  kind:
+                    Function:
+                      - autoIncrement
+                      - []
+              - name: document
+                typ:
+                  Plain:
+                    - Document
+                    - []
+                    - true
+                annotations:
+                  annotations: {}
+                default_value: ~
+              - name: userId
+                typ:
+                  Plain:
+                    - String
+                    - []
+                    - true
+                annotations:
+                  annotations: {}
+                default_value: ~
+              - name: read
+                typ:
+                  Plain:
+                    - Boolean
+                    - []
+                    - true
+                annotations:
+                  annotations: {}
+                default_value: ~
+              - name: write
+                typ:
+                  Plain:
+                    - Boolean
+                    - []
+                    - true
+                annotations:
+                  annotations: {}
+                default_value: ~
+            annotations:
+              annotations: {}
+        methods: []
+        interceptors: []
+        base_exofile: input.exo
+    - ~
+    - ~
+    - ~
+  map:
+    DocsDatabase:
+      index: 0
+      generation: ~
+

--- a/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__with_macros.snap
+++ b/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__with_macros.snap
@@ -225,8 +225,9 @@ types:
                                                 index: 0
                                                 generation: ~
                                       - Primitive: Boolean
-                                typ: Defer
-                            - Error
+                                typ:
+                                  Primitive: Boolean
+                            - Primitive: Boolean
                       query:
                         FieldSelection:
                           Select:
@@ -335,8 +336,9 @@ types:
                                                 index: 0
                                                 generation: ~
                                       - Primitive: Boolean
-                                typ: Defer
-                            - Error
+                                typ:
+                                  Primitive: Boolean
+                            - Primitive: Boolean
     - - ~
       - Composite:
           name: DocumentUser
@@ -629,8 +631,9 @@ modules:
                                                   index: 0
                                                   generation: ~
                                         - Primitive: Boolean
-                                  typ: Defer
-                              - Defer
+                                  typ:
+                                    Primitive: Boolean
+                              - Primitive: Boolean
                         query:
                           FieldSelection:
                             Select:
@@ -739,8 +742,9 @@ modules:
                                                   index: 0
                                                   generation: ~
                                         - Primitive: Boolean
-                                  typ: Defer
-                              - Defer
+                                  typ:
+                                    Primitive: Boolean
+                              - Primitive: Boolean
           - name: DocumentUser
             kind: Type
             fields:

--- a/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__with_macros.snap
+++ b/crates/builder/src/typechecker/snapshots/builder__typechecker__tests__with_macros.snap
@@ -139,7 +139,7 @@ types:
                                       generation: ~
                             - Macro:
                                 name:
-                                  - exists
+                                  - some
                                 elem_name:
                                   - du
                                 expr:
@@ -250,7 +250,7 @@ types:
                                       generation: ~
                             - Macro:
                                 name:
-                                  - exists
+                                  - some
                                 elem_name:
                                   - du
                                 expr:
@@ -545,7 +545,7 @@ modules:
                                         generation: ~
                               - Macro:
                                   name:
-                                    - exists
+                                    - some
                                   elem_name:
                                     - du
                                   expr:
@@ -656,7 +656,7 @@ modules:
                                         generation: ~
                               - Macro:
                                   name:
-                                    - exists
+                                    - some
                                   elem_name:
                                     - du
                                   expr:

--- a/crates/core-subsystem/core-model-builder/src/ast/ast_types.rs
+++ b/crates/core-subsystem/core-model-builder/src/ast/ast_types.rs
@@ -345,14 +345,14 @@ impl FieldSelection<Typed> {
             match selection {
                 FieldSelection::Single(elem, _) => match elem {
                     FieldSelectionElement::Identifier(name, _, _) => acc.push(name.clone()),
-                    FieldSelectionElement::Macro(_, _, _, _, _) => todo!(),
+                    FieldSelectionElement::Macro { .. } => todo!(),
                 },
                 FieldSelection::Select(path, elem, _, _) => {
                     flatten(path, acc);
 
                     match elem {
                         FieldSelectionElement::Identifier(name, _, _) => acc.push(name.clone()),
-                        FieldSelectionElement::Macro(_, _, _, _, _) => todo!(),
+                        FieldSelectionElement::Macro { .. } => todo!(),
                     }
                 }
             }
@@ -383,23 +383,23 @@ pub enum FieldSelectionElement<T: NodeTypedness> {
         Span,
         T::FieldSelection,
     ),
-    Macro(
+    Macro {
         #[serde(skip_serializing)]
         #[serde(skip_deserializing)]
         #[serde(default = "default_span")]
-        Span,
-        Identifier,      // name of the macro such as "exists" and "all"
-        Identifier,      // name of the macro argument such as "du"
-        Box<AstExpr<T>>, // expression passed to the macro such as "du.userId == AuthContext.id && du.read"
-        T::FieldSelection,
-    ),
+        span: Span,
+        name: Identifier,      // name of the macro such as "exists" and "all"
+        elem_name: Identifier, // name of the macro argument such as "du"
+        expr: Box<AstExpr<T>>, // expression passed to the macro such as "du.userId == AuthContext.id && du.read"
+        typ: T::FieldSelection,
+    },
 }
 
 impl<T: NodeTypedness> FieldSelectionElement<T> {
     pub fn span(&self) -> &Span {
         match &self {
-            FieldSelectionElement::Identifier(_, s, _) => s,
-            FieldSelectionElement::Macro(s, _, _, _, _) => s,
+            FieldSelectionElement::Identifier(_, span, _) => span,
+            FieldSelectionElement::Macro { span, .. } => span,
         }
     }
 }

--- a/crates/core-subsystem/core-model-builder/src/ast/ast_types.rs
+++ b/crates/core-subsystem/core-model-builder/src/ast/ast_types.rs
@@ -340,20 +340,21 @@ impl FieldSelection<Typed> {
     }
 
     // temporary method to get a string representation of the path until we resolve typechecking etc
-    pub fn string_path(&self) -> Vec<String> {
+    pub fn context_path(&self) -> Vec<String> {
         fn flatten(selection: &FieldSelection<Typed>, acc: &mut Vec<String>) {
-            match selection {
-                FieldSelection::Single(elem, _) => match elem {
+            fn process_selection_elem(elem: &FieldSelectionElement<Typed>, acc: &mut Vec<String>) {
+                match elem {
                     FieldSelectionElement::Identifier(name, _, _) => acc.push(name.clone()),
-                    FieldSelectionElement::Macro { .. } => todo!(),
-                },
+                    FieldSelectionElement::Macro { .. } => {
+                        unimplemented!("Context path doesn't support function calls yet")
+                    }
+                }
+            }
+            match selection {
+                FieldSelection::Single(elem, _) => process_selection_elem(elem, acc),
                 FieldSelection::Select(path, elem, _, _) => {
                     flatten(path, acc);
-
-                    match elem {
-                        FieldSelectionElement::Identifier(name, _, _) => acc.push(name.clone()),
-                        FieldSelectionElement::Macro { .. } => todo!(),
-                    }
+                    process_selection_elem(elem, acc);
                 }
             }
         }

--- a/crates/core-subsystem/core-model-builder/src/ast/ast_types.rs
+++ b/crates/core-subsystem/core-model-builder/src/ast/ast_types.rs
@@ -402,6 +402,13 @@ impl<T: NodeTypedness> FieldSelectionElement<T> {
             FieldSelectionElement::Macro { span, .. } => span,
         }
     }
+
+    pub fn typ(&self) -> &T::FieldSelection {
+        match &self {
+            FieldSelectionElement::Identifier(_, _, typ) => typ,
+            FieldSelectionElement::Macro { typ, .. } => typ,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/crates/core-subsystem/core-model-builder/src/typechecker/mod.rs
+++ b/crates/core-subsystem/core-model-builder/src/typechecker/mod.rs
@@ -9,6 +9,8 @@
 
 pub mod annotation;
 pub mod annotation_map;
+use std::collections::HashMap;
+
 pub use annotation_map::AnnotationMap;
 pub mod typ;
 
@@ -23,8 +25,29 @@ use crate::ast::ast_types::NodeTypedness;
 
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Default)]
 pub struct Scope {
     pub enclosing_type: Option<String>,
+    pub placeholder_mapping: HashMap<String, String>,
+}
+
+impl Scope {
+    pub fn with_enclosing_type(enclosing_type: String) -> Self {
+        Self {
+            enclosing_type: Some(enclosing_type),
+            placeholder_mapping: HashMap::new(),
+        }
+    }
+
+    pub fn with_placeholder_mapping(
+        enclosing_type: Option<String>,
+        placeholder_mapping: HashMap<String, String>,
+    ) -> Self {
+        Self {
+            enclosing_type,
+            placeholder_mapping,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]

--- a/crates/core-subsystem/core-model-builder/src/typechecker/mod.rs
+++ b/crates/core-subsystem/core-model-builder/src/typechecker/mod.rs
@@ -25,28 +25,36 @@ use crate::ast::ast_types::NodeTypedness;
 
 use serde::{Deserialize, Serialize};
 
+/// The scope for the current typechecking context.
+///
+/// Typically starts out with ("self" -> name of the type being checked) extended with additional
+/// mappings when a access control selection with a function such as `.some(du => ...)` is
+/// encountered.
 #[derive(Debug, Default)]
 pub struct Scope {
-    pub enclosing_type: Option<String>,
-    pub placeholder_mapping: HashMap<String, String>,
+    mapping: HashMap<String, String>,
 }
 
 impl Scope {
     pub fn with_enclosing_type(enclosing_type: String) -> Self {
         Self {
-            enclosing_type: Some(enclosing_type),
-            placeholder_mapping: HashMap::new(),
+            mapping: HashMap::from_iter([("self".to_string(), enclosing_type)]),
         }
     }
 
-    pub fn with_placeholder_mapping(
-        enclosing_type: Option<String>,
-        placeholder_mapping: HashMap<String, String>,
-    ) -> Self {
+    pub fn with_additional_mapping(&self, additional_mapping: HashMap<String, String>) -> Self {
         Self {
-            enclosing_type,
-            placeholder_mapping,
+            mapping: self
+                .mapping
+                .clone()
+                .into_iter()
+                .chain(additional_mapping)
+                .collect(),
         }
+    }
+
+    pub fn get_type(&self, name: &str) -> Option<&str> {
+        self.mapping.get(name).map(|s| s.as_str())
     }
 }
 

--- a/crates/core-subsystem/core-model/src/access.rs
+++ b/crates/core-subsystem/core-model/src/access.rs
@@ -104,3 +104,13 @@ pub enum CommonAccessPrimitiveExpression {
     BooleanLiteral(bool),               // for example, true
     NumberLiteral(i64),                 // for example, integer (-13, 0, 300, etc.)
 }
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct FunctionCall<PrimExpr>
+where
+    PrimExpr: Send + Sync,
+{
+    pub name: String,                              // "some", "all", etc
+    pub parameter_name: String,                    // "du"
+    pub expr: AccessPredicateExpression<PrimExpr>, // "du.id == AuthContext.id && du.read"
+}

--- a/crates/core-subsystem/core-model/src/access.rs
+++ b/crates/core-subsystem/core-model/src/access.rs
@@ -95,6 +95,32 @@ where
             AccessRelationalOp::In(left, right) => (left, right),
         }
     }
+
+    pub fn owned_sides(self) -> (Box<PrimExpr>, Box<PrimExpr>) {
+        match self {
+            AccessRelationalOp::Eq(left, right) => (left, right),
+            AccessRelationalOp::Neq(left, right) => (left, right),
+            AccessRelationalOp::Lt(left, right) => (left, right),
+            AccessRelationalOp::Lte(left, right) => (left, right),
+            AccessRelationalOp::Gt(left, right) => (left, right),
+            AccessRelationalOp::Gte(left, right) => (left, right),
+            AccessRelationalOp::In(left, right) => (left, right),
+        }
+    }
+
+    pub fn combiner(
+        &self,
+    ) -> impl Fn(Box<PrimExpr>, Box<PrimExpr>) -> AccessRelationalOp<PrimExpr> {
+        match self {
+            AccessRelationalOp::Eq(_, _) => AccessRelationalOp::Eq,
+            AccessRelationalOp::Neq(_, _) => AccessRelationalOp::Neq,
+            AccessRelationalOp::Lt(_, _) => AccessRelationalOp::Lt,
+            AccessRelationalOp::Lte(_, _) => AccessRelationalOp::Lte,
+            AccessRelationalOp::Gt(_, _) => AccessRelationalOp::Gt,
+            AccessRelationalOp::Gte(_, _) => AccessRelationalOp::Gte,
+            AccessRelationalOp::In(_, _) => AccessRelationalOp::In,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/postgres-subsystem/postgres-model-builder/Cargo.toml
+++ b/crates/postgres-subsystem/postgres-model-builder/Cargo.toml
@@ -19,7 +19,7 @@ postgres-model = { path = "../postgres-model" }
 exo-sql = { path = "../../../libs/exo-sql" }
 
 [dev-dependencies]
-insta = { workspace = true, features = ["yaml"] }
+insta.workspace = true
 builder = { path = "../../builder" }
 
 

--- a/crates/postgres-subsystem/postgres-model-builder/src/access_utils.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/access_utils.rs
@@ -224,11 +224,17 @@ pub fn compute_predicate_expression(
                     }
                 }
                 DatabasePathSelection::Function(column_path, function_call) => {
-                    compute_function_expr(
-                        column_path,
-                        function_call.parameter_name,
-                        function_call.expr,
-                    )
+                    if function_call.name != "some" {
+                        Err(ModelBuildingError::Generic(
+                            "Only `some` function is supported".to_string(),
+                        ))
+                    } else {
+                        compute_function_expr(
+                            column_path,
+                            function_call.parameter_name,
+                            function_call.expr,
+                        )
+                    }
                 }
                 DatabasePathSelection::Context(context_selection, field_type) => {
                     if field_type.innermost() == &PrimitiveType::Boolean {

--- a/crates/postgres-subsystem/postgres-model-builder/src/access_utils.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/access_utils.rs
@@ -651,7 +651,7 @@ fn compute_column_selection<'a>(
                             Some(field_type),
                         )
                     }
-                    FieldSelectionElement::Macro { .. } => unreachable!(),
+                    FieldSelectionElement::HofCall { .. } => unreachable!(),
                 }
             },
         )
@@ -679,9 +679,9 @@ fn compute_column_selection<'a>(
                             parameter_name,
                         )
                     }
-                    FieldSelectionElement::Macro {
+                    FieldSelectionElement::HofCall {
                         name,
-                        elem_name,
+                        param_name: elem_name,
                         expr,
                         ..
                     } => {
@@ -717,8 +717,8 @@ fn compute_column_selection<'a>(
                 DatabasePathSelection::Context(context_selection, context_field_type)
             }
         }
-        FieldSelectionElement::Macro { .. } => {
-            unreachable!("Macro selection at the top level is not supported")
+        FieldSelectionElement::HofCall { .. } => {
+            unreachable!("Function selection at the top level is not supported")
         }
     }
 }
@@ -775,7 +775,7 @@ fn compute_json_selection<'a>(
 
                         (field_composite_type, json_path, Some(field_type))
                     }
-                    FieldSelectionElement::Macro { .. } => unreachable!(),
+                    FieldSelectionElement::HofCall { .. } => unreachable!(),
                 }
             },
         )
@@ -800,9 +800,9 @@ fn compute_json_selection<'a>(
                                 compute_json_path(scope_type, path_tail);
                             JsonPathSelection::Path(json_path, field_type.unwrap(), parameter_name)
                         }
-                        FieldSelectionElement::Macro {
+                        FieldSelectionElement::HofCall {
                             name,
-                            elem_name,
+                            param_name: elem_name,
                             expr,
                             ..
                         } => {
@@ -838,8 +838,8 @@ fn compute_json_selection<'a>(
                 }
             }
         }
-        FieldSelectionElement::Macro { .. } => {
-            unreachable!("Macro selection at the top level is not supported")
+        FieldSelectionElement::HofCall { .. } => {
+            unreachable!("Function selection at the top level is not supported")
         }
     }
 }

--- a/crates/postgres-subsystem/postgres-model-builder/src/access_utils.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/access_utils.rs
@@ -378,7 +378,7 @@ fn compute_column_selection<'a>(
         (column_path_link, &field.typ)
     }
 
-    let path_elements = selection.path();
+    let path_elements = selection.string_path();
 
     if path_elements[0] == "self" {
         let (_, column_path, field_type) = path_elements[1..].iter().fold(
@@ -410,6 +410,7 @@ fn compute_column_selection<'a>(
         // TODO: Avoid this unwrap (parser should have caught expression "self" without any fields)
         DatabasePathSelection::Column(column_path.unwrap(), field_type.unwrap())
     } else {
+        let path_elements = selection.string_path();
         let (context_selection, context_field_type) =
             get_context(&path_elements, resolved_env.contexts);
         DatabasePathSelection::Context(context_selection, context_field_type)
@@ -432,7 +433,7 @@ fn compute_json_selection<'a>(
             .unwrap_or_else(|| panic!("Field {field_name} not found while processing access rules"))
     }
 
-    let path_elements = selection.path();
+    let path_elements = selection.string_path();
 
     if path_elements[0] == "self" {
         let (_, json_path, field_type) = path_elements[1..].iter().fold(

--- a/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__with_access.snap
+++ b/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__with_access.snap
@@ -86,7 +86,9 @@ values:
                             - Single:
                                 - Identifier:
                                     - AuthContext
-                                    - Defer
+                                    - Reference:
+                                        index: 15
+                                        generation: ~
                                 - Reference:
                                     index: 15
                                     generation: ~
@@ -104,7 +106,9 @@ values:
                       - Single:
                           - Identifier:
                               - self
-                              - Defer
+                              - Reference:
+                                  index: 16
+                                  generation: ~
                           - Reference:
                               index: 16
                               generation: ~

--- a/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__with_access.snap
+++ b/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__with_access.snap
@@ -84,11 +84,15 @@ values:
                       - FieldSelection:
                           Select:
                             - Single:
-                                - - AuthContext
+                                - Identifier:
+                                    - AuthContext
+                                    - Defer
                                 - Reference:
                                     index: 15
                                     generation: ~
-                            - - role
+                            - Identifier:
+                                - role
+                                - Defer
                             - Reference:
                                 index: 4
                                 generation: ~
@@ -98,11 +102,15 @@ values:
                 - FieldSelection:
                     Select:
                       - Single:
-                          - - self
+                          - Identifier:
+                              - self
+                              - Defer
                           - Reference:
                               index: 16
                               generation: ~
-                      - - public
+                      - Identifier:
+                          - public
+                          - Defer
                       - Reference:
                           index: 0
                           generation: ~

--- a/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__with_access_default_values.snap
+++ b/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__with_access_default_values.snap
@@ -86,7 +86,9 @@ values:
                             - Single:
                                 - Identifier:
                                     - AuthContext
-                                    - Defer
+                                    - Reference:
+                                        index: 15
+                                        generation: ~
                                 - Reference:
                                     index: 15
                                     generation: ~
@@ -104,7 +106,9 @@ values:
                       - Single:
                           - Identifier:
                               - self
-                              - Defer
+                              - Reference:
+                                  index: 16
+                                  generation: ~
                           - Reference:
                               index: 16
                               generation: ~

--- a/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__with_access_default_values.snap
+++ b/crates/postgres-subsystem/postgres-model-builder/src/snapshots/postgres_model_builder__resolved_builder__tests__with_access_default_values.snap
@@ -84,11 +84,15 @@ values:
                       - FieldSelection:
                           Select:
                             - Single:
-                                - - AuthContext
+                                - Identifier:
+                                    - AuthContext
+                                    - Defer
                                 - Reference:
                                     index: 15
                                     generation: ~
-                            - - role
+                            - Identifier:
+                                - role
+                                - Defer
                             - Reference:
                                 index: 4
                                 generation: ~
@@ -98,11 +102,15 @@ values:
                 - FieldSelection:
                     Select:
                       - Single:
-                          - - self
+                          - Identifier:
+                              - self
+                              - Defer
                           - Reference:
                               index: 16
                               generation: ~
-                      - - public
+                      - Identifier:
+                          - public
+                          - Defer
                       - Reference:
                           index: 0
                           generation: ~

--- a/crates/postgres-subsystem/postgres-model-builder/src/type_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/type_builder.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::HashMap;
+
 use crate::{
     aggregate_type_builder::aggregate_type_name, naming::ToPlural,
     resolved_builder::ResolvedFieldTypeHelper, shallow::Shallow,
@@ -441,6 +443,7 @@ fn compute_database_access_expr(
                 access_utils::compute_predicate_expression(
                     ast_expr,
                     entity,
+                    HashMap::new(),
                     resolved_env,
                     &building.primitive_types,
                     &building.entity_types,
@@ -480,6 +483,7 @@ fn compute_input_access_expr(
                 access_utils::compute_input_predicate_expression(
                     ast_expr,
                     entity,
+                    HashMap::new(),
                     resolved_env,
                     &building.primitive_types,
                     &building.entity_types,

--- a/crates/postgres-subsystem/postgres-model-builder/src/type_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/type_builder.rs
@@ -482,8 +482,7 @@ fn compute_input_access_expr(
             ast_expr.as_ref().map(|ast_expr| {
                 access_utils::compute_input_predicate_expression(
                     ast_expr,
-                    entity,
-                    HashMap::new(),
+                    HashMap::from_iter([("self".to_string(), entity)]),
                     resolved_env,
                     &building.primitive_types,
                     &building.entity_types,

--- a/crates/postgres-subsystem/postgres-model-builder/src/type_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/type_builder.rs
@@ -340,8 +340,10 @@ fn expand_dynamic_default_values(
                         .and_then(|default_value| match default_value {
                             ResolvedFieldDefault::Value(expr) => match expr.as_ref() {
                                 AstExpr::FieldSelection(selection) => {
-                                    let (context_selection, context_type) =
-                                        get_context(&selection.path(), resolved_env.contexts);
+                                    let (context_selection, context_type) = get_context(
+                                        &selection.string_path(),
+                                        resolved_env.contexts,
+                                    );
 
                                     match entity_field.relation {
                                         PostgresRelation::Scalar { .. } => {

--- a/crates/postgres-subsystem/postgres-model-builder/src/type_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/type_builder.rs
@@ -343,7 +343,7 @@ fn expand_dynamic_default_values(
                             ResolvedFieldDefault::Value(expr) => match expr.as_ref() {
                                 AstExpr::FieldSelection(selection) => {
                                     let (context_selection, context_type) = get_context(
-                                        &selection.string_path(),
+                                        &selection.context_path(),
                                         resolved_env.contexts,
                                     );
 

--- a/crates/postgres-subsystem/postgres-model/src/access.rs
+++ b/crates/postgres-subsystem/postgres-model/src/access.rs
@@ -35,7 +35,7 @@ pub struct UpdateAccessExpression {
 /// such as equal and less than.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum DatabaseAccessPrimitiveExpression {
-    Column(PhysicalColumnPath), // Column path, for example self.user.id
+    Column(PhysicalColumnPath, Option<String>), // Column path, for example self.user.id and parameter name (such as "du", default: "self")
     Function(PhysicalColumnPath, FunctionCall<Self>), // Function, for example self.documentUser.some(du => du.id == AuthContext.id && du.read)
     Common(CommonAccessPrimitiveExpression),          // expression shared by all access expressions
 }
@@ -43,7 +43,7 @@ pub enum DatabaseAccessPrimitiveExpression {
 /// Primitive expressions that can express data input access control rules.
 #[derive(Serialize, Deserialize, Debug)]
 pub enum InputAccessPrimitiveExpression {
-    Path(Vec<String>),                         // JSON path, for example self.user.id
+    Path(Vec<String>, Option<String>), // JSON path, for example self.user.id and parameter name (such as "du", default: "self")
     Function(Vec<String>, FunctionCall<Self>), // Function, for example self.documentUser.some(du => du.id == AuthContext.id && du.read)
     Common(CommonAccessPrimitiveExpression),   // expression shared by all access expressions
 }

--- a/crates/postgres-subsystem/postgres-model/src/access.rs
+++ b/crates/postgres-subsystem/postgres-model/src/access.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use core_plugin_interface::core_model::{
-    access::{AccessPredicateExpression, CommonAccessPrimitiveExpression},
+    access::{AccessPredicateExpression, CommonAccessPrimitiveExpression, FunctionCall},
     mapped_arena::SerializableSlabIndex,
 };
 use exo_sql::PhysicalColumnPath;
@@ -36,12 +36,14 @@ pub struct UpdateAccessExpression {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum DatabaseAccessPrimitiveExpression {
     Column(PhysicalColumnPath), // Column path, for example self.user.id
-    Common(CommonAccessPrimitiveExpression), // expression shared by all access expressions
+    Function(PhysicalColumnPath, FunctionCall<Self>), // Function, for example self.documentUser.some(du => du.id == AuthContext.id && du.read)
+    Common(CommonAccessPrimitiveExpression),          // expression shared by all access expressions
 }
 
 /// Primitive expressions that can express data input access control rules.
 #[derive(Serialize, Deserialize, Debug)]
 pub enum InputAccessPrimitiveExpression {
-    Path(Vec<String>),                       // JSON path, for example self.user.id
-    Common(CommonAccessPrimitiveExpression), // expression shared by all access expressions
+    Path(Vec<String>),                         // JSON path, for example self.user.id
+    Function(Vec<String>, FunctionCall<Self>), // Function, for example self.documentUser.some(du => du.id == AuthContext.id && du.read)
+    Common(CommonAccessPrimitiveExpression),   // expression shared by all access expressions
 }

--- a/crates/postgres-subsystem/postgres-resolver/src/access_solver.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/access_solver.rs
@@ -95,7 +95,7 @@ impl<'a> AccessSolver<'a, DatabaseAccessPrimitiveExpression, AbstractPredicateWr
                         reduce_common_primitive_expression(solver, request_context, expr).await?;
                     Some(SolvedPrimitiveExpression::Common(primitive_expr))
                 }
-                DatabaseAccessPrimitiveExpression::Column(column_path) => {
+                DatabaseAccessPrimitiveExpression::Column(column_path, _) => {
                     Some(SolvedPrimitiveExpression::Column(column_path.clone()))
                 }
                 DatabaseAccessPrimitiveExpression::Function(_, _) => {
@@ -223,7 +223,7 @@ impl<'a> AccessSolver<'a, InputAccessPrimitiveExpression, AbstractPredicateWrapp
                         reduce_common_primitive_expression(solver, request_context, expr).await?;
                     Some(SolvedJsonPrimitiveExpression::Common(primitive_expr))
                 }
-                InputAccessPrimitiveExpression::Path(path) => {
+                InputAccessPrimitiveExpression::Path(path, _) => {
                     Some(SolvedJsonPrimitiveExpression::Path(path.clone()))
                 }
                 InputAccessPrimitiveExpression::Function(_, _) => {
@@ -528,7 +528,7 @@ mod tests {
         column_path: PhysicalColumnPath,
     ) -> AccessPredicateExpression<DatabaseAccessPrimitiveExpression> {
         AccessPredicateExpression::RelationalOp(AccessRelationalOp::Eq(
-            Box::new(DatabaseAccessPrimitiveExpression::Column(column_path)),
+            Box::new(DatabaseAccessPrimitiveExpression::Column(column_path, None)),
             Box::new(DatabaseAccessPrimitiveExpression::Common(
                 CommonAccessPrimitiveExpression::BooleanLiteral(true),
             )),
@@ -630,6 +630,7 @@ mod tests {
                     context_selection_expr("AccessContext", "user_id"),
                     Box::new(DatabaseAccessPrimitiveExpression::Column(
                         owner_id_column_path.clone(),
+                        None,
                     )),
                 );
                 assert_solve_access!(
@@ -649,6 +650,7 @@ mod tests {
                 let test_ae = relational_op(
                     Box::new(DatabaseAccessPrimitiveExpression::Column(
                         owner_id_column_path.clone(),
+                        None,
                     )),
                     context_selection_expr("AccessContext", "user_id"),
                 );
@@ -674,9 +676,11 @@ mod tests {
                 let test_ae = relational_op(
                     Box::new(DatabaseAccessPrimitiveExpression::Column(
                         dept1_id_column_path.clone(),
+                        None,
                     )),
                     Box::new(DatabaseAccessPrimitiveExpression::Column(
                         dept2_id_column_path.clone(),
+                        None,
                     )),
                 );
 
@@ -695,9 +699,11 @@ mod tests {
                 let test_ae = relational_op(
                     Box::new(DatabaseAccessPrimitiveExpression::Column(
                         dept2_id_column_path.clone(),
+                        None,
                     )),
                     Box::new(DatabaseAccessPrimitiveExpression::Column(
                         dept1_id_column_path.clone(),
+                        None,
                     )),
                 );
 
@@ -1123,6 +1129,7 @@ mod tests {
             context_selection_expr("AccessContext", "user_id"),
             Box::new(DatabaseAccessPrimitiveExpression::Column(
                 owner_id_column_path.clone(),
+                None,
             )),
         ));
 
@@ -1177,6 +1184,7 @@ mod tests {
             let data_rule = AccessPredicateExpression::RelationalOp(AccessRelationalOp::Eq(
                 Box::new(DatabaseAccessPrimitiveExpression::Column(
                     published_column_path.clone(),
+                    None,
                 )),
                 Box::new(DatabaseAccessPrimitiveExpression::Common(
                     CommonAccessPrimitiveExpression::BooleanLiteral(true),
@@ -1335,7 +1343,7 @@ mod tests {
         ] {
             // We test with both a column and a literal on the other side of the relational operator
             let column_expr_fn =
-                &|| DatabaseAccessPrimitiveExpression::Column(owner_id_column_path.clone());
+                &|| DatabaseAccessPrimitiveExpression::Column(owner_id_column_path.clone(), None);
             let literal_expr_fn = &|| {
                 DatabaseAccessPrimitiveExpression::Common(
                     CommonAccessPrimitiveExpression::NumberLiteral(1),
@@ -1412,6 +1420,7 @@ mod tests {
                             context_selection_expr("AccessContext", "user_id"),
                             Box::new(DatabaseAccessPrimitiveExpression::Column(
                                 owner_id_column_path.clone(),
+                                None,
                             )),
                         ))),
                         Box::new(AccessPredicateExpression::BooleanLiteral(true)),

--- a/crates/postgres-subsystem/postgres-resolver/src/access_solver.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/access_solver.rs
@@ -99,7 +99,8 @@ impl<'a> AccessSolver<'a, DatabaseAccessPrimitiveExpression, AbstractPredicateWr
                     Some(SolvedPrimitiveExpression::Column(column_path.clone()))
                 }
                 DatabaseAccessPrimitiveExpression::Function(_, _) => {
-                    todo!("Function calls are not supported yet")
+                    // TODO: Fix this through better types
+                    unreachable!("Function calls should not remain in the resolver expression")
                 }
             })
         }
@@ -227,7 +228,7 @@ impl<'a> AccessSolver<'a, InputAccessPrimitiveExpression, AbstractPredicateWrapp
                     Some(SolvedJsonPrimitiveExpression::Path(path.clone()))
                 }
                 InputAccessPrimitiveExpression::Function(_, _) => {
-                    todo!("Function calls are not supported yet")
+                    unreachable!("Function calls should not remain in the resolver expression")
                 }
             })
         }

--- a/crates/postgres-subsystem/postgres-resolver/src/access_solver.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/access_solver.rs
@@ -98,6 +98,9 @@ impl<'a> AccessSolver<'a, DatabaseAccessPrimitiveExpression, AbstractPredicateWr
                 DatabaseAccessPrimitiveExpression::Column(column_path) => {
                     Some(SolvedPrimitiveExpression::Column(column_path.clone()))
                 }
+                DatabaseAccessPrimitiveExpression::Function(_, _) => {
+                    todo!("Function calls are not supported yet")
+                }
             })
         }
 
@@ -222,6 +225,9 @@ impl<'a> AccessSolver<'a, InputAccessPrimitiveExpression, AbstractPredicateWrapp
                 }
                 InputAccessPrimitiveExpression::Path(path) => {
                     Some(SolvedJsonPrimitiveExpression::Path(path.clone()))
+                }
+                InputAccessPrimitiveExpression::Function(_, _) => {
+                    todo!("Function calls are not supported yet")
                 }
             })
         }

--- a/crates/postgres-subsystem/postgres-resolver/src/predicate_mapper.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/predicate_mapper.rs
@@ -83,6 +83,8 @@ impl<'a> SQLMapper<'a, AbstractPredicate> for PredicateParamInput<'a> {
                 logical_op_params,
             } => {
                 // first, match any logical op predicates the argument_value might contain
+                // logical_op_argument_value is of the form operation and value pair. For example,
+                // `and: [{name: {eq: "foo"}}, {id: {lt: 1}}]` will be mapped to `("and", Some([{name: {eq: "foo"}}, {id: {lt: 1}}]))`
                 let logical_op_argument_value: (&str, Option<&Val>) = logical_op_params
                     .iter()
                     .map(|parameter| {
@@ -146,9 +148,10 @@ impl<'a> SQLMapper<'a, AbstractPredicate> for PredicateParamInput<'a> {
                                         )
                                     });
 
-                                    let mapped: Result<Vec<_>, _> = try_join_all(predicates).await;
+                                    let predicates: Result<Vec<_>, _> =
+                                        try_join_all(predicates).await;
 
-                                    Ok(mapped?
+                                    Ok(predicates?
                                         .into_iter()
                                         .fold(identity_predicate, |acc, predicate| {
                                             predicate_connector(acc, predicate)

--- a/crates/subsystem-util/subsystem-model-builder-util/src/builder/access_utils.rs
+++ b/crates/subsystem-util/subsystem-model-builder-util/src/builder/access_utils.rs
@@ -133,7 +133,7 @@ fn compute_selection<'a>(
     selection: &FieldSelection<Typed>,
     resolved_env: &'a ResolvedTypeEnv<'a>,
 ) -> PathSelection<'a> {
-    let path_elements = selection.path();
+    let path_elements = selection.string_path();
 
     let (context_selection, column_type) = get_context(&path_elements, resolved_env.contexts);
     PathSelection::Context(context_selection, column_type)

--- a/crates/subsystem-util/subsystem-model-builder-util/src/builder/access_utils.rs
+++ b/crates/subsystem-util/subsystem-model-builder-util/src/builder/access_utils.rs
@@ -133,7 +133,7 @@ fn compute_selection<'a>(
     selection: &FieldSelection<Typed>,
     resolved_env: &'a ResolvedTypeEnv<'a>,
 ) -> PathSelection<'a> {
-    let path_elements = selection.string_path();
+    let path_elements = selection.context_path();
 
     let (context_selection, column_type) = get_context(&path_elements, resolved_env.contexts);
     PathSelection::Context(context_selection, column_type)

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -49,7 +49,7 @@ crossbeam-channel = "0.5.8"
 
 
 [dev-dependencies]
-insta = { workspace = true, features = ["yaml"] }
+insta.workspace = true
 
 [build-dependencies]
 which = "4.4.0"

--- a/integration-tests/shared-docs/external-auth/access-control/src/index.exo
+++ b/integration-tests/shared-docs/external-auth/access-control/src/index.exo
@@ -1,0 +1,29 @@
+context AuthContext {
+  @jwt("sub") id: String
+  @jwt role: String
+}
+
+@postgres
+module DocsDatabase {
+  @access(
+    query = AuthContext.role == "admin"|| self.documentUsers.exists(du, du.userId == AuthContext.id && du.read),
+    mutation = AuthContext.role == "admin" || self.documentUsers.exists(du, du.userId == AuthContext.id && du.write)
+  )  
+  type Document {
+    @pk id: Int = autoIncrement()
+    content: String
+    documentUsers: Set<DocumentUser>
+  }
+
+  @access(
+    query = AuthContext.role == "admin" || (self.userId == AuthContext.id && self.read),
+    mutation = AuthContext.role == "admin" || (self.userId == AuthContext.id && self.write)
+  )
+  type DocumentUser {
+    @pk id: Int = autoIncrement()
+    document: Document
+    userId: String
+    read: Boolean
+    write: Boolean
+  }
+}

--- a/integration-tests/shared-docs/external-auth/access-control/src/index.exo
+++ b/integration-tests/shared-docs/external-auth/access-control/src/index.exo
@@ -6,8 +6,8 @@ context AuthContext {
 @postgres
 module DocsDatabase {
   @access(
-    query = AuthContext.role == "admin"|| self.documentUsers.exists(du, du.userId == AuthContext.id && du.read),
-    mutation = AuthContext.role == "admin" || self.documentUsers.exists(du, du.userId == AuthContext.id && du.write)
+    query = AuthContext.role == "admin"|| self.documentUsers.some(du => du.userId == AuthContext.id && du.read),
+    mutation = AuthContext.role == "admin" || self.documentUsers.some(du => du.userId == AuthContext.id && du.write)
   )  
   type Document {
     @pk id: Int = autoIncrement()

--- a/integration-tests/shared-docs/external-auth/access-control/tests/init.gql
+++ b/integration-tests/shared-docs/external-auth/access-control/tests/init.gql
@@ -1,0 +1,59 @@
+# d1 -> u1 (r, w),   u2 (-r, -w), u3 (r), u4 (-)
+# d2 -> u1 (-r, -w), u2 (r, w),   u3 (r), u4 (-)
+# d3 -> u1 (-),      u2 (-),      u3 (-), u4 (r, -w)
+operation: |
+    mutation {
+        d1: createDocument(data: {
+            content: "d1", 
+            documentUsers: [
+                {userId: "u1", read: true,  write: true}, 
+                {userId: "u2", read: false,  write: false},
+                {userId: "u3", read: true,  write: false},
+                # u4 doesn't have any relation to d1
+            ]
+        }) {
+            id
+            content
+            documentUsers {
+                id
+                read
+                write
+            }
+        }
+        d2: createDocument(data: {
+            content: "d2", 
+            documentUsers: [
+                {userId: "u1", read: false,  write: false},
+                {userId: "u2", read: true,  write: true},
+                {userId: "u3", read: true,  write: false},
+                # u4 doesn't have any relation to d2
+            ]
+        }) {
+            id
+            content
+            documentUsers {
+                id
+                read
+                write
+            }
+        }
+        d3: createDocument(data: {
+            content: "d3", 
+            documentUsers: [
+                {userId: "u4", read: true,  write: false},
+                # u1, u2, u3 don't have any relation to d3
+            ]
+        }) {
+            id
+            content
+            documentUsers {
+                id
+                read
+                write
+            }
+        }                
+    }
+auth: |
+    {
+        "role": "admin"
+    }

--- a/integration-tests/shared-docs/external-auth/access-control/tests/mutation/create.exotest
+++ b/integration-tests/shared-docs/external-auth/access-control/tests/mutation/create.exotest
@@ -1,0 +1,106 @@
+stages:
+  - operation: |
+      fragment DocumentWithUser on Document {
+        id
+        content
+        documentUsers {
+          userId
+          read
+          write
+        }
+      }
+      mutation {
+        createDocument(data: {
+            content: "created-by-u1", 
+            documentUsers: [
+                {userId: "u1", read: true,  write: true}
+            ]
+        }) {
+          ...DocumentWithUser
+        }
+      }
+    auth: |
+      {
+        "sub": "u1"
+      }
+    response: |
+      {
+        "data": {
+          "createDocument": {
+            "id": 6,
+            "content": "created-by-u1",
+            "documentUsers": [
+              {
+                "userId": "u1",
+                "read": true,
+                "write": true
+              }
+            ]
+          }
+        }
+      }
+  - operation: |
+      fragment DocumentWithUser on Document {
+        id
+        content
+        documentUsers {
+          userId
+          read
+          write
+        }
+      }
+      mutation {
+        createDocument(data: {
+            content: "created-by-u1-for-u2", 
+            documentUsers: [
+                {userId: "u2", read: true,  write: true}
+            ]
+        }) {
+          ...DocumentWithUser
+        }
+      }
+    auth: |
+      {
+        "sub": "u1"
+      }
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Not authorized"
+          }
+        ]
+      }
+
+  - operation: |
+      fragment DocumentWithUser on Document {
+        id
+        content
+        documentUsers {
+          userId
+          read
+          write
+        }
+      }
+      mutation {
+        createDocument(data: {
+            content: "created-by-u1-no-write", 
+            documentUsers: [
+                {userId: "u2", read: true,  write: false}
+            ]
+        }) {
+          ...DocumentWithUser
+        }
+      }
+    auth: |
+      {
+        "sub": "u1"
+      }
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Not authorized"
+          }
+        ]
+      }      

--- a/integration-tests/shared-docs/external-auth/access-control/tests/mutation/init.gql
+++ b/integration-tests/shared-docs/external-auth/access-control/tests/mutation/init.gql
@@ -1,0 +1,44 @@
+# d1 -> u1 (r, w),   u2 (-r, -w), u3 (r), u4 (-)
+# d2 -> u1 (-r, -w), u2 (r, w),   u3 (r), u4 (-)
+# d3 -> u1 (-),      u2 (-),      u3 (-), u4 (r, -w)
+operation: |
+    mutation {
+        all_readable_and_writable: createDocument(data: {
+            content: "all-readable-and-writable", 
+            documentUsers: [
+                {userId: "u1", read: true,  write: true}, 
+                {userId: "u2", read: true,  write: true},
+                {userId: "u3", read: true,  write: true},
+                {userId: "u4", read: true,  write: true},
+            ]
+        }) {
+            id
+            content
+            documentUsers {
+                id
+                read
+                write
+            }
+        }
+        all_readable_no_writable: createDocument(data: {
+            content: "all-readable-no-writable", 
+            documentUsers: [
+                {userId: "u1", read: true,  write: false}, 
+                {userId: "u2", read: true,  write: false},
+                {userId: "u3", read: true,  write: false},
+                {userId: "u4", read: true,  write: false},
+            ]
+        }) {
+            id
+            content
+            documentUsers {
+                id
+                read
+                write
+            }
+        }              
+    }
+auth: |
+    {
+        "role": "admin"
+    }

--- a/integration-tests/shared-docs/external-auth/access-control/tests/mutation/update.exotest
+++ b/integration-tests/shared-docs/external-auth/access-control/tests/mutation/update.exotest
@@ -1,0 +1,190 @@
+stages:
+  - operation: |
+      fragment DocumentWithUser on Document {
+        id
+        content
+        documentUsers {
+          id
+          userId
+          read
+          write
+        }
+      }
+      mutation {
+        updateDocuments(data: { # no `where` clause, implies all documents writable by u1
+            content: "updated-by-u1"
+        }) {
+          ...DocumentWithUser
+        }
+      }
+    auth: |
+      {
+        "sub": "u1"
+      }
+    response: |
+      {
+        "data": {
+          "updateDocuments": [
+            {
+              "id": 1,
+              "content": "updated-by-u1",
+              "documentUsers": [
+                {
+                  "id": 1,
+                  "userId": "u1",
+                  "read": true,
+                  "write": true
+                }
+              ]
+            },
+            {
+              "id": 4,
+              "content": "updated-by-u1",
+              "documentUsers": [
+                {
+                  "id": 8,
+                  "userId": "u1",
+                  "read": true,
+                  "write": true
+                }
+              ]
+            }
+          ]
+        }
+      }
+
+  - operation: |
+      fragment DocumentWithUser on Document {
+        id
+        content
+        documentUsers {
+          userId
+          read
+          write
+        }
+      }
+      mutation {
+        updateDocument(id: 1, data: {
+            content: "updated-by-u1 (with id)"
+        }) {
+          ...DocumentWithUser
+        }
+      }
+    auth: |
+      {
+        "sub": "u1"
+      }
+    response: |
+      {
+        "data": {
+          "updateDocument": {
+            "id": 1,
+            "content": "updated-by-u1 (with id)",
+            "documentUsers": [
+              {
+                "userId": "u1",
+                "read": true,
+                "write": true
+              }
+            ]
+          }
+        }
+      }
+
+  - operation: |
+      fragment DocumentWithUser on Document {
+        id
+        content
+        documentUsers {
+          userId
+          read
+          write
+        }
+      }
+      mutation {
+        updateDocument(id: 1, data: { # attempt to transfer a owned document to another user (u1 -> u2)
+            content: "updated-by-u1",
+            documentUsers: {update: [
+                {id: 1, userId: "u2", read: true,  write: true}
+            ]}
+        }) {
+          ...DocumentWithUser
+        }
+      }
+    auth: |
+      {
+        "sub": "u1"
+      }
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Not authorized"
+          }
+        ]
+      }
+  - operation: |
+      fragment DocumentWithUser on Document {
+        id
+        content
+        documentUsers {
+          userId
+          read
+          write
+        }
+      }
+      mutation {
+        updateDocuments(data: { # attempt to transfer a owned document to another user (u1 -> u2)
+            content: "updated-by-u1",
+            documentUsers: {update: [
+                {id: 1, userId: "u2", read: true,  write: true}
+            ]}
+        }) {
+          ...DocumentWithUser
+        }
+      }
+    auth: |
+      {
+        "sub": "u1"
+      }
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Not authorized"
+          }
+        ]
+      }
+
+  - operation: |
+      fragment DocumentWithUser on Document {
+        id
+        content
+        documentUsers {
+          userId
+          read
+          write
+        }
+      }
+      mutation {
+        updateDocuments(data: { # another attempt to transfer a owned document to another user (u1 -> u2) by creating a new documentUser
+            content: "updated-by-u1",
+            documentUsers: {create: [
+                {userId: "u2", read: true,  write: true}
+            ]}
+        }) {
+          ...DocumentWithUser
+        }
+      }
+    auth: |
+      {
+        "sub": "u1"
+      }
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Not authorized"
+          }
+        ]
+      }

--- a/integration-tests/shared-docs/external-auth/access-control/tests/query/admin-with-explicit-predicate.exotest
+++ b/integration-tests/shared-docs/external-auth/access-control/tests/query/admin-with-explicit-predicate.exotest
@@ -1,0 +1,451 @@
+operation: |
+  fragment DocumentWithUser on Document {
+    id
+    content
+    documentUsers {
+      userId
+      read
+      write
+    }
+  }
+  query @unordered {
+    u1Readable: documents(where: {
+      documentUsers: {and: [
+        {userId: {eq: "u1"}},
+        {read: {eq: true}}
+      ]}}) {
+      ...DocumentWithUser
+    }
+    u1Writable: documents(where: {
+      documentUsers: {and: [
+        {userId: {eq: "u1"}},
+        {write: {eq: true}}
+      ]}}) {
+      ...DocumentWithUser
+    }
+    u1ReadableAndWritable: documents(where: {
+      documentUsers: {and: [
+        {userId: {eq: "u1"}},
+        {and: [
+          {read: {eq: true}},
+          {write: {eq: true}}
+        ]}
+      ]}}) {
+      ...DocumentWithUser
+    }
+    u1ReadableOrWritable: documents(where: {
+      documentUsers: {and: [
+        {userId: {eq: "u1"}},
+        {or: [
+          {read: {eq: true}},
+          {write: {eq: true}}
+        ]}
+      ]}}) {
+      ...DocumentWithUser
+    }
+    u2Readable: documents(where: {
+      documentUsers: {and: [
+        {userId: {eq: "u2"}},
+        {read: {eq: true}}
+      ]}}) {
+      ...DocumentWithUser
+    }
+    u2Writable: documents(where: {
+      documentUsers: {and: [
+        {userId: {eq: "u2"}},
+        {write: {eq: true}}
+      ]}}) {
+      ...DocumentWithUser
+    }
+    u2ReadableAndWritable: documents(where: {
+      documentUsers: {and: [
+        {userId: {eq: "u2"}},
+        {and: [
+          {read: {eq: true}},
+          {write: {eq: true}}
+        ]}
+      ]}}) {
+      ...DocumentWithUser
+    }
+    u2ReadableOrWritable: documents(where: {
+      documentUsers: {and: [
+        {userId: {eq: "u2"}},
+        {or: [
+          {read: {eq: true}},
+          {write: {eq: true}}
+        ]}
+      ]}}) {
+      ...DocumentWithUser
+    }
+    u3Readable: documents(where: {
+      documentUsers: {and: [
+        {userId: {eq: "u3"}},
+        {read: {eq: true}}
+      ]}}) {
+      ...DocumentWithUser
+    }
+    u3Writable: documents(where: {
+      documentUsers: {and: [
+        {userId: {eq: "u3"}},
+        {write: {eq: true}}
+      ]}}) {
+      ...DocumentWithUser
+    }
+    u3ReadableAndWritable: documents(where: {
+      documentUsers: {and: [
+        {userId: {eq: "u3"}},
+        {and: [
+          {read: {eq: true}},
+          {write: {eq: true}}
+        ]}
+      ]}}) {
+      ...DocumentWithUser
+    }
+    u3ReadableOrWritable: documents(where: {
+      documentUsers: {and: [
+        {userId: {eq: "u3"}},
+        {or: [
+          {read: {eq: true}},
+          {write: {eq: true}}
+        ]}
+      ]}}) {
+      ...DocumentWithUser
+    }
+    u4Readable: documents(where: {
+      documentUsers: {and: [
+        {userId: {eq: "u4"}},
+        {read: {eq: true}}
+      ]}}) {
+      ...DocumentWithUser
+    }
+    u4Writable: documents(where: {
+      documentUsers: {and: [
+        {userId: {eq: "u4"}},
+        {write: {eq: true}}
+      ]}}) {
+      ...DocumentWithUser
+    }
+    u4ReadableAndWritable: documents(where: {
+      documentUsers: {and: [
+        {userId: {eq: "u4"}},
+        {and: [
+          {read: {eq: true}},
+          {write: {eq: true}}
+        ]}
+      ]}}) {
+      ...DocumentWithUser
+    }
+    u4ReadableOrWritable: documents(where: {
+      documentUsers: {and: [
+        {userId: {eq: "u4"}},
+        {write: {eq: true}}
+        {or: [
+          {read: {eq: true}},
+          {write: {eq: true}}
+        ]}
+      ]}}) {
+      ...DocumentWithUser
+    }         
+  }
+auth: |
+  {
+    "role": "admin"
+  }
+response: |
+  {
+    "data": {
+      "u1Readable": [
+        {
+          "id": 1,
+          "content": "d1",
+          "documentUsers": [
+            {
+              "userId": "u1",
+              "read": true,
+              "write": true
+            },
+            {
+              "userId": "u2",
+              "read": false,
+              "write": false
+            },
+            {
+              "userId": "u3",
+              "read": true,
+              "write": false
+            }
+          ]
+        }
+      ],
+      "u1Writable": [
+        {
+          "id": 1,
+          "content": "d1",
+          "documentUsers": [
+            {
+              "userId": "u1",
+              "read": true,
+              "write": true
+            },
+            {
+              "userId": "u2",
+              "read": false,
+              "write": false
+            },
+            {
+              "userId": "u3",
+              "read": true,
+              "write": false
+            }
+          ]
+        }
+      ],      
+      "u1ReadableAndWritable": [
+        {
+          "id": 1,
+          "content": "d1",
+          "documentUsers": [
+            {
+              "userId": "u1",
+              "read": true,
+              "write": true
+            },
+            {
+              "userId": "u2",
+              "read": false,
+              "write": false
+            },
+            {
+              "userId": "u3",
+              "read": true,
+              "write": false
+            }
+          ]
+        }
+      ],
+      "u1ReadableOrWritable": [
+        {
+          "id": 1,
+          "content": "d1",
+          "documentUsers": [
+            {
+              "userId": "u1",
+              "read": true,
+              "write": true
+            },
+            {
+              "userId": "u2",
+              "read": false,
+              "write": false
+            },
+            {
+              "userId": "u3",
+              "read": true,
+              "write": false
+            }
+          ]
+        }
+      ],      
+
+      "u2Readable": [
+        {
+          "id": 2,
+          "content": "d2",
+          "documentUsers": [
+            {
+              "userId": "u1",
+              "read": false,
+              "write": false
+            },
+            {
+              "userId": "u2",
+              "read": true,
+              "write": true
+            },
+            {
+              "userId": "u3",
+              "read": true,
+              "write": false
+            }
+          ]
+        }
+      ],
+      "u2Writable": [
+        {
+          "id": 2,
+          "content": "d2",
+          "documentUsers": [
+            {
+              "userId": "u1",
+              "read": false,
+              "write": false
+            },
+            {
+              "userId": "u2",
+              "read": true,
+              "write": true
+            },
+            {
+              "userId": "u3",
+              "read": true,
+              "write": false
+            }
+          ]
+        }
+      ],
+      "u2ReadableAndWritable": [
+        {
+          "id": 2,
+          "content": "d2",
+          "documentUsers": [
+            {
+              "userId": "u1",
+              "read": false,
+              "write": false
+            },
+            {
+              "userId": "u2",
+              "read": true,
+              "write": true
+            },
+            {
+              "userId": "u3",
+              "read": true,
+              "write": false
+            }
+          ]
+        }
+      ],
+      "u2ReadableOrWritable": [
+        {
+          "id": 2,
+          "content": "d2",
+          "documentUsers": [
+            {
+              "userId": "u1",
+              "read": false,
+              "write": false
+            },
+            {
+              "userId": "u2",
+              "read": true,
+              "write": true
+            },
+            {
+              "userId": "u3",
+              "read": true,
+              "write": false
+            }
+          ]
+        }
+      ],
+
+      "u3Readable": [
+        {
+          "id": 1,
+          "content": "d1",
+          "documentUsers": [
+            {
+              "userId": "u1",
+              "read": true,
+              "write": true
+            },
+            {
+              "userId": "u2",
+              "read": false,
+              "write": false
+            },
+            {
+              "userId": "u3",
+              "read": true,
+              "write": false
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "content": "d2",
+          "documentUsers": [
+            {
+              "userId": "u1",
+              "read": false,
+              "write": false
+            },
+            {
+              "userId": "u2",
+              "read": true,
+              "write": true
+            },
+            {
+              "userId": "u3",
+              "read": true,
+              "write": false
+            }
+          ]
+        }
+      ],
+      "u3Writable": [],
+      "u3ReadableAndWritable": [],
+      "u3ReadableOrWritable": [
+        {
+          "id": 1,
+          "content": "d1",
+          "documentUsers": [
+            {
+              "userId": "u1",
+              "read": true,
+              "write": true
+            },
+            {
+              "userId": "u2",
+              "read": false,
+              "write": false
+            },
+            {
+              "userId": "u3",
+              "read": true,
+              "write": false
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "content": "d2",
+          "documentUsers": [
+            {
+              "userId": "u1",
+              "read": false,
+              "write": false
+            },
+            {
+              "userId": "u2",
+              "read": true,
+              "write": true
+            },
+            {
+              "userId": "u3",
+              "read": true,
+              "write": false
+            }
+          ]
+        }        
+      ],
+
+      "u4Readable": [
+        {
+          "id": 3,
+          "content": "d3",
+          "documentUsers": [
+            {
+              "userId": "u4",
+              "read": true,
+              "write": false
+            }
+          ]
+        }
+      ],
+      "u4Writable": [],
+      "u4ReadableAndWritable": [],
+      "u4ReadableOrWritable": []
+    }
+  }

--- a/integration-tests/shared-docs/external-auth/access-control/tests/query/docs-for-self.exotest
+++ b/integration-tests/shared-docs/external-auth/access-control/tests/query/docs-for-self.exotest
@@ -1,0 +1,188 @@
+stages:
+  - operation: |
+      fragment DocumentWithUser on Document {
+        id
+        content
+        documentUsers {
+          userId
+          read
+          write
+        }
+      }
+      query @unordered {
+        documents {
+          ...DocumentWithUser
+        }
+      }
+    auth: |
+      {
+        "sub": "u1"
+      }
+    response: |
+      {
+        "data": {
+          "documents": [
+            {
+              "id": 1,
+              "content": "d1",
+              "documentUsers": [
+                {
+                  "userId": "u1",
+                  "read": true,
+                  "write": true
+                }
+              ]
+            }
+          ]
+        }
+      }
+  - operation: |
+      fragment DocumentWithUser on Document {
+        id
+        content
+        documentUsers {
+          userId
+          read
+          write
+        }
+      }
+      query @unordered {
+        documents {
+          ...DocumentWithUser
+        }
+      }
+    auth: |
+      {
+        "sub": "u2"
+      }
+    response: |
+      {
+        "data": {
+          "documents": [
+            {
+              "id": 2,
+              "content": "d2",
+              "documentUsers": [
+                {
+                  "userId": "u2",
+                  "read": true,
+                  "write": true
+                }
+              ]
+            }
+          ]
+        }
+      }
+
+  - operation: |
+      fragment DocumentWithUser on Document {
+        id
+        content
+        documentUsers {
+          userId
+          read
+          write
+        }
+      }
+      query @unordered {
+        documents {
+          ...DocumentWithUser
+        }
+      }
+    auth: |
+      {
+        "sub": "u3"
+      }
+    response: |
+      {
+        "data": {
+          "documents": [
+            {
+              "id": 1,
+              "content": "d1",
+              "documentUsers": [
+                {
+                  "userId": "u3",
+                  "read": true,
+                  "write": false
+                }
+              ]
+            },
+            {
+              "id": 2,
+              "content": "d2",
+              "documentUsers": [
+                {
+                  "userId": "u3",
+                  "read": true,
+                  "write": false
+                }
+              ]
+            }
+          ]
+        }
+      }
+
+  - operation: |
+      fragment DocumentWithUser on Document {
+        id
+        content
+        documentUsers {
+          userId
+          read
+          write
+        }
+      }
+      query @unordered {
+        documents {
+          ...DocumentWithUser
+        }
+      }
+    auth: |
+      {
+        "sub": "u4"
+      }
+    response: |
+      {
+        "data": {
+          "documents": [
+            {
+              "id": 3,
+              "content": "d3",
+              "documentUsers": [
+                {
+                  "userId": "u4",
+                  "read": true,
+                  "write": false
+                }
+              ]
+            }
+          ]
+        }
+      }
+
+  - operation: |
+      fragment DocumentWithUser on Document {
+        id
+        content
+        documentUsers {
+          userId
+          read
+          write
+        }
+      }
+      query @unordered {
+        documents {
+          ...DocumentWithUser
+        }
+      }
+    auth: |
+      {
+        "sub": "u-does-not-exist" 
+      }
+    response: |
+      {
+        "data": {
+          "documents": []
+        }
+      }

--- a/libs/exo-sql/src/asql/column_path.rs
+++ b/libs/exo-sql/src/asql/column_path.rs
@@ -209,21 +209,17 @@ impl PhysicalColumnPath {
         self
     }
 
-    pub fn can_join(&self, tail: &Self) -> bool {
-        matches!(
+    pub fn join(mut self, tail: Self) -> Self {
+        // Assert that the the last link in the path points to the same table as the new link's self table
+        // This checks for the last two invariants (see above):
+        // the last link must be a relation and its table must be the same as the new link's self table
+        assert!(matches!(
             self.0.last().unwrap(),
             ColumnPathLink::Relation(RelationLink {
                 foreign_column_id,
                 ..
             }) if foreign_column_id.table_id == tail.0[0].self_column_id().table_id
-        )
-    }
-
-    pub fn join(mut self, tail: Self) -> Self {
-        // Assert that the the last link in the path points to the same table as the new link's self table
-        // This checks for the last two invariants (see above):
-        // the last link must be a relation and its table must be the same as the new link's self table
-        assert!(self.can_join(&tail));
+        ));
 
         self.0.extend(tail.0);
 

--- a/libs/exo-sql/src/asql/column_path.rs
+++ b/libs/exo-sql/src/asql/column_path.rs
@@ -209,6 +209,26 @@ impl PhysicalColumnPath {
         self
     }
 
+    pub fn join(mut self, tail: Self) -> Self {
+        // Assert that the the last link in the path points to the same table as the new link's self table
+        // This checks for the last two invariants (see above):
+        // the last link must be a relation and its table must be the same as the new link's self table
+        assert!(
+            matches!(
+                self.0.last().unwrap(),
+                ColumnPathLink::Relation(RelationLink {
+                    foreign_column_id,
+                    ..
+                }) if foreign_column_id.table_id == tail.0[0].self_column_id().table_id
+            ),
+            "Expected link to point to next table"
+        );
+
+        self.0.extend(tail.0);
+
+        self
+    }
+
     #[cfg(test)]
     pub fn from_columns(columns: Vec<ColumnId>, database: &Database) -> Self {
         assert!(

--- a/libs/exo-sql/src/asql/column_path.rs
+++ b/libs/exo-sql/src/asql/column_path.rs
@@ -209,20 +209,21 @@ impl PhysicalColumnPath {
         self
     }
 
+    pub fn can_join(&self, tail: &Self) -> bool {
+        matches!(
+            self.0.last().unwrap(),
+            ColumnPathLink::Relation(RelationLink {
+                foreign_column_id,
+                ..
+            }) if foreign_column_id.table_id == tail.0[0].self_column_id().table_id
+        )
+    }
+
     pub fn join(mut self, tail: Self) -> Self {
         // Assert that the the last link in the path points to the same table as the new link's self table
         // This checks for the last two invariants (see above):
         // the last link must be a relation and its table must be the same as the new link's self table
-        assert!(
-            matches!(
-                self.0.last().unwrap(),
-                ColumnPathLink::Relation(RelationLink {
-                    foreign_column_id,
-                    ..
-                }) if foreign_column_id.table_id == tail.0[0].self_column_id().table_id
-            ),
-            "Expected link to point to next table"
-        );
+        assert!(self.can_join(&tail));
 
         self.0.extend(tail.0);
 


### PR DESCRIPTION
This change allows expressing access-control rules involving collection elements. For example, the following describes that only readers can query and writers can mutate documents:

```exo
context AuthContext {
  @jwt("sub") id: String
  @jwt role: String
}

@postgres
module DocsDatabase {
  @access(
    query = self.documentUsers.some(du => du.userId == AuthContext.id && du.read),
    mutation = self.documentUsers.some(du => du.userId == AuthContext.id && du.write)
  )  
  type Document {
    @pk id: Int = autoIncrement()
    content: String
    documentUsers: Set<DocumentUser>
  }

  @access(
    query = self.userId == AuthContext.id && self.read,
    mutation = self.userId == AuthContext.id && self.write
  )
  type DocumentUser {
    @pk id: Int = autoIncrement()
    document: Document
    userId: String
    read: Boolean
    write: Boolean
  }
}
```