### PR TITLE
Upgrade actix-cors to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "actix-cors"
-version = "0.6.5"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0346d8c1f762b41b458ed3145eea914966bb9ad20b9be0d6d463b20d45586370"
+checksum = "f9e772b3bcafe335042b5db010ab7c09013dad6eac4915c91d8d50902769f331"
 dependencies = [
  "actix-utils",
  "actix-web",

--- a/crates/server-actix/Cargo.toml
+++ b/crates/server-actix/Cargo.toml
@@ -25,7 +25,7 @@ actix-web = { version = "4.4.1", default-features = false, features = [
   "macros",
   "cookies",
 ] }
-actix-cors = "0.6.5"
+actix-cors = "0.7.0"
 actix-files = "0.6.2"
 thiserror.workspace = true
 


### PR DESCRIPTION
Fixes an issue where not setting `EXO_CORS_DOMAINS` to include the server address resulted in CORS errors in the playground. The fix in 0.7.0 makes this work (see https://github.com/actix/actix-extras/issues/378 for more details).