### PR TITLE
Support namespaced NPM packages

### DIFF
--- a/integration-tests/services/npm-module/src/test_ops.ts
+++ b/integration-tests/services/npm-module/src/test_ops.ts
@@ -1,5 +1,9 @@
 import Color from "npm:color"; // CommonJS
 import tinycolor from "npm:tinycolor2"; // ESM
+import { Resend } from "npm:resend"; // Module with namespace (indirectly "@react-email/render")
+
+// Needed to trigger dynamic import
+const resend = new Resend('fake-api-key');
 
 export function lighten_color(color: string): string {
 	const lightened = Color(color).lighten(0.5);


### PR DESCRIPTION
We found an issue while trying the "resend" package, which indirectly uses a namespaced package. This PR fixes that issue and extends a test to cover this case.