### PR TITLE
Use ctor to ensure deno runtime is initialized early in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,6 +1626,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d2b3721e861707777e3195b0158f950ae6dc4a27e4d02ff9f67e3eb3de199e"
+dependencies = [
+ "quote 1.0.32",
+ "syn 2.0.28",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3017,6 +3027,7 @@ name = "exo-deno"
 version = "0.4.2"
 dependencies = [
  "async-trait",
+ "ctor",
  "deno_ast",
  "deno_core",
  "deno_fs",
@@ -7529,6 +7540,7 @@ dependencies = [
  "core-plugin-interface",
  "core-resolver",
  "crossbeam-channel",
+ "ctor",
  "deno_core",
  "exo-deno",
  "exo-sql",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ bytes = "1"
 chrono = { version = "0.4.22", default-features = false, features = ["clock"] }
 codemap = "0.1.3"
 codemap-diagnostic = "0.1.1"
+ctor = "0.2.6"
 deno = { git = "https://github.com/exograph/deno.git", branch = "patched_1_38_5" }
 deno_ast = "0.31.6"
 deno_core = "0.232.0"

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -51,6 +51,7 @@ crossbeam-channel = "0.5.8"
 
 [dev-dependencies]
 insta.workspace = true
+ctor.workspace = true
 
 [build-dependencies]
 which.workspace = true

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -25,6 +25,16 @@ use crate::exotest::common::TestResult;
 use crate::exotest::introspection_tests::run_introspection_test;
 use crate::exotest::loader::ProjectTests;
 
+#[cfg(test)]
+use ctor::ctor;
+
+#[cfg(test)]
+#[ctor]
+// Make sure deno runtime is initialized in the main thread in test executables.
+fn init_deno_runtime() {
+    deno_core::JsRuntime::init_platform(None);
+}
+
 /// Loads test files from the supplied directory and runs them using a thread pool.
 pub fn run(
     root_directory: &PathBuf,

--- a/libs/exo-deno/Cargo.toml
+++ b/libs/exo-deno/Cargo.toml
@@ -37,3 +37,6 @@ serde_json.workspace = true
 tracing.workspace = true
 include_dir.workspace = true
 tempfile.workspace = true
+
+[dev-dependencies]
+ctor.workspace = true

--- a/libs/exo-deno/src/lib.rs
+++ b/libs/exo-deno/src/lib.rs
@@ -26,3 +26,13 @@ mod embedded_module_loader;
 mod typescript_module_loader;
 
 pub use deno_core;
+
+#[cfg(test)]
+use ctor::ctor;
+
+#[cfg(test)]
+#[ctor]
+// Make sure deno runtime is initialized in the main thread in test executables.
+fn init_deno_runtime() {
+    deno_core::JsRuntime::init_platform(None);
+}


### PR DESCRIPTION
When running `cargo test` we still get segfaults due to deno_core issue #247. By using ctor we can initialize the runtime in the lib.rs file when the test configuration is enabled.

This has been added to both the exo-deno and testing crates, which is enough to prevent the crash when running standard rust tests.