### PR TITLE
Support 'exo playground' command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6522,12 +6522,14 @@ dependencies = [
  "common",
  "core-resolver",
  "futures",
+ "reqwest",
  "resolver",
  "serde_json",
  "server-common",
  "thiserror",
  "tracing",
  "tracing-actix-web",
+ "url",
 ]
 
 [[package]]
@@ -7779,9 +7781,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -8193,7 +8195,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand",
  "static_assertions",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ tokio-postgres = "0.7.10"
 tree-sitter = "0.20.9"
 tree-sitter-cli = "0.20.8"
 typed-generational-arena = { version = "0.2.5", features = ["serde"] }
+url = "2.3.1"
 wasmtime = "13.0.0"
 wasmtime-wasi = "13.0.0"
 wasi-common = "13.0.0"

--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use clap::{ArgMatches, Command};
 use colored::Colorize;
 use common::env_const::{
-    EXO_CORS_DOMAINS, EXO_DEPLOYMENT_MODE, EXO_INTROSPECTION, EXO_INTROSPECTION_LIVE_UPDATE,
+    EXO_CORS_DOMAINS, EXO_INTROSPECTION, EXO_INTROSPECTION_LIVE_UPDATE, _EXO_DEPLOYMENT_MODE,
 };
 use futures::FutureExt;
 use std::path::PathBuf;
@@ -31,7 +31,7 @@ pub struct DevCommandDefinition {}
 
 #[async_trait]
 impl CommandDefinition for DevCommandDefinition {
-    fn command(&self) -> clap::Command {
+    fn command(&self) -> Command {
         Command::new("dev")
             .about("Run exograph server in development mode")
             .arg(port_arg())
@@ -51,7 +51,7 @@ impl CommandDefinition for DevCommandDefinition {
         // In the serve mode, which is meant for development, always enable introspection and use relaxed CORS
         std::env::set_var(EXO_INTROSPECTION, "true");
         std::env::set_var(EXO_INTROSPECTION_LIVE_UPDATE, "true");
-        std::env::set_var(EXO_DEPLOYMENT_MODE, "dev");
+        std::env::set_var(_EXO_DEPLOYMENT_MODE, "dev");
 
         std::env::set_var(EXO_CORS_DOMAINS, "*");
 

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod command;
 pub(crate) mod deploy;
 pub(crate) mod dev;
 pub(crate) mod new;
+pub(crate) mod playground;
 pub(crate) mod schema;
 pub(crate) mod test;
 pub(super) mod util;

--- a/crates/cli/src/commands/playground.rs
+++ b/crates/cli/src/commands/playground.rs
@@ -58,7 +58,6 @@ impl CommandDefinition for PlaygroundCommandDefinition {
         std::env::set_var(EXO_CORS_DOMAINS, "*");
 
         std::env::set_var(_EXO_DEPLOYMENT_MODE, "playground");
-
         std::env::set_var(_EXO_PLAYGROUND_ENDPOINT_URL, &endpoint_url);
 
         let mut server =

--- a/crates/cli/src/commands/playground.rs
+++ b/crates/cli/src/commands/playground.rs
@@ -9,7 +9,7 @@ use clap::{Arg, ArgMatches, Command};
 use anyhow::Result;
 use common::env_const::{
     EXO_CHECK_CONNECTION_ON_STARTUP, EXO_CORS_DOMAINS, EXO_INTROSPECTION, EXO_POSTGRES_URL,
-    _EXO_DEPLOYMENT_MODE,
+    _EXO_DEPLOYMENT_MODE, _EXO_PLAYGROUND_ENDPOINT_URL,
 };
 
 use crate::{commands::command::get_required, util::watcher};
@@ -59,7 +59,7 @@ impl CommandDefinition for PlaygroundCommandDefinition {
 
         std::env::set_var(_EXO_DEPLOYMENT_MODE, "playground");
 
-        std::env::set_var("_EXO_PLAYGROUND_ENDPOINT_URL", &endpoint_url);
+        std::env::set_var(_EXO_PLAYGROUND_ENDPOINT_URL, &endpoint_url);
 
         let mut server =
             watcher::build_and_start_server(port, &|| async { Ok(()) }.boxed()).await?;

--- a/crates/cli/src/commands/playground.rs
+++ b/crates/cli/src/commands/playground.rs
@@ -9,7 +9,7 @@ use clap::{Arg, ArgMatches, Command};
 use anyhow::Result;
 use common::env_const::{
     EXO_CHECK_CONNECTION_ON_STARTUP, EXO_CORS_DOMAINS, EXO_INTROSPECTION, EXO_POSTGRES_URL,
-    _EXO_DEPLOYMENT_MODE, _EXO_PLAYGROUND_ENDPOINT_URL,
+    _EXO_DEPLOYMENT_MODE, _EXO_UPSTREAM_ENDPOINT_URL,
 };
 
 use crate::{commands::command::get_required, util::watcher};
@@ -58,7 +58,7 @@ impl CommandDefinition for PlaygroundCommandDefinition {
         std::env::set_var(EXO_CORS_DOMAINS, "*");
 
         std::env::set_var(_EXO_DEPLOYMENT_MODE, "playground");
-        std::env::set_var(_EXO_PLAYGROUND_ENDPOINT_URL, &endpoint_url);
+        std::env::set_var(_EXO_UPSTREAM_ENDPOINT_URL, &endpoint_url);
 
         let mut server =
             watcher::build_and_start_server(port, &|| async { Ok(()) }.boxed()).await?;

--- a/crates/cli/src/commands/playground.rs
+++ b/crates/cli/src/commands/playground.rs
@@ -1,0 +1,81 @@
+use colored::Colorize;
+use futures::FutureExt;
+use std::path::PathBuf;
+
+use anyhow::anyhow;
+use async_trait::async_trait;
+use clap::{Arg, ArgMatches, Command};
+
+use anyhow::Result;
+use common::env_const::{
+    EXO_CHECK_CONNECTION_ON_STARTUP, EXO_CORS_DOMAINS, EXO_INTROSPECTION, EXO_POSTGRES_URL,
+    _EXO_DEPLOYMENT_MODE,
+};
+
+use crate::{commands::command::get_required, util::watcher};
+
+use super::command::{ensure_exo_project_dir, get, port_arg, CommandDefinition};
+
+/// Run local exograph server in playground-only mode
+///
+/// This mode is meant to be useful with production deployments of Exograph (which, by default, does
+/// not expose introspection or the playground code). This command takes one required argument,
+/// `endpoint`, which is the URL of the GraphQL endpoint to connect to.
+///
+/// In this mode, Exograph fetches the schema from the server started from this command (which has
+/// all resolvers, except the schema resolver, disabled) and uses that to run the playground. All
+/// GraphQL requests execute against the endpoint specified by the `endpoint` argument.
+pub struct PlaygroundCommandDefinition {}
+
+#[async_trait]
+impl CommandDefinition for PlaygroundCommandDefinition {
+    fn command(&self) -> Command {
+        Command::new("playground")
+            .about("Run Exograph in playground-only mode")
+            .arg(port_arg())
+            .arg(
+                Arg::new("endpoint")
+                    .help("Endpoint URL to connect to (typically http://<remote-url>/graphql)")
+                    .long("endpoint")
+                    .required(true),
+            )
+    }
+
+    async fn execute(&self, matches: &ArgMatches) -> Result<()> {
+        let port: Option<u32> = get(matches, "port");
+        let endpoint_url: String = get_required(matches, "endpoint")?;
+
+        ensure_exo_project_dir(&PathBuf::from("."))?;
+
+        std::env::set_var(EXO_INTROSPECTION, "only");
+        // We don't need a database connection in playground mode, but the Postgres resolver
+        // currently requires a valid URL to be set (when we fix
+        // https://github.com/exograph/exograph/issues/532), we won't need to instantiate the
+        // Postgres resolver at all.
+        std::env::set_var(EXO_POSTGRES_URL, "postgres://__placeholder");
+        std::env::set_var(EXO_CHECK_CONNECTION_ON_STARTUP, "false");
+
+        std::env::set_var(EXO_CORS_DOMAINS, "*");
+
+        std::env::set_var(_EXO_DEPLOYMENT_MODE, "playground");
+
+        std::env::set_var("_EXO_PLAYGROUND_ENDPOINT_URL", &endpoint_url);
+
+        let mut server =
+            watcher::build_and_start_server(port, &|| async { Ok(()) }.boxed()).await?;
+
+        if let Some(child) = server.as_mut() {
+            println!(
+                "{} {}",
+                "Starting playground server connected to the endpoint at:"
+                    .purple()
+                    .bold(),
+                endpoint_url.blue().bold()
+            );
+            child.wait().await?;
+            Ok(())
+        } else {
+            Err(anyhow!("Failed to start server"))
+        }
+    }
+}

--- a/crates/cli/src/commands/yolo.rs
+++ b/crates/cli/src/commands/yolo.rs
@@ -13,7 +13,7 @@ use async_trait::async_trait;
 use clap::{ArgMatches, Command};
 use colored::Colorize;
 use common::env_const::{
-    EXO_CORS_DOMAINS, EXO_DEPLOYMENT_MODE, EXO_INTROSPECTION, EXO_INTROSPECTION_LIVE_UPDATE,
+    EXO_CORS_DOMAINS, EXO_INTROSPECTION, EXO_INTROSPECTION_LIVE_UPDATE, _EXO_DEPLOYMENT_MODE,
 };
 use std::{path::PathBuf, sync::atomic::Ordering};
 
@@ -45,7 +45,7 @@ pub struct YoloCommandDefinition {}
 
 #[async_trait]
 impl CommandDefinition for YoloCommandDefinition {
-    fn command(&self) -> clap::Command {
+    fn command(&self) -> Command {
         Command::new("yolo")
             .about("Run local exograph server with a temporary database")
             .arg(port_arg())
@@ -102,7 +102,7 @@ async fn run_server(
     std::env::remove_var(EXO_POSTGRES_PASSWORD);
     std::env::set_var(EXO_INTROSPECTION, "true");
     std::env::set_var(EXO_INTROSPECTION_LIVE_UPDATE, "true");
-    std::env::set_var(EXO_DEPLOYMENT_MODE, "yolo");
+    std::env::set_var(_EXO_DEPLOYMENT_MODE, "yolo");
 
     match jwt_secret {
         JWTSecret::EnvSecret(s) => std::env::set_var(EXO_JWT_SECRET, s),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -68,8 +68,8 @@ async fn main() -> Result<()> {
             Box::new(BuildCommandDefinition {}),
             Box::new(deploy::command_definition()),
             Box::new(schema::command_definition()),
-            Box::new(TestCommandDefinition {}),
             Box::new(PlaygroundCommandDefinition {}),
+            Box::new(TestCommandDefinition {}),
         ],
     );
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -24,6 +24,7 @@ use commands::{
     deploy,
     dev::DevCommandDefinition,
     new::NewCommandDefinition,
+    playground::PlaygroundCommandDefinition,
     schema,
     test::TestCommandDefinition,
     yolo::YoloCommandDefinition,
@@ -68,6 +69,7 @@ async fn main() -> Result<()> {
             Box::new(deploy::command_definition()),
             Box::new(schema::command_definition()),
             Box::new(TestCommandDefinition {}),
+            Box::new(PlaygroundCommandDefinition {}),
         ],
     );
 

--- a/crates/common/src/env_const.rs
+++ b/crates/common/src/env_const.rs
@@ -33,7 +33,7 @@ pub enum EnvError {
 pub enum DeploymentMode {
     Yolo,
     Dev,
-    Playground,
+    Playground(String), // URL of the GraphQL endpoint to connect to
     Prod,
 }
 
@@ -41,7 +41,15 @@ pub fn get_deployment_mode() -> Result<DeploymentMode, EnvError> {
     match std::env::var(_EXO_DEPLOYMENT_MODE).as_deref() {
         Ok("yolo") => Ok(DeploymentMode::Yolo),
         Ok("dev") => Ok(DeploymentMode::Dev),
-        Ok("playground") => Ok(DeploymentMode::Playground),
+        Ok("playground") => {
+            let endpoint_url =
+                std::env::var(_EXO_PLAYGROUND_ENDPOINT_URL).map_err(|_| EnvError::InvalidEnum {
+                    env_key: _EXO_PLAYGROUND_ENDPOINT_URL,
+                    env_value: "".to_string(),
+                    message: "Must be set to a valid URL".to_string(),
+                })?;
+            Ok(DeploymentMode::Playground(endpoint_url))
+        }
         Ok("prod") | Err(_) => Ok(DeploymentMode::Prod),
         Ok(other) => Err(EnvError::InvalidEnum {
             env_key: _EXO_DEPLOYMENT_MODE,

--- a/crates/common/src/env_const.rs
+++ b/crates/common/src/env_const.rs
@@ -18,7 +18,7 @@ pub const EXO_SERVER_PORT: &str = "EXO_SERVER_PORT";
 
 pub const _EXO_DEPLOYMENT_MODE: &str = "_EXO_DEPLOYMENT_MODE"; // "yolo", "dev", "playground" or "prod" (default)
 
-pub const _EXO_PLAYGROUND_ENDPOINT_URL: &str = "_EXO_PLAYGROUND_ENDPOINT_URL";
+pub const _EXO_UPSTREAM_ENDPOINT_URL: &str = "_EXO_UPSTREAM_ENDPOINT_URL";
 
 #[derive(Error, Debug)]
 pub enum EnvError {
@@ -43,8 +43,8 @@ pub fn get_deployment_mode() -> Result<DeploymentMode, EnvError> {
         Ok("dev") => Ok(DeploymentMode::Dev),
         Ok("playground") => {
             let endpoint_url =
-                std::env::var(_EXO_PLAYGROUND_ENDPOINT_URL).map_err(|_| EnvError::InvalidEnum {
-                    env_key: _EXO_PLAYGROUND_ENDPOINT_URL,
+                std::env::var(_EXO_UPSTREAM_ENDPOINT_URL).map_err(|_| EnvError::InvalidEnum {
+                    env_key: _EXO_UPSTREAM_ENDPOINT_URL,
                     env_value: "".to_string(),
                     message: "Must be set to a valid URL".to_string(),
                 })?;

--- a/crates/common/src/env_const.rs
+++ b/crates/common/src/env_const.rs
@@ -18,6 +18,8 @@ pub const EXO_SERVER_PORT: &str = "EXO_SERVER_PORT";
 
 pub const _EXO_DEPLOYMENT_MODE: &str = "_EXO_DEPLOYMENT_MODE"; // "yolo", "dev", "playground" or "prod" (default)
 
+pub const _EXO_PLAYGROUND_ENDPOINT_URL: &str = "_EXO_PLAYGROUND_ENDPOINT_URL";
+
 #[derive(Error, Debug)]
 pub enum EnvError {
     #[error("Invalid env value {env_value} for {env_key}: {message}")]

--- a/crates/common/src/env_const.rs
+++ b/crates/common/src/env_const.rs
@@ -16,7 +16,7 @@ pub const EXO_CHECK_CONNECTION_ON_STARTUP: &str = "EXO_CHECK_CONNECTION_ON_START
 
 pub const EXO_SERVER_PORT: &str = "EXO_SERVER_PORT";
 
-pub const EXO_DEPLOYMENT_MODE: &str = "EXO_DEPLOYMENT_MODE"; // "yolo", "dev" or "prod" (default)
+pub const _EXO_DEPLOYMENT_MODE: &str = "_EXO_DEPLOYMENT_MODE"; // "yolo", "dev", "playground" or "prod" (default)
 
 #[derive(Error, Debug)]
 pub enum EnvError {
@@ -31,18 +31,20 @@ pub enum EnvError {
 pub enum DeploymentMode {
     Yolo,
     Dev,
+    Playground,
     Prod,
 }
 
 pub fn get_deployment_mode() -> Result<DeploymentMode, EnvError> {
-    match std::env::var(EXO_DEPLOYMENT_MODE).as_deref() {
+    match std::env::var(_EXO_DEPLOYMENT_MODE).as_deref() {
         Ok("yolo") => Ok(DeploymentMode::Yolo),
         Ok("dev") => Ok(DeploymentMode::Dev),
+        Ok("playground") => Ok(DeploymentMode::Playground),
         Ok("prod") | Err(_) => Ok(DeploymentMode::Prod),
         Ok(other) => Err(EnvError::InvalidEnum {
-            env_key: EXO_DEPLOYMENT_MODE,
+            env_key: _EXO_DEPLOYMENT_MODE,
             env_value: other.to_string(),
-            message: "Must be one of 'yolo', 'dev' or 'prod'".to_string(),
+            message: "Must be one of 'yolo', 'dev', 'playground', or 'prod'".to_string(),
         }),
     }
 }

--- a/crates/deno-subsystem/deno-model-builder/Cargo.toml
+++ b/crates/deno-subsystem/deno-model-builder/Cargo.toml
@@ -11,7 +11,7 @@ core-plugin-interface = { path = "../../core-subsystem/core-plugin-interface" }
 subsystem-model-builder-util = { path = "../../subsystem-util/subsystem-model-builder-util" }
 deno-model = { path = "../deno-model" }
 exo-deno = { path = "../../../libs/exo-deno" }
-url = "2.3.1"
+url.workspace = true
 tokio.workspace = true
 async-trait.workspace = true
 anyhow.workspace = true

--- a/crates/resolver/src/graphiql.rs
+++ b/crates/resolver/src/graphiql.rs
@@ -29,17 +29,7 @@ pub fn get_asset_bytes<P: AsRef<Path>>(file_name: P) -> Option<Vec<u8>> {
                 .contents_utf8()
                 .expect("index.html for playground should be utf8");
             let str = str.replace("%%PLAYGROUND_URL%%", &get_playground_http_path());
-
-            // If the server is running in the playground mode, then use the endpoint URL from the
-            // environment variable (such as "http://<remote-server-address>/graphql"). Otherwise,
-            // use the default endpoint relative path (such as "/graphql").
-            let str = match std::env::var("_EXO_PLAYGROUND_ENDPOINT_URL") {
-                Ok(url) => str.replace("%%ENDPOINT_URL%%", &url),
-                Err(_) => str.replace("%%ENDPOINT_URL%%", &get_endpoint_http_path()),
-            };
-
-            let str = str.replace("%%SCHEMA_URL%%", &get_endpoint_http_path());
-
+            let str = str.replace("%%ENDPOINT_URL%%", &get_endpoint_http_path());
             let str = str.replace(
                 "%%ENABLE_INTROSPECTION_LIVE_UPDATE%%",
                 &enable_introspection_live_update,

--- a/crates/resolver/src/graphiql.rs
+++ b/crates/resolver/src/graphiql.rs
@@ -29,7 +29,17 @@ pub fn get_asset_bytes<P: AsRef<Path>>(file_name: P) -> Option<Vec<u8>> {
                 .contents_utf8()
                 .expect("index.html for playground should be utf8");
             let str = str.replace("%%PLAYGROUND_URL%%", &get_playground_http_path());
-            let str = str.replace("%%ENDPOINT_URL%%", &get_endpoint_http_path());
+
+            // If the server is running in the playground mode, then use the endpoint URL from the
+            // environment variable (such as "http://<remote-server-address>/graphql"). Otherwise,
+            // use the default endpoint relative path (such as "/graphql").
+            let str = match std::env::var("_EXO_PLAYGROUND_ENDPOINT_URL") {
+                Ok(url) => str.replace("%%ENDPOINT_URL%%", &url),
+                Err(_) => str.replace("%%ENDPOINT_URL%%", &get_endpoint_http_path()),
+            };
+
+            let str = str.replace("%%SCHEMA_URL%%", &get_endpoint_http_path());
+
             let str = str.replace(
                 "%%ENABLE_INTROSPECTION_LIVE_UPDATE%%",
                 &enable_introspection_live_update,

--- a/crates/resolver/src/graphiql.rs
+++ b/crates/resolver/src/graphiql.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use common::env_const::EXO_INTROSPECTION_LIVE_UPDATE;
+use common::env_const::{EXO_INTROSPECTION_LIVE_UPDATE, _EXO_UPSTREAM_ENDPOINT_URL};
 use include_dir::{include_dir, Dir};
 use std::path::Path;
 
@@ -30,6 +30,12 @@ pub fn get_asset_bytes<P: AsRef<Path>>(file_name: P) -> Option<Vec<u8>> {
                 .expect("index.html for playground should be utf8");
             let str = str.replace("%%PLAYGROUND_URL%%", &get_playground_http_path());
             let str = str.replace("%%ENDPOINT_URL%%", &get_endpoint_http_path());
+
+            let str = str.replace(
+                "%%UPSTREAM_ENDPOINT_URL%%",
+                &std::env::var(_EXO_UPSTREAM_ENDPOINT_URL).unwrap_or("".to_string()),
+            );
+
             let str = str.replace(
                 "%%ENABLE_INTROSPECTION_LIVE_UPDATE%%",
                 &enable_introspection_live_update,

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -21,4 +21,6 @@ pub use root_resolver::get_endpoint_http_path;
 pub use root_resolver::get_playground_http_path;
 pub use root_resolver::{create_system_resolver, create_system_resolver_or_exit};
 pub use root_resolver::{resolve, resolve_in_memory};
-pub use system_loader::{allow_introspection, LOCAL_ALLOW_INTROSPECTION, LOCAL_ENVIRONMENT};
+pub use system_loader::{
+    introspection_mode, IntrospectionMode, LOCAL_ALLOW_INTROSPECTION, LOCAL_ENVIRONMENT,
+};

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -16,11 +16,11 @@ mod root_resolver;
 mod system_loader;
 
 pub mod graphiql;
-pub use root_resolver::create_system_resolver_from_serialized_bytes;
-pub use root_resolver::get_endpoint_http_path;
-pub use root_resolver::get_playground_http_path;
-pub use root_resolver::{create_system_resolver, create_system_resolver_or_exit};
-pub use root_resolver::{resolve, resolve_in_memory};
+pub use root_resolver::{
+    create_system_resolver, create_system_resolver_from_serialized_bytes,
+    create_system_resolver_or_exit, get_endpoint_http_path, get_playground_http_path, resolve,
+    resolve_in_memory, ResponseStream,
+};
 pub use system_loader::{
     introspection_mode, IntrospectionMode, LOCAL_ALLOW_INTROSPECTION, LOCAL_ENVIRONMENT,
 };

--- a/crates/server-actix/Cargo.toml
+++ b/crates/server-actix/Cargo.toml
@@ -33,6 +33,8 @@ serde_json = { workspace = true, features = ["preserve_order"] }
 futures.workspace = true
 tracing.workspace = true
 tracing-actix-web = "0.7.7"
+url.workspace = true
+reqwest.workspace = true
 resolver = { path = "../resolver" }
 core-resolver = { path = "../core-subsystem/core-resolver" }
 server-common = { path = "../server-common" }

--- a/crates/server-actix/src/lib.rs
+++ b/crates/server-actix/src/lib.rs
@@ -14,9 +14,11 @@ use std::path::Path;
 use actix_web::{
     http::header::{CacheControl, CacheDirective},
     web::{self, Bytes, Redirect, ServiceConfig},
-    Error, HttpRequest, HttpResponse, Responder,
+    Error, HttpRequest, HttpResponse, HttpResponseBuilder, Responder,
 };
+use url::Url;
 
+use common::env_const::{get_deployment_mode, DeploymentMode, _EXO_PLAYGROUND_ENDPOINT_URL};
 use core_resolver::context::{ContextExtractionError, RequestContext};
 use core_resolver::system_resolver::SystemResolver;
 use core_resolver::OperationsPayload;
@@ -35,8 +37,17 @@ pub fn configure_resolver(
 ) -> impl FnOnce(&mut ServiceConfig) {
     let resolve_path = get_endpoint_http_path();
 
+    let endpoint_url = match (
+        std::env::var(_EXO_PLAYGROUND_ENDPOINT_URL),
+        get_deployment_mode(),
+    ) {
+        (Ok(url), Ok(DeploymentMode::Playground)) => Some(Url::parse(&url).unwrap()),
+        _ => None,
+    };
+
     move |app| {
         app.app_data(system_resolver)
+            .app_data(web::Data::new(endpoint_url))
             .service(web::scope(&resolve_path).route("", web::post().to(resolve)));
     }
 }
@@ -57,11 +68,36 @@ pub fn configure_playground(cfg: &mut ServiceConfig) {
         .route("/", web::get().to(playground_redirect));
 }
 
+/// Resolve a GraphQL request
+///
+/// # Arguments
+/// * `endpoint_url` - The target URL for resolving data (None implies that the current server is also the target)
 async fn resolve(
+    http_request: HttpRequest,
+    body: web::Json<Value>,
+    endpoint_url: web::Data<Option<Url>>,
+    system_resolver: web::Data<SystemResolver>,
+) -> impl Responder {
+    match endpoint_url.as_ref() {
+        Some(endpoint_url) => match http_request.headers().get("_exo_operation_kind") {
+            Some(value) if value == "schema_operation" => {
+                // This is a schema fetch request, so solve it locally
+                resolve_locally(http_request, body, system_resolver).await
+            }
+            _ => forward_request(http_request, body, endpoint_url).await,
+        },
+        None => {
+            // We aren't operating in the playground mode, so we can resolve it here
+            resolve_locally(http_request, body, system_resolver).await
+        }
+    }
+}
+
+async fn resolve_locally(
     req: HttpRequest,
     body: web::Json<Value>,
     system_resolver: web::Data<SystemResolver>,
-) -> impl Responder {
+) -> HttpResponse {
     let request = ActixRequest::from_request(req);
     let request_context = RequestContext::new(&request, vec![], system_resolver.as_ref());
 
@@ -108,6 +144,52 @@ async fn resolve(
             base_response
                 .content_type("application/json")
                 .streaming(Box::pin(futures::stream::once(async { error_message })))
+        }
+    }
+}
+
+async fn forward_request(
+    req: HttpRequest,
+    body: web::Json<Value>,
+    forward_url: &Url,
+) -> HttpResponse {
+    let mut forward_url = forward_url.clone();
+    forward_url.set_query(req.uri().query());
+
+    let body = body.into_inner().to_string();
+
+    let forwarded_req = reqwest::Client::default()
+        .request(req.method().clone(), forward_url)
+        .body(body);
+
+    let forwarded_req = req
+        .headers()
+        .iter()
+        .filter(|(h, _)| *h != "origin")
+        .fold(forwarded_req, |forwarded_req, (h, v)| {
+            forwarded_req.header(h.clone(), v.clone())
+        });
+
+    let res = match forwarded_req.send().await {
+        Ok(res) => res,
+        Err(err) => {
+            tracing::error!("Error forwarding request to the endpoint: {}", err);
+            return HttpResponse::InternalServerError()
+                .body(error_msg!("Error forwarding request to the endpoint"));
+        }
+    };
+
+    let mut client_resp = HttpResponseBuilder::new(res.status());
+
+    for (header_name, header_value) in res.headers().iter().filter(|(h, _)| *h != "connection") {
+        client_resp.insert_header((header_name.clone(), header_value.clone()));
+    }
+
+    match res.bytes().await {
+        Ok(bytes) => client_resp.body(bytes),
+        Err(err) => {
+            tracing::error!("Error reading response body from endpoint: {}", err);
+            client_resp.body(error_msg!("Error reading response body from endpoint"))
         }
     }
 }

--- a/crates/server-actix/src/main.rs
+++ b/crates/server-actix/src/main.rs
@@ -78,7 +78,7 @@ async fn main() -> Result<(), ServerError> {
         Ok(host) => server.bind((host, server_port)),
         Err(_) => {
             match get_deployment_mode()? {
-                DeploymentMode::Dev | DeploymentMode::Yolo | DeploymentMode::Playground => {
+                DeploymentMode::Dev | DeploymentMode::Yolo | DeploymentMode::Playground(_) => {
                     // Bind to "localhost" (needed for development). By binding to "localhost" we
                     // bind to both IPv4 and IPv6 loopback addresses ([::1]:9876, 127.0.0.1:9876)
                     //

--- a/crates/testing/src/exotest/integration_tests.rs
+++ b/crates/testing/src/exotest/integration_tests.rs
@@ -20,7 +20,8 @@ use jsonwebtoken::{encode, EncodingKey, Header};
 use rand::{distributions::Alphanumeric, Rng};
 use regex::Regex;
 use resolver::{
-    create_system_resolver, resolve_in_memory, LOCAL_ALLOW_INTROSPECTION, LOCAL_ENVIRONMENT,
+    create_system_resolver, resolve_in_memory, IntrospectionMode, LOCAL_ALLOW_INTROSPECTION,
+    LOCAL_ENVIRONMENT,
 };
 use serde::Serialize;
 use serde_json::{json, Map, Value};
@@ -131,7 +132,7 @@ pub(crate) async fn run_testfile(
                             jwt.borrow_mut().replace(jwtsecret.clone());
 
                             LOCAL_ALLOW_INTROSPECTION.with(|allow| {
-                                allow.borrow_mut().replace(true);
+                                allow.borrow_mut().replace(IntrospectionMode::Enabled);
 
                                 LOCAL_ENVIRONMENT.with(|env| {
                                     env.borrow_mut().replace(extra_envs.clone());

--- a/crates/testing/src/exotest/introspection_tests.rs
+++ b/crates/testing/src/exotest/introspection_tests.rs
@@ -19,7 +19,7 @@ use exo_deno::{
 };
 use exo_sql::{LOCAL_CHECK_CONNECTION_ON_STARTUP, LOCAL_CONNECTION_POOL_SIZE, LOCAL_URL};
 use include_dir::{include_dir, Dir};
-use resolver::{create_system_resolver, LOCAL_ALLOW_INTROSPECTION};
+use resolver::{create_system_resolver, IntrospectionMode, LOCAL_ALLOW_INTROSPECTION};
 use serde_json::Value;
 use std::{collections::HashMap, path::Path};
 
@@ -51,7 +51,7 @@ pub(crate) async fn run_introspection_test(model_path: &Path) -> Result<TestResu
                     pool_size.borrow_mut().replace(1);
 
                     LOCAL_ALLOW_INTROSPECTION.with(|allow| {
-                        allow.borrow_mut().replace(true);
+                        allow.borrow_mut().replace(IntrospectionMode::Enabled);
 
                         LOCAL_CHECK_CONNECTION_ON_STARTUP.with(|check_connection| {
                             check_connection.borrow_mut().replace(false);

--- a/graphiql/public/index.html
+++ b/graphiql/public/index.html
@@ -12,6 +12,7 @@
     <title>Exograph Playground</title>
     <script>
       window.exoGraphQLEndpoint = "%%ENDPOINT_URL%%";
+      window.exoSchemaEndpoint = "%%SCHEMA_URL%%";
       window.enableSchemaLiveUpdate = %%ENABLE_INTROSPECTION_LIVE_UPDATE%%;
       window.exoOidcUrl = "%%OIDC_URL%%";
     </script>

--- a/graphiql/public/index.html
+++ b/graphiql/public/index.html
@@ -12,6 +12,7 @@
     <title>Exograph Playground</title>
     <script>
       window.exoGraphQLEndpoint = "%%ENDPOINT_URL%%";
+      window.exoUpstreamGraphQLEndpoint = "%%UPSTREAM_ENDPOINT_URL%%";
       window.enableSchemaLiveUpdate = %%ENABLE_INTROSPECTION_LIVE_UPDATE%%;
       window.exoOidcUrl = "%%OIDC_URL%%";
     </script>

--- a/graphiql/public/index.html
+++ b/graphiql/public/index.html
@@ -12,7 +12,6 @@
     <title>Exograph Playground</title>
     <script>
       window.exoGraphQLEndpoint = "%%ENDPOINT_URL%%";
-      window.exoSchemaEndpoint = "%%SCHEMA_URL%%";
       window.enableSchemaLiveUpdate = %%ENABLE_INTROSPECTION_LIVE_UPDATE%%;
       window.exoOidcUrl = "%%OIDC_URL%%";
     </script>

--- a/graphiql/src/App.tsx
+++ b/graphiql/src/App.tsx
@@ -135,18 +135,36 @@ function App() {
 }
 
 function Core(props: { schema: GraphQLSchema | null; fetcher: Fetcher }) {
+  const upstreamGraphQLEndpoint = (window as any).exoUpstreamGraphQLEndpoint;
+
   return (
-    <GraphiQL
-      fetcher={props.fetcher}
-      defaultEditorToolsVisibility={true}
-      isHeadersEditorEnabled={true}
-      schema={props.schema}
-      toolbar={{ additionalContent: <AuthToolbarButton /> }}
-    >
-      <GraphiQL.Logo>
-        <Logo />
-      </GraphiQL.Logo>
-    </GraphiQL>
+    <>
+      <GraphiQL
+        fetcher={props.fetcher}
+        defaultEditorToolsVisibility={true}
+        isHeadersEditorEnabled={true}
+        schema={props.schema}
+        toolbar={{ additionalContent: <AuthToolbarButton /> }}
+      >
+        <GraphiQL.Logo>
+          <Logo />
+        </GraphiQL.Logo>
+        {upstreamGraphQLEndpoint && (
+          <GraphiQL.Footer>
+            <div style={{ paddingTop: "5px" }}>
+              <b>Endpoint URL</b>:{" "}
+              <span
+                style={{
+                  color: "hsl(var(--color-primary))",
+                }}
+              >
+                {upstreamGraphQLEndpoint}
+              </span>
+            </div>
+          </GraphiQL.Footer>
+        )}
+      </GraphiQL>
+    </>
   );
 }
 

--- a/graphiql/src/App.tsx
+++ b/graphiql/src/App.tsx
@@ -59,8 +59,15 @@ function App() {
     });
   }, [getTokenFn]);
 
+  const schemaFetcher = useMemo(() => {
+    return createGraphiQLFetcher({
+      url: (window as any).exoSchemaEndpoint,
+      fetch: window.fetch,
+    });
+  }, []);
+
   async function fetchAndSetSchema() {
-    const schema = await fetchSchema(fetcher);
+    const schema = await fetchSchema(schemaFetcher);
 
     // Ignore network errors for 3 consecutive fetches (to avoid failing when the server is restarting during development or the network is flaky)
     if (networkErrorCount.current >= 3) {
@@ -137,7 +144,9 @@ function ErrorMessage(props: {
   return (
     <div className="error-message">
       <div className="error-title">{props.title}</div>
-      {props.message && <div className="error-description">{props.message}</div>}
+      {props.message && (
+        <div className="error-description">{props.message}</div>
+      )}
       {props.children}
     </div>
   );
@@ -162,7 +171,10 @@ function NetworkError() {
       title="Network error"
       message="Please ensure that the server is running."
     >
-      <button className="graphiql-button reload-btn" onClick={() => window.location.reload()}>
+      <button
+        className="graphiql-button reload-btn"
+        onClick={() => window.location.reload()}
+      >
         Reload
       </button>
     </ErrorMessage>
@@ -170,5 +182,7 @@ function NetworkError() {
 }
 
 function Overlay(props: { children: React.ReactNode }) {
-  return <div className="overlay graphiql-dialog-overlay">{props.children}</div>;
+  return (
+    <div className="overlay graphiql-dialog-overlay">{props.children}</div>
+  );
 }

--- a/graphiql/src/App.tsx
+++ b/graphiql/src/App.tsx
@@ -60,9 +60,23 @@ function App() {
   }, [getTokenFn]);
 
   const schemaFetcher = useMemo(() => {
+    const schemaFetch = async (
+      input: RequestInfo | URL,
+      init?: RequestInit | undefined
+    ) => {
+      const headers = {
+        ...init?.headers,
+        // This is a special header that tells the server that the current operation is a schema query
+        // This is used in playground mode to resolve such request locally (and not forward it to the upstream server)
+        _exo_operation_kind: "schema_query",
+      };
+      const withHeader = { ...init, headers };
+      return await window.fetch(input, withHeader);
+    };
+
     return createGraphiQLFetcher({
-      url: (window as any).exoSchemaEndpoint,
-      fetch: window.fetch,
+      url: (window as any).exoGraphQLEndpoint,
+      fetch: schemaFetch,
     });
   }, []);
 


### PR DESCRIPTION
This command support the use case, where a remote exo server doesn't have introspection enabled (which is the default behavior in production model), but the user wants to have a good developer experience with the right schema to execute GraphQL operations against. Here, the schema is fetched from the local server and GraphQL operations are executed against the remote server.