### PR TITLE
Unset EXO_* envs before running integration tests

### DIFF
--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -54,6 +54,13 @@ impl CommandDefinition for TestCommandDefinition {
             Err(_) => Ok(false),
         }?;
 
+        // Clear all EXO_ env vars before running tests (this way, if the user has set any, they won't affect the tests)
+        for (key, _) in std::env::vars() {
+            if key.starts_with("EXO_") {
+                std::env::remove_var(key);
+            }
+        }
+
         testing::run(&dir, &pattern, run_introspection_tests)
     }
 }


### PR DESCRIPTION
This avoids conflict with envs sourced by the user (for example, through a script).

Specifically, if the user sets `EXO_OIDC_URL`, without this change, there would be a conflict with `EXO_JWT_URL`. "exo test" will set `EXO_JWT_URL` and that will lead to "Configuration error: Invalid setup: Both EXO_JWT_SECRET and EXO_OIDC_URL are set. Only one of them can be set at a time".