### PR TITLE
Initialise deno runtime in testing library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7529,6 +7529,7 @@ dependencies = [
  "core-plugin-interface",
  "core-resolver",
  "crossbeam-channel",
+ "deno_core",
  "exo-deno",
  "exo-sql",
  "futures",

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -19,6 +19,7 @@ not_cross = ["exo-deno/not_cross"]
 [dependencies]
 anyhow.workspace = true
 colored.workspace = true
+deno_core.workspace = true
 num_cpus = "1.13.1"
 serde.workspace = true
 jsonwebtoken.workspace = true

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -32,6 +32,7 @@ pub fn run(
     run_introspection_tests: bool,
 ) -> Result<()> {
     let root_directory_str = root_directory.to_str().unwrap();
+    deno_core::JsRuntime::init_platform(None);
 
     println!(
         "{} {} {} {}",


### PR DESCRIPTION
Integration tests still suffer from the deno segfault issue since `exo test` runs multiple tests in parallel and it's not guaranteed the runtime will be initialized in the main thread.

This change calls deno_core::JsRuntime::init_platform in the testing crate before it begins to run the tests, making sure that it is called on the main thread.