### PR TITLE
Explicitly set the builder property in railway.toml

### DIFF
--- a/crates/cli/src/commands/templates/railway.toml
+++ b/crates/cli/src/commands/templates/railway.toml
@@ -1,2 +1,3 @@
 [build]
+builder = "DOCKERFILE"
 dockerfilePath = "Dockerfile.railway"


### PR DESCRIPTION
We observed that sometimes (especially with "railway up") the default (nix) builder is used, which, of course, doesn't work.
 This commit explicitly sets the builder property in railway.toml to use the docker builder.