### PR TITLE
Allow access expression to compare non-option and option types

### DIFF
--- a/crates/builder/src/typechecker/relational_op.rs
+++ b/crates/builder/src/typechecker/relational_op.rs
@@ -54,6 +54,7 @@ impl TypecheckFrom<RelationalOp<Untyped>> for RelationalOp<Typed> {
             let out_updated = if o_typ.is_incomplete() {
                 let left_typ = left.typ().deref(type_env);
                 let right_typ = right.typ().deref(type_env);
+
                 if left_typ.is_complete()
                     && right_typ.is_complete()
                     && type_match(&left_typ, &right_typ)
@@ -96,7 +97,13 @@ impl TypecheckFrom<RelationalOp<Untyped>> for RelationalOp<Typed> {
         };
 
         fn identical_match(left: &Type, right: &Type) -> bool {
-            left == right
+            // Allow optional types to be compared to non-optional types
+            match (left, right) {
+                (Type::Optional(left), Type::Optional(right)) => left == right,
+                (Type::Optional(left), right) => left.as_ref() == right,
+                (left, Type::Optional(right)) => left == right.as_ref(),
+                _ => left == right,
+            }
         }
 
         fn in_relation_match(left: &Type, right: &Type) -> bool {

--- a/integration-tests/access-expressions/src/index.exo
+++ b/integration-tests/access-expressions/src/index.exo
@@ -1,6 +1,7 @@
 context AuthContext {
   @jwt("sub") id: Int 
   @jwt("roles") roles: Array<String> 
+  @jwt("externalId") externalId: Int
 }
 
 @postgres
@@ -41,5 +42,13 @@ module DocumentModule {
     @pk id: Int = autoIncrement()
     content: String
     user: User
+  }
+
+  // To set up a scenario where access control uses an optional field (and compares to a non-optional context field)
+  @access(self.externalId == AuthContext.externalId || "ADMIN" in AuthContext.roles)
+  type ExternalDoc {
+    @pk id: Int = autoIncrement()
+    externalId: Int?
+    content: String
   }
 }

--- a/integration-tests/access-expressions/tests/init-docs.gql
+++ b/integration-tests/access-expressions/tests/init-docs.gql
@@ -32,7 +32,13 @@ operation: |
         }
         adminNotes: createAdminNotes(data: [{content: "n1_user3", user: {id: 3}}, {content: "n2_user4", user: {id: 4}}]) {
             id
-        }                       
+        }
+        externalDoc1: createExternalDoc(data: {content: "externalDoc1", externalId: 1}) {
+            id
+        }
+        externalDoc2: createExternalDoc(data: {content: "externalDoc2", externalId: 2}) {
+            id
+        }                    
     }  
 auth: |
     {

--- a/integration-tests/access-expressions/tests/optional-field-access-control.exotest
+++ b/integration-tests/access-expressions/tests/optional-field-access-control.exotest
@@ -1,0 +1,104 @@
+stages:
+  - operation: |
+      query {
+        externalDocs {
+          id
+          content
+        }
+      }
+    auth: |
+        {
+            "externalId": 1
+        }  
+    response: |
+        {
+          "data": {
+            "externalDocs": [
+              {
+                "id": 1,
+                "content": "externalDoc1"
+              }
+            ]
+          }
+        }
+  - operation: |
+      query {
+        externalDocs {
+          id
+          content
+        }
+      }
+    auth: |
+        {
+            "externalId": 2
+        }  
+    response: |
+        {
+          "data": {
+            "externalDocs": [
+              {
+                "id": 2,
+                "content": "externalDoc2"
+              }
+            ]
+          }
+        }
+  - operation: |
+      query {
+        externalDocs {
+          id
+          content
+        }
+      }
+    auth: |
+        {
+            "externalId": 3
+        }  
+    response: |
+        {
+          "data": {
+            "externalDocs": [
+            ]
+          }
+        }        
+  - operation: |
+      query {
+        externalDocs {
+          id
+          content
+        }
+      }
+    auth: |
+        {
+            "roles": ["ADMIN"]
+        }  
+    response: |
+        {
+          "data": {
+            "externalDocs": [
+              {
+                "id": 1,
+                "content": "externalDoc1"
+              },
+              {
+                "id": 2,
+                "content": "externalDoc2"
+              }
+            ]
+          }
+        }
+  - operation: |
+      query {
+        externalDocs {
+          id
+          content
+        }
+      }
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Not authorized"
+          }
+        ]
+      }


### PR DESCRIPTION
We have been too strict about matching the types of the left and right-hand sides of an access expression. This change relaxes that restriction to allow one of the sides to be an option type (and compare the other side to the inner type of the option).