### PR TITLE
Use better defaults for the railway template

### DIFF
--- a/crates/cli/src/commands/deploy/railway.rs
+++ b/crates/cli/src/commands/deploy/railway.rs
@@ -52,37 +52,36 @@ impl CommandDefinition for RailwayCommandDefinition {
 
         println!(
             "{}",
-            "\nPush the repository to a (public or private) repository on GitHub".blue()
+            "\n- Push the repository to a (public or private) repository on GitHub".blue()
         );
         println!(
-            "{}\n",
-            "Create a new project on Railway.app and connect it to the GitHub repository".blue()
+            "{}",
+            "- Create a new project on Railway.app and connect it to the GitHub repository".blue()
         );
 
         if use_railway_db {
             println!(
                 "{}",
-                r#"In the same project, choose "New" and then add a Postgres database"#.blue()
+                r#"- In the same project, choose "New" and then add a Postgres database"#.blue()
             );
             println!(
                 "{}",
-                "Set the following environment variables in Railway.app:".blue()
+                "- Set the following environment variables in Railway.app:".blue()
             );
             println!(
                 "\t{} to point to {}",
-                "DATABASE_URL".blue(),
+                "DATABASE_URL".green(),
                 "${{Postgres.DATABASE_URL}}".yellow()
             );
             println!(
                 "\t{} to point to {}",
-                "DATABASE_PRIVATE_URL".blue(),
+                "DATABASE_PRIVATE_URL".green(),
                 "${{Postgres.DATABASE_PRIVATE_URL}}".yellow()
             );
         } else {
             println!(
                 "{}",
-                "Create a Postgres database and set the following environment variables in Railway.app:"
-                    .blue()
+                "Set the following environment variables in Railway.app:".blue()
             );
             println!(
                 "\t{} to point to {}",
@@ -92,14 +91,17 @@ impl CommandDefinition for RailwayCommandDefinition {
         }
 
         println!(
-            "\n{}",
-            r#"Go to the "Networking" section in the "Settings" tab and click "Generate Domain"."#
-                .blue()
+            "{}",
+            r#"- Go to the "Settings" -> "Networking" and click "Generate Domain"."#.blue()
+        );
+        println!("{}", "- Start Exograph in playground mode".blue());
+        println!(
+            "\t{}",
+            "exo playground --endpoint <the generated domain>/graphql".yellow()
         );
         println!(
             "{}",
-            "Visit the displayed URL, and you will see the familiar Exograph GraphQL playground!"
-                .blue()
+            r#"- Open the playground URL shown and execute GraphQL operations as usual"#.blue()
         );
 
         Ok(())
@@ -131,11 +133,7 @@ fn create_dockerfile(base_dir: &Path, use_railway_db: bool) -> Result<()> {
     let mut dockerfile = File::create(dockerfile_path)?;
     dockerfile.write_all(dockerfile_content.as_bytes())?;
 
-    println!(
-        "{}",
-        "Created Dockerfile.railway file. You may edit this file to customize the deployment such as installing additional dependencies."
-            .green()
-    );
+    println!("{}", "Created Dockerfile.railway file.".green());
 
     Ok(())
 }
@@ -157,10 +155,7 @@ fn create_config_toml(base_dir: &Path) -> Result<()> {
     let config_file_content = RAILWAY_TOML;
     config_file.write_all(config_file_content.as_bytes())?;
 
-    println!(
-        "{}",
-        "Created railway.toml file. You may edit this file to customize the deployment.".green()
-    );
+    println!("{}", "Created railway.toml file.".green());
 
     Ok(())
 }

--- a/crates/cli/src/commands/templates/Dockerfile.railway.external_db
+++ b/crates/cli/src/commands/templates/Dockerfile.railway.external_db
@@ -23,8 +23,6 @@ WORKDIR /app
 COPY --from=builder /app/target/index.exo_ir ./target/index.exo_ir
 
 # Update the following environment variables to match your needs. See the documentation for more information.
-ENV EXO_INTROSPECTION=true 
-ENV EXO_CORS_DOMAINS="*"
 
 # The following defers checking for connection to the database until the first request is received.
 ENV EXO_CHECK_CONNECTION_ON_STARTUP=false

--- a/crates/cli/src/commands/templates/Dockerfile.railway.railway_db
+++ b/crates/cli/src/commands/templates/Dockerfile.railway.railway_db
@@ -23,8 +23,6 @@ WORKDIR /app
 COPY --from=builder /app/target/index.exo_ir ./target/index.exo_ir
 
 # Update the following environment variables to match your needs. See the documentation for more information.
-ENV EXO_INTROSPECTION=true 
-ENV EXO_CORS_DOMAINS="*"
 ENV EXO_POSTGRES_URL=${DATABASE_PRIVATE_URL}?sslmode=disable
 
 # The following defers checking for connection to the database until the first request is received.

--- a/crates/server-actix/src/lib.rs
+++ b/crates/server-actix/src/lib.rs
@@ -162,9 +162,9 @@ async fn forward_request(
     let forwarded_req = req
         .headers()
         .iter()
-        .filter(|(h, _)| *h != "origin")
+        .filter(|(h, _)| *h != "origin" && *h != "connection" && *h != "host")
         .fold(forwarded_req, |forwarded_req, (h, v)| {
-            forwarded_req.header(h.clone(), v.clone())
+            forwarded_req.header(h.as_str(), v.as_bytes())
         });
 
     let res = match forwarded_req.send().await {


### PR DESCRIPTION
Now that we have the playground mode, we can turn off introspection and setting up CORS for the railway template.

Also, fix a bug in forwarding requests to the upstream server in playground mode.