### PR TITLE
Enable logging in CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,7 +1223,14 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 name = "common"
 version = "0.5.0"
 dependencies = [
+ "opentelemetry 0.21.0",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "thiserror",
+ "tonic",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -6596,18 +6603,12 @@ dependencies = [
 name = "server-common"
 version = "0.5.0"
 dependencies = [
+ "common",
  "core-plugin-interface",
  "core-resolver",
  "deno-resolver",
- "opentelemetry 0.21.0",
- "opentelemetry-otlp",
- "opentelemetry_sdk",
  "postgres-resolver",
  "resolver",
- "tonic",
- "tracing",
- "tracing-opentelemetry",
- "tracing-subscriber",
  "wasm-resolver",
 ]
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -13,6 +13,7 @@ use std::{
 };
 
 use anyhow::Result;
+use common::logging_tracing;
 use tokio::sync::{
     broadcast::{Receiver, Sender},
     Mutex,
@@ -44,6 +45,8 @@ pub static EXIT_ON_SIGINT: AtomicBool = AtomicBool::new(true);
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    logging_tracing::init();
+
     // register a sigint handler
     ctrlc::set_handler(move || {
         // set SIGINT event when receiving signal

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -6,6 +6,21 @@ publish = false
 
 [dependencies]
 thiserror.workspace = true
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
+tracing-opentelemetry = "0.22"
+opentelemetry = { version = "0.21", default-features = false, features = [
+  "trace",
+] }
+opentelemetry_sdk = { version = "0.21", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.14", features = [
+  "reqwest-client",
+  "reqwest-rustls",
+  "http-proto",
+  "tls",
+] }
+# Tonic isn't used directly but we need these flags to establish a TLS connection
+tonic = { version = "0.9", features = ["tls", "tls-roots"] }
 
 [lib]
 doctest = false

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -8,3 +8,4 @@
 // by the Apache License, Version 2.0.
 
 pub mod env_const;
+pub mod logging_tracing;

--- a/crates/common/src/logging_tracing.rs
+++ b/crates/common/src/logging_tracing.rs
@@ -38,13 +38,13 @@
 use std::str::FromStr;
 use tracing_subscriber::{filter::LevelFilter, prelude::*, EnvFilter};
 
-const EXO_LOG: &str = "EXO_LOG";
+pub const EXO_LOG: &str = "EXO_LOG";
 /// Initialize the tracing subscriber.
 ///
 /// Creates a `tracing_subscriber::fmt` layer by default and adds a `tracing_opentelemetry`
 /// layer if OpenTelemetry, exporting traces with `opentelemetry_otlp` if any OpenTelemetry
 /// environment variables are set.
-pub(super) fn init() {
+pub fn init() {
     let fmt_layer = tracing_subscriber::fmt::layer().compact();
     let telemetry_layer =
         create_otlp_tracer().map(|t| tracing_opentelemetry::layer().with_tracer(t));

--- a/crates/common/src/logging_tracing.rs
+++ b/crates/common/src/logging_tracing.rs
@@ -38,7 +38,7 @@
 use std::str::FromStr;
 use tracing_subscriber::{filter::LevelFilter, prelude::*, EnvFilter};
 
-pub const EXO_LOG: &str = "EXO_LOG";
+const EXO_LOG: &str = "EXO_LOG";
 /// Initialize the tracing subscriber.
 ///
 /// Creates a `tracing_subscriber::fmt` layer by default and adds a `tracing_opentelemetry`

--- a/crates/server-common/Cargo.toml
+++ b/crates/server-common/Cargo.toml
@@ -5,22 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
-tracing-opentelemetry = "0.22"
-opentelemetry = { version = "0.21", default-features = false, features = [
-  "trace",
-] }
-opentelemetry_sdk = { version = "0.21", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.14", features = [
-  "reqwest-client",
-  "reqwest-rustls",
-  "http-proto",
-  "tls",
-] }
-# Tonic isn't used directly but we need these flags to establish a TLS connection
-tonic = { version = "0.9", features = ["tls", "tls-roots"] }
-
+common = { path = "../common" }
 resolver = { path = "../resolver" }
 core-resolver = { path = "../core-subsystem/core-resolver" }
 core-plugin-interface = { path = "../core-subsystem/core-plugin-interface" }

--- a/crates/server-common/src/lib.rs
+++ b/crates/server-common/src/lib.rs
@@ -9,12 +9,11 @@
 
 use std::{env, process::exit};
 
+use common::logging_tracing;
 use core_plugin_interface::interface::SubsystemLoader;
 use core_resolver::system_resolver::SystemResolver;
 
 use resolver::create_system_resolver_or_exit;
-
-mod logging_tracing;
 
 /// Initialize the server by:
 /// - Initializing tracing


### PR DESCRIPTION
Earlier, we had logging only in the server, which made dealing with errors (especially during integration tests) difficult.