### PR TITLE
Fix variable binding in named operations

### DIFF
--- a/integration-tests/todo/tests/create-todo-admin.exotest
+++ b/integration-tests/todo/tests/create-todo-admin.exotest
@@ -3,7 +3,7 @@ stages:
   - operation: |
         mutation createTodo($title: String!, $completed: Boolean!, $userId: Int!) {
           createTodo(data: { title: $title, completed: $completed, user: {id: $userId} }) {
-            id
+            id @bind(name: "newTodoId")
             title
             completed
           }
@@ -12,7 +12,7 @@ stages:
       {
         "title": "U1-T3-by-admin",
         "completed": true,
-        "userId": 1
+        "userId": $.u1Id
       }
     auth: |
       {
@@ -40,7 +40,7 @@ stages:
       }
     auth: |
       {
-          "sub": 1,
+          "sub": $.u1Id,
           "role": null
       } 
     response: |
@@ -48,17 +48,17 @@ stages:
         "data": {
           "todos": [
             {
-              "id": 1,
+              "id": $.u1TodoIds[0],
               "title": "U1-T1",
               "completed": false
             },
             {
-              "id": 2,
+              "id": $.u1TodoIds[1],
               "title": "U1-T2",
               "completed": true
             },
             {
-              "id": 5,
+              "id": $.newTodoId,
               "title": "U1-T3-by-admin",
               "completed": true
             }

--- a/integration-tests/todo/tests/create-todo-user.exotest
+++ b/integration-tests/todo/tests/create-todo-user.exotest
@@ -3,7 +3,7 @@ stages:
   - operation: |
         mutation createTodo($title: String!, $completed: Boolean) {
           createTodo(data: { title: $title, completed: $completed }) {
-            id
+            id @bind(name: "newTodoId")
             title
             completed
           }
@@ -47,17 +47,17 @@ stages:
         "data": {
           "todos": [
             {
-              "id": 1,
+              "id": $.u1TodoIds[0],
               "title": "U1-T1",
               "completed": false
             },
             {
-              "id": 2,
+              "id": $.u1TodoIds[1],
               "title": "U1-T2",
               "completed": true
             },
             {
-              "id": 5,
+              "id": $.newTodoId,
               "title": "U1-T3",
               "completed": true
             }

--- a/integration-tests/todo/tests/delete-todo-admin.exotest
+++ b/integration-tests/todo/tests/delete-todo-admin.exotest
@@ -11,7 +11,7 @@ stages:
         }
     variable: |
       {
-        "id": 2
+        "id": $.u1TodoIds[1]
       }
     auth: |
       {
@@ -22,7 +22,7 @@ stages:
       {
         "data": {
           "deleteTodo": {
-            "id": 2,
+            "id": $.u1TodoIds[1],
             "title": "U1-T2",
             "completed": true
           }
@@ -39,7 +39,7 @@ stages:
       }
     auth: |
       {
-          "sub": 1,
+          "sub": $.u1Id,
           "role": null
       } 
     response: |
@@ -47,7 +47,7 @@ stages:
         "data": {
           "todos": [
             {
-              "id": 1,
+              "id": $.u1TodoIds[0],
               "title": "U1-T1",
               "completed": false
             }

--- a/integration-tests/todo/tests/delete-todo-user.exotest
+++ b/integration-tests/todo/tests/delete-todo-user.exotest
@@ -11,7 +11,7 @@ stages:
         }
     variable: |
       {
-        "id": 2
+        "id": $.u1TodoIds[1]
       }
     auth: |
       {
@@ -22,7 +22,7 @@ stages:
       {
         "data": {
           "deleteTodo": {
-            "id": 2,
+            "id": $.u1TodoIds[1],
             "title": "U1-T2",
             "completed": true
           }
@@ -40,7 +40,7 @@ stages:
         }
     variable: |
       {
-        "id": 2
+        "id": $.u1TodoIds[1]
       }
     auth: |
       {
@@ -63,7 +63,7 @@ stages:
       }
     auth: |
       {
-          "sub": 1,
+          "sub": $.u1Id,
           "role": null
       } 
     response: |
@@ -71,7 +71,7 @@ stages:
         "data": {
           "todos": [
             {
-              "id": 1,
+              "id": $.u1TodoIds[0],
               "title": "U1-T1",
               "completed": false
             }

--- a/integration-tests/todo/tests/init.gql
+++ b/integration-tests/todo/tests/init.gql
@@ -4,10 +4,16 @@ operation: |
         u1: createUser(data: {email: "one@example.com", firstName: "F1", lastName: "L1", profileImageUrl: "https://example.com/1.jpg",
                               todos: [{title: "U1-T1", completed: false}, {title: "U1-T2", completed: true}]}) {
             id @bind(name: "u1Id")
+            todos {
+                id @bind(name: "u1TodoIds")
+            }
         }
         u2: createUser(data: {email: "two@example.com", firstName: "F2", lastName: "L2", profileImageUrl: "https://example.com/2.jpg",
                               todos: [{title: "U2-T1", completed: false}, {title: "U2-T2", completed: true}]}) {
             id @bind(name: "u2Id")
+            todos {
+                id @bind(name: "u2TodoIds")
+            }
         }
     }
 auth: |

--- a/integration-tests/todo/tests/update-todo-admin.exotest
+++ b/integration-tests/todo/tests/update-todo-admin.exotest
@@ -10,7 +10,7 @@ stages:
         }
     variable: |
       {
-        "id": 2,
+        "id": $.u1TodoIds[1],
         "title": "U1-T2-updated",
         "completed": true
       }
@@ -23,7 +23,7 @@ stages:
       {
         "data": {
           "updateTodo": {
-            "id": 2,
+            "id": $.u1TodoIds[1],
             "title": "U1-T2-updated",
             "completed": true
           }
@@ -40,7 +40,7 @@ stages:
       }
     auth: |
       {
-          "sub": 1,
+          "sub": $.u1Id,
           "role": null
       } 
     response: |
@@ -48,12 +48,12 @@ stages:
         "data": {
           "todos": [
             {
-              "id": 1,
+              "id": $.u1TodoIds[0],
               "title": "U1-T1",
               "completed": false
             },
             {
-              "id": 2,
+              "id": $.u1TodoIds[1],
               "title": "U1-T2-updated",
               "completed": true
             }

--- a/integration-tests/todo/tests/update-todo-user.exotest
+++ b/integration-tests/todo/tests/update-todo-user.exotest
@@ -11,7 +11,7 @@ stages:
         }
     variable: |
       {
-        "id": 2,
+        "id": $.u1TodoIds[1],
         "title": "U1-T2-updated",
         "completed": true
       }
@@ -24,7 +24,7 @@ stages:
       {
         "data": {
           "updateTodo": {
-            "id": 2,
+            "id": $.u1TodoIds[1],
             "title": "U1-T2-updated",
             "completed": true
           }
@@ -41,7 +41,7 @@ stages:
         }
     variable: |
       {
-        "id": 2,
+        "id": $.u1TodoIds[1],
         "title": "U1-T2-updated",
         "completed": true
       }
@@ -74,12 +74,12 @@ stages:
         "data": {
           "todos": [
             {
-              "id": 1,
+              "id": $.u1TodoIds[0],
               "title": "U1-T1",
               "completed": false
             },
             {
-              "id": 2,
+              "id": $.u1TodoIds[1],
               "title": "U1-T2-updated",
               "completed": true
             }


### PR DESCRIPTION
For named operations, we had an extra path element (the operation's name) during processing binding mapping, which caused the bindings to fail. This commit fixes the issue (and updates an integration test to illustrate).