### PR TITLE
Simplify fly deployment

### DIFF
--- a/crates/cli/src/commands/templates/Dockerfile.fly
+++ b/crates/cli/src/commands/templates/Dockerfile.fly
@@ -1,7 +1,33 @@
+FROM ghcr.io/exograph/cli:latest as builder
+
+WORKDIR /app
+
+COPY ./src ./src
+
+RUN exo build
+
+USER root
+
+# Migrate database. Remove the next line if you want to handle migration separately.
+RUN --mount=type=secret,id=DATABASE_URL \
+  EXO_POSTGRES_URL="$(cat /run/secrets/DATABASE_URL)" exo schema migrate --apply-to-database
+
+# Check that migration brought up the schema to match the model.
+RUN --mount=type=secret,id=DATABASE_URL \
+  EXO_POSTGRES_URL="$(cat /run/secrets/DATABASE_URL)" exo schema verify
+
 FROM ghcr.io/exograph/server:latest
 
-COPY ./target/index.exo_ir ./target/index.exo_ir
+WORKDIR /app
+
+COPY --from=builder /app/target/index.exo_ir ./target/index.exo_ir
+
+# Update the following environment variables to match your needs. See the documentation for more information.
+
+# The following defers checking for connection to the database until the first request is received.
+ENV EXO_CHECK_CONNECTION_ON_STARTUP=false
 
 EXPOSE 8080
 
-CMD ["sh", "-c", "EXO_SERVER_PORT=8080 <<<EXTRA_ENV>>> exo-server"]
+CMD ["sh", "-c", "EXO_SERVER_PORT=8080 EXO_POSTGRES_URL=$DATABASE_URL exo-server"]
+

--- a/crates/cli/src/commands/templates/Dockerfile.fly.builder
+++ b/crates/cli/src/commands/templates/Dockerfile.fly.builder
@@ -1,0 +1,26 @@
+# syntax = docker/dockerfile:1
+
+FROM flyio/flyctl:latest as flyio
+FROM debian:bullseye-slim
+
+RUN apt-get update; apt-get install -y ca-certificates jq
+
+COPY <<"EOF" /srv/deploy.sh
+#!/bin/bash
+deploy=(flyctl deploy)
+touch /srv/.secrets
+
+while read -r secret; do
+  echo "export ${secret}=${!secret}" >> /srv/.secrets
+  deploy+=(--build-secret "${secret}=${!secret}")
+done < <(flyctl secrets list --json | jq -r ".[].Name")
+
+${deploy[@]}
+EOF
+
+RUN chmod +x /srv/deploy.sh
+
+COPY --from=flyio /flyctl /usr/bin
+
+WORKDIR /build
+COPY . .

--- a/crates/cli/src/commands/templates/fly.toml
+++ b/crates/cli/src/commands/templates/fly.toml
@@ -5,7 +5,7 @@ kill_timeout = 5
 processes = []
 
 [build]
-image = "<<<IMAGE_NAME>>>"
+dockerfile = "Dockerfile.fly"
 
 [env]
 <<<ENV_VARS>>>


### PR DESCRIPTION
Instead of building a Docker image locally and pushing it to Fly, we now use the remote builder.

Similar to Railway, we separate the build and and execution stages. In the build stage, we also run migrations.