### PR TITLE
Fix loading dependencies of an ESM NPM module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,9 @@ name = "anyhow"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arbitrary"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,7 +18,7 @@ colored.workspace = true
 tokio.workspace = true
 async-trait.workspace = true
 async-recursion.workspace = true
-anyhow.workspace = true
+anyhow = { workspace = true, features = ["backtrace"] }
 heck.workspace = true
 lazy_static.workspace = true
 notify-debouncer-mini = "0.2.1"

--- a/crates/deno-subsystem/deno-model-builder/src/system_builder.rs
+++ b/crates/deno-subsystem/deno-model-builder/src/system_builder.rs
@@ -19,7 +19,10 @@ use core_plugin_interface::{
     },
 };
 
-use deno::{module_loader::NpmModuleLoader, CliFactory, CliOptions, Flags, PathBuf};
+use deno::{
+    cache::ParsedSourceCache, module_loader::NpmModuleLoader, node::CliCjsCodeAnalyzer, CliFactory,
+    CliOptions, Flags, PathBuf,
+};
 use deno_ast::{MediaType, ParseParams, SourceTextInfo};
 use deno_graph::{Module, ModuleEntryRef, ModuleGraph, ModuleSpecifier, WalkOptions};
 use deno_model::{
@@ -28,7 +31,7 @@ use deno_model::{
     subsystem::DenoSubsystem,
 };
 use deno_runtime::{
-    deno_node::{NodeResolution, NodeResolver},
+    deno_node::{analyze::NodeCodeTranslator, NodeResolution, NodeResolver},
     permissions::PermissionsContainer,
 };
 use deno_virtual_fs::virtual_fs::{VfsBuilder, VirtualDirectory};
@@ -156,9 +159,11 @@ fn process_script(
             let npm_resolver = factory.npm_resolver().await.unwrap();
             let npm_resolution = factory.npm_resolution().await.unwrap();
 
+            let code_translator = factory.node_code_translator().await.unwrap().clone();
+            let parsed_source_cache = factory.parsed_source_cache().unwrap().clone();
             let npm_loader = NpmModuleLoader::new(
                 factory.cjs_resolutions().clone(),
-                factory.node_code_translator().await.unwrap().clone(),
+                code_translator.clone(),
                 factory.fs().clone(),
                 factory.node_resolver().await.unwrap().clone(),
             );
@@ -189,7 +194,14 @@ fn process_script(
             };
 
             Ok::<DenoScriptDefn, ModelBuildingError>(DenoScriptDefn {
-                modules: walk_module_graph(graph, npm_loader, node_resolver.clone(), root_path)?,
+                modules: walk_module_graph(
+                    graph,
+                    npm_loader,
+                    node_resolver.clone(),
+                    code_translator,
+                    parsed_source_cache,
+                    root_path,
+                )?,
                 npm_snapshot: Some((
                     npm_resolution.serialized_valid_snapshot().into_serialized(),
                     vfs.0,
@@ -205,10 +217,177 @@ fn process_script(
     Ok((root.to_string(), serde_json::to_vec(&script_defn).unwrap()))
 }
 
+fn walk_node_resolutions(
+    root: NodeResolution,
+    npm_loader: &NpmModuleLoader,
+    node_resolver: &Arc<NodeResolver>,
+    code_translator: &Arc<NodeCodeTranslator<CliCjsCodeAnalyzer>>,
+    parsed_source_cache: &Arc<ParsedSourceCache>,
+    root_path: &PathBuf,
+    modules: &mut HashMap<Url, ResolvedModule>,
+) -> Option<(String, MediaType, ModuleSpecifier, bool)> {
+    match root {
+        NodeResolution::BuiltIn(_) => None,
+        NodeResolution::CommonJs(cjs_specifier) => {
+            let loaded = npm_loader
+                .load_sync_if_in_npm_package(
+                    &cjs_specifier,
+                    None,
+                    &PermissionsContainer::allow_all(),
+                )
+                .unwrap()
+                .unwrap();
+
+            let loaded_rewritten = code_translator
+                .translate_cjs_to_esm(
+                    &cjs_specifier,
+                    Some(loaded.code.as_str()),
+                    &PermissionsContainer::allow_all(),
+                )
+                .unwrap();
+
+            let cjs_path = cjs_specifier.to_file_path().unwrap();
+
+            let node_relative_path = cjs_path.strip_prefix(root_path.clone()).unwrap();
+
+            // encode the segments of the path with forward slashes, even on windows
+            let node_relative_path_str = node_relative_path
+                .components()
+                .map(|c| c.as_os_str().to_str().unwrap())
+                .collect::<Vec<_>>()
+                .join("/");
+
+            // Deno generates a thin ESM wrapper that uses an absolute path
+            let mut root_replaced_specifier: ModuleSpecifier = ModuleSpecifier::parse(&format!(
+                "file:///EXOGRAPH_NPM_MODULES_SNAPSHOT/{}",
+                node_relative_path_str
+            ))
+            .unwrap();
+            root_replaced_specifier.set_host(Some("localhost")).unwrap();
+
+            let root_replaced = loaded_rewritten.as_str().replace(
+                &cjs_specifier
+                    .to_file_path()
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .replace('\\', "\\\\")
+                    .replace('\'', "\\\'")
+                    .replace('\"', "\\\""),
+                &format!("/EXOGRAPH_NPM_MODULES_SNAPSHOT/{}", node_relative_path_str)
+                    .replace('\\', "\\\\")
+                    .replace('\'', "\\\'")
+                    .replace('\"', "\\\""),
+            );
+
+            if !modules.contains_key(&root_replaced_specifier) {
+                modules.insert(
+                    root_replaced_specifier.clone(),
+                    ResolvedModule::Module(
+                        root_replaced.clone(),
+                        deno_core::ModuleType::JavaScript,
+                        root_replaced_specifier.clone(),
+                        true,
+                    ),
+                );
+            }
+
+            Some((
+                root_replaced,
+                MediaType::JavaScript,
+                root_replaced_specifier,
+                true,
+            ))
+        }
+        NodeResolution::Esm(esm_specifier) => {
+            let loaded = npm_loader
+                .load_sync_if_in_npm_package(
+                    &esm_specifier,
+                    None,
+                    &PermissionsContainer::allow_all(),
+                )
+                .unwrap()
+                .unwrap();
+
+            let esm_path = esm_specifier.to_file_path().unwrap();
+
+            let node_relative_path = esm_path.strip_prefix(root_path.clone()).unwrap();
+
+            // encode the segments of the path with forward slashes, even on windows
+            let node_relative_path_str = node_relative_path
+                .components()
+                .map(|c| c.as_os_str().to_str().unwrap())
+                .collect::<Vec<_>>()
+                .join("/");
+
+            // Deno generates a thin ESM wrapper that uses an absolute path
+            let mut root_replaced_specifier: ModuleSpecifier = ModuleSpecifier::parse(&format!(
+                "file:///EXOGRAPH_NPM_MODULES_SNAPSHOT/{}",
+                node_relative_path_str
+            ))
+            .unwrap();
+            root_replaced_specifier.set_host(Some("localhost")).unwrap();
+
+            if !modules.contains_key(&root_replaced_specifier) {
+                // insert first so that we don't recurse infinitely
+                modules.insert(
+                    root_replaced_specifier.clone(),
+                    ResolvedModule::Module(
+                        loaded.code.as_str().to_string(),
+                        deno_core::ModuleType::JavaScript,
+                        root_replaced_specifier.clone(),
+                        false,
+                    ),
+                );
+
+                let analysis = parsed_source_cache
+                    .as_analyzer()
+                    .analyze(
+                        &esm_specifier,
+                        Arc::from(loaded.code.as_str()),
+                        MediaType::JavaScript,
+                    )
+                    .expect("Failed to analyze dependes of an ESM NPM module");
+
+                for dep in &analysis.dependencies {
+                    let resolved = node_resolver
+                        .resolve(
+                            &dep.specifier,
+                            &esm_specifier,
+                            deno_runtime::deno_node::NodeResolutionMode::Execution,
+                            &PermissionsContainer::allow_all(),
+                        )
+                        .expect("Failed to resolve dependency of an ESM NPM module")
+                        .expect("Failed to resolve dependency of an ESM NPM module");
+
+                    walk_node_resolutions(
+                        resolved,
+                        npm_loader,
+                        node_resolver,
+                        code_translator,
+                        parsed_source_cache,
+                        root_path,
+                        modules,
+                    );
+                }
+            }
+
+            Some((
+                loaded.code.as_str().to_string(),
+                MediaType::JavaScript,
+                root_replaced_specifier,
+                false,
+            ))
+        }
+    }
+}
+
 fn walk_module_graph(
     graph: ModuleGraph,
     npm_loader: NpmModuleLoader,
     node_resolver: Arc<NodeResolver>,
+    code_translator: Arc<NodeCodeTranslator<CliCjsCodeAnalyzer>>,
+    parsed_source_cache: Arc<ParsedSourceCache>,
     root_path: PathBuf,
 ) -> Result<HashMap<Url, ResolvedModule>, ModelBuildingError> {
     let mut modules: HashMap<Url, ResolvedModule> = HashMap::new();
@@ -238,10 +417,6 @@ fn walk_module_graph(
                     )),
                     Module::Node(_) => None,
                     Module::Npm(npm) => {
-                        // trigger CommonJS detection, which will lead to `npm_loader` giving us the wrapped module
-                        let _ = npm_loader
-                            .resolve_nv_ref(&npm.nv_reference, &PermissionsContainer::allow_all())
-                            .unwrap();
                         let resolved = node_resolver
                             .resolve_npm_reference(
                                 &npm.nv_reference,
@@ -251,105 +426,15 @@ fn walk_module_graph(
                             .unwrap()
                             .unwrap();
 
-                        match resolved {
-                            NodeResolution::BuiltIn(_) => {
-                                unreachable!("only NPM modules")
-                            }
-                            NodeResolution::CommonJs(cjs_specifier) => {
-                                let loaded = npm_loader
-                                    .load_sync_if_in_npm_package(
-                                        &cjs_specifier,
-                                        None,
-                                        &PermissionsContainer::allow_all(),
-                                    )
-                                    .unwrap()
-                                    .unwrap();
-
-                                let cjs_path = cjs_specifier.to_file_path().unwrap();
-
-                                let node_relative_path =
-                                    cjs_path.strip_prefix(root_path.clone()).unwrap();
-
-                                // encode the segments of the path with forward slashes, even on windows
-                                let node_relative_path_str = node_relative_path
-                                    .components()
-                                    .map(|c| c.as_os_str().to_str().unwrap())
-                                    .collect::<Vec<_>>()
-                                    .join("/");
-
-                                // Deno generates a thin ESM wrapper that uses an absolute path
-                                let mut root_replaced_specifier: ModuleSpecifier =
-                                    ModuleSpecifier::parse(&format!(
-                                        "file:///EXOGRAPH_NPM_MODULES_SNAPSHOT/{}",
-                                        node_relative_path_str
-                                    ))
-                                    .unwrap();
-                                root_replaced_specifier.set_host(Some("localhost")).unwrap();
-
-                                let root_replaced = loaded.code.as_str().replace(
-                                    &cjs_specifier
-                                        .to_file_path()
-                                        .unwrap()
-                                        .to_str()
-                                        .unwrap()
-                                        .replace('\\', "\\\\")
-                                        .replace('\'', "\\\'")
-                                        .replace('\"', "\\\""),
-                                    &format!(
-                                        "/EXOGRAPH_NPM_MODULES_SNAPSHOT/{}",
-                                        node_relative_path_str
-                                    )
-                                    .replace('\\', "\\\\")
-                                    .replace('\'', "\\\'")
-                                    .replace('\"', "\\\""),
-                                );
-
-                                Some((
-                                    root_replaced,
-                                    MediaType::JavaScript,
-                                    root_replaced_specifier,
-                                    true,
-                                ))
-                            }
-                            NodeResolution::Esm(esm_specifier) => {
-                                let loaded = npm_loader
-                                    .load_sync_if_in_npm_package(
-                                        &esm_specifier,
-                                        None,
-                                        &PermissionsContainer::allow_all(),
-                                    )
-                                    .unwrap()
-                                    .unwrap();
-
-                                let esm_path = esm_specifier.to_file_path().unwrap();
-
-                                let node_relative_path =
-                                    esm_path.strip_prefix(root_path.clone()).unwrap();
-
-                                // encode the segments of the path with forward slashes, even on windows
-                                let node_relative_path_str = node_relative_path
-                                    .components()
-                                    .map(|c| c.as_os_str().to_str().unwrap())
-                                    .collect::<Vec<_>>()
-                                    .join("/");
-
-                                // Deno generates a thin ESM wrapper that uses an absolute path
-                                let mut root_replaced_specifier: ModuleSpecifier =
-                                    ModuleSpecifier::parse(&format!(
-                                        "file:///EXOGRAPH_NPM_MODULES_SNAPSHOT/{}",
-                                        node_relative_path_str
-                                    ))
-                                    .unwrap();
-                                root_replaced_specifier.set_host(Some("localhost")).unwrap();
-
-                                Some((
-                                    loaded.code.as_str().to_string(),
-                                    MediaType::JavaScript,
-                                    root_replaced_specifier,
-                                    false,
-                                ))
-                            }
-                        }
+                        walk_node_resolutions(
+                            resolved,
+                            &npm_loader,
+                            &node_resolver,
+                            &code_translator,
+                            &parsed_source_cache,
+                            &root_path,
+                            &mut modules,
+                        )
                     }
                     o => {
                         return Err(ModelBuildingError::Generic(format!(

--- a/integration-tests/services/deno-stripe/.gitignore
+++ b/integration-tests/services/deno-stripe/.gitignore
@@ -1,0 +1,2 @@
+target/
+generated/

--- a/integration-tests/services/deno-stripe/src/index.exo
+++ b/integration-tests/services/deno-stripe/src/index.exo
@@ -1,0 +1,6 @@
+@deno("test_ops.ts")
+module TodoDatabase {
+  query fake(): String
+  @access(true)
+  mutation create_customer(email: String): String
+}

--- a/integration-tests/services/deno-stripe/src/test_ops.ts
+++ b/integration-tests/services/deno-stripe/src/test_ops.ts
@@ -1,0 +1,12 @@
+import Stripe from "npm:stripe";
+
+// public test key from https://stripe.com/docs/stripe-cli
+const stripe = new Stripe('sk_test_4eC39HqLyjWDarjtT1zdp7dc');
+
+export async function create_customer(email: string): Promise<string> {
+	const customer = await stripe.customers.create({
+		email: email,
+	});
+
+	return customer.id.substring(0, 4);
+}

--- a/integration-tests/services/deno-stripe/tests/basic-query.exotest
+++ b/integration-tests/services/deno-stripe/tests/basic-query.exotest
@@ -1,0 +1,10 @@
+operation: |
+  mutation {
+    create_customer(email: "customer@example.com")
+  }
+response: |
+  {
+    "data": {
+      "create_customer": "cus_"
+    }
+  }

--- a/libs/exo-deno/src/embedded_module_loader.rs
+++ b/libs/exo-deno/src/embedded_module_loader.rs
@@ -15,6 +15,8 @@ use deno_core::ModuleLoader;
 use deno_core::ModuleSource;
 use deno_core::ModuleSpecifier;
 use deno_core::ResolutionKind;
+use deno_runtime::deno_node::NodeResolver;
+use deno_runtime::permissions::PermissionsContainer;
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -32,6 +34,7 @@ pub(super) struct EmbeddedModuleLoader {
     #[allow(unused)]
     pub embedded_dirs: HashMap<String, &'static Dir<'static>>,
     pub source_code_map: Rc<RefCell<HashMap<Url, ResolvedModule>>>,
+    pub node_resolver: Option<NodeResolver>,
 }
 
 impl ModuleLoader for EmbeddedModuleLoader {
@@ -41,6 +44,21 @@ impl ModuleLoader for EmbeddedModuleLoader {
         referrer: &str,
         _kind: ResolutionKind,
     ) -> Result<ModuleSpecifier, AnyError> {
+        if let Some(node_resolver) = &self.node_resolver {
+            if let Ok(referrer) = ModuleSpecifier::parse(referrer) {
+                if node_resolver.in_npm_package(&referrer) {
+                    if let Ok(Some(res)) = node_resolver.resolve(
+                        specifier,
+                        &referrer,
+                        deno_runtime::deno_node::NodeResolutionMode::Execution,
+                        &PermissionsContainer::allow_all(),
+                    ) {
+                        return Ok(res.into_url());
+                    }
+                }
+            }
+        }
+
         Ok(resolve_import(specifier, referrer)?)
     }
 
@@ -51,7 +69,20 @@ impl ModuleLoader for EmbeddedModuleLoader {
         is_dynamic: bool,
     ) -> Pin<Box<deno_core::ModuleSourceFuture>> {
         let borrowed_map = self.source_code_map.borrow();
-        let mut resolved = borrowed_map.get(module_specifier);
+
+        #[allow(unused_mut)]
+        let mut module_specifier_unix = module_specifier.clone();
+        #[cfg(target_os = "windows")]
+        {
+            module_specifier_unix =
+                ModuleSpecifier::parse(&module_specifier_unix.as_str().replace(
+                    "/C:/EXOGRAPH_NPM_MODULES_SNAPSHOT",
+                    "/EXOGRAPH_NPM_MODULES_SNAPSHOT",
+                ))
+                .unwrap();
+        }
+
+        let mut resolved = borrowed_map.get(&module_specifier_unix);
         while let Some(ResolvedModule::Redirect(to)) = resolved {
             resolved = borrowed_map.get(to);
         }
@@ -75,11 +106,15 @@ impl ModuleLoader for EmbeddedModuleLoader {
                         "/EXOGRAPH_NPM_MODULES_SNAPSHOT",
                         "C:\\\\EXOGRAPH_NPM_MODULES_SNAPSHOT",
                     );
+                }
+
+                #[cfg(target_os = "windows")]
+                {
                     final_specifier = ModuleSpecifier::parse(&final_specifier.as_str().replace(
                         "/EXOGRAPH_NPM_MODULES_SNAPSHOT",
                         "C:\\EXOGRAPH_NPM_MODULES_SNAPSHOT",
                     ))
-                    .unwrap()
+                    .unwrap();
                 }
 
                 let module_source = ModuleSource::new_with_redirect(


### PR DESCRIPTION
Fix loading dependencies of an ESM NPM module











Unlike CommonJS, if an NPM module has ESM sources they are loaded through the same `EmbeddedModuleLoader` pipeline as Deno modules. This would result in us being unable to load dependencies of such a module since they aren't loaded directly from the file system but instead from `EmbeddedModuleLoader` again.

Fixing this requires three steps. First, we have `EmbeddedModuleLoader` use an underlying `NodeResolver` when it is processing a resolution on behalf of a file inside an NPM module (this also allows NPM ESM sources to load Node builtins). Second, we need the ESM sources of transitive dependencies to be in the `EmbeddedModuleLoader`'s map. We achieve this by having the Deno system builder walk the dependencies of NPM modules (stopping when we reach a CommonJS source). Third, we need to pre-generate the ESM wrappers around any CommonJS sources that may be loaded (we originally only handled top-level imports). This is handled by the same logic as step 2, by generating these wrappers for any CommonJS module we encounter while walking the NPM transitive dependencies.

Note that we do not need to walk the dependencies of a CommonJS module itself, since entering a CommonJS module switches the execution mode to have resolution go directly to the virtual filesystem instead of through `EmbeddedModuleLoader`.

With this change, we are able to fully load the `stripe` NPM module and make networked API calls.
