### PR TITLE
Read array dimensions work for all Postgres versions

### DIFF
--- a/libs/exo-sql/src/sql/database_client.rs
+++ b/libs/exo-sql/src/sql/database_client.rs
@@ -98,10 +98,6 @@ impl<'a> DatabaseClient {
             config.password(password);
         }
 
-        if config.get_user().is_none() {
-            return Err(DatabaseError::Config("Database user must be specified as a part of EXO_POSTGRES_URL or through EXO_POSTGRES_USER".into()));
-        }
-
         let manager_config = ManagerConfig {
             recycling_method: RecyclingMethod::Fast,
         };


### PR DESCRIPTION
Depending on the Postgres version, the array dimensions are stored as `int2` or `int4`. This commit makes the code work for both versions.