### PR TITLE
Support hof calls on optional collection fields

### DIFF
--- a/integration-tests/shared-docs/external-auth/access-control-optional-collection/src/index.exo
+++ b/integration-tests/shared-docs/external-auth/access-control-optional-collection/src/index.exo
@@ -1,0 +1,30 @@
+context AuthContext {
+  @jwt("sub") id: String
+  @jwt role: String
+}
+
+@postgres
+module DocsDatabase {
+  @access(
+    query = AuthContext.role == "admin"|| self.documentUsers.some(du => du.userId == AuthContext.id && du.read),
+    mutation = AuthContext.role == "admin" || self.documentUsers.some(du => du.userId == AuthContext.id && du.write)
+  )  
+  type Document {
+    @pk id: Int = autoIncrement()
+    content: String
+    // The "?" is the difference from the sibling (access-control) test setup
+    documentUsers: Set<DocumentUser>?
+  }
+
+  @access(
+    query = AuthContext.role == "admin" || (self.userId == AuthContext.id && self.read),
+    mutation = AuthContext.role == "admin" || (self.userId == AuthContext.id && self.write)
+  )
+  type DocumentUser {
+    @pk id: Int = autoIncrement()
+    document: Document
+    userId: String
+    read: Boolean
+    write: Boolean
+  }
+}

--- a/integration-tests/shared-docs/external-auth/access-control-optional-collection/tests
+++ b/integration-tests/shared-docs/external-auth/access-control-optional-collection/tests
@@ -1,0 +1,1 @@
+../access-control/tests


### PR DESCRIPTION
We already support hof calls on collection fields:

```exo
  @access(
    self.documentUsers.some(du => du.userId == AuthContext.id)
  )
  type Document {
    ...
    documentUsers: Set<DocumentUser>
  }
```

This commit extends it to optional collection fields (note the "?" for `documentUsers`).
```exo
  @access(
    self.documentUsers.some(du => du.userId == AuthContext.id)
  )
  type Document {
    ...
    documentUsers: Set<DocumentUser>?
  }
```