### PR TITLE
Support binding variables in integration test auth

### DIFF
--- a/crates/testing/src/exotest/integration_tests.rs
+++ b/crates/testing/src/exotest/integration_tests.rs
@@ -298,7 +298,7 @@ async fn run_operation(
 
             // add JWT token if specified in testfile
             if let Some(auth) = auth {
-                let mut auth = auth.clone();
+                let mut auth = evaluate_using_deno(auth, "", &ctx.testvariables).await?;
                 let auth_ref = auth.as_object_mut().unwrap();
                 let epoch_time = SystemTime::UNIX_EPOCH.elapsed().unwrap().as_secs();
 

--- a/crates/testing/src/exotest/loader.rs
+++ b/crates/testing/src/exotest/loader.rs
@@ -33,7 +33,7 @@ pub enum TestfileOperation {
         variables: Option<String>,        // stringified
         expected_payload: Option<String>, // stringified
         deno_prelude: Option<String>,
-        auth: Option<serde_json::Value>,
+        auth: Option<String>,    // stringified
         headers: Option<String>, // stringified
     },
 }
@@ -292,7 +292,7 @@ Error as a multistage test: {}
             Ok(TestfileOperation::GqlDocument {
                 document: stage.operation,
                 operations_metadata,
-                auth: stage.auth.map(from_json).transpose()?,
+                auth: stage.auth,
                 variables: stage.variable,
                 expected_payload: stage.response,
                 headers: stage.headers,
@@ -332,7 +332,7 @@ fn construct_operation_from_init_file(path: &Path) -> Result<TestfileOperation> 
             Ok(TestfileOperation::GqlDocument {
                 document: deserialized_initfile.operation.clone(),
                 operations_metadata: build_operations_metadata(&gql_document),
-                auth: deserialized_initfile.auth.map(from_json).transpose()?,
+                auth: deserialized_initfile.auth,
                 variables: deserialized_initfile.variable,
                 headers: deserialized_initfile.headers,
                 expected_payload: None,
@@ -343,11 +343,6 @@ fn construct_operation_from_init_file(path: &Path) -> Result<TestfileOperation> 
             bail!("Bad extension")
         }
     }
-}
-
-// Parse JSON from a string
-fn from_json(json: String) -> Result<serde_json::Value> {
-    serde_json::from_str(&json).context("Failed to parse JSON")
 }
 
 // Exograph projects have a src/index.exo file

--- a/crates/testing/src/exotest/testvariable_bindings.rs
+++ b/crates/testing/src/exotest/testvariable_bindings.rs
@@ -235,7 +235,7 @@ pub fn resolve_testvariable(
             [key, path_tail @ ..] => {
                 match base_value {
                     // binding on a pk query (e.g. log(id: 2) {
-                    //    id @(name: "log_id")
+                    //    id @bind(name: "log_id")
                     // })
                     serde_json::Value::Object(obj) => {
                         if let Some(value) = obj.get(key) {

--- a/integration-tests/todo/tests/create-todo-user.exotest
+++ b/integration-tests/todo/tests/create-todo-user.exotest
@@ -15,7 +15,7 @@ stages:
       }
     auth: |
       {
-          "sub": 1,
+          "sub": $.u1Id,
           "role": null
       } 
     response: |
@@ -39,7 +39,7 @@ stages:
       }
     auth: |
       {
-          "sub": 1,
+          "sub": $.u1Id,
           "role": null
       } 
     response: |

--- a/integration-tests/todo/tests/delete-todo-user.exotest
+++ b/integration-tests/todo/tests/delete-todo-user.exotest
@@ -15,7 +15,7 @@ stages:
       }
     auth: |
       {
-          "sub": 1,
+          "sub": $.u1Id,
           "role": null
       } 
     response: |
@@ -44,7 +44,7 @@ stages:
       }
     auth: |
       {
-          "sub": 2,
+          "sub": $.u2Id,
           "role": null
       } 
     response: |

--- a/integration-tests/todo/tests/init.gql
+++ b/integration-tests/todo/tests/init.gql
@@ -3,11 +3,11 @@ operation: |
     mutation {
         u1: createUser(data: {email: "one@example.com", firstName: "F1", lastName: "L1", profileImageUrl: "https://example.com/1.jpg",
                               todos: [{title: "U1-T1", completed: false}, {title: "U1-T2", completed: true}]}) {
-            id
+            id @bind(name: "u1Id")
         }
         u2: createUser(data: {email: "two@example.com", firstName: "F2", lastName: "L2", profileImageUrl: "https://example.com/2.jpg",
                               todos: [{title: "U2-T1", completed: false}, {title: "U2-T2", completed: true}]}) {
-            id
+            id @bind(name: "u2Id")
         }
     }
 auth: |

--- a/integration-tests/todo/tests/update-todo-user.exotest
+++ b/integration-tests/todo/tests/update-todo-user.exotest
@@ -17,7 +17,7 @@ stages:
       }
     auth: |
       {
-          "sub": 1,
+          "sub": $.u1Id,
           "role": null
       } 
     response: |
@@ -47,7 +47,7 @@ stages:
       }
     auth: |
       {
-          "sub": 2,
+          "sub": $.u2Id,
           "role": null
       } 
     response: |
@@ -66,7 +66,7 @@ stages:
       }
     auth: |
       {
-          "sub": 1,
+          "sub": $.u1Id,
           "role": null
       } 
     response: |


### PR DESCRIPTION
This allows us to, for example, use the user ID of a user created in an earlier mutation.

```
    auth: |
      {
          "sub": $.u1Id
      }
```