### PR TITLE
Make Postgres error messages opaque

### DIFF
--- a/crates/postgres-subsystem/postgres-resolver/src/postgres_execution_error.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/postgres_execution_error.rs
@@ -66,7 +66,7 @@ impl PostgresExecutionError {
             // Do not reveal the underlying database error as it may expose sensitive details (such as column names or data involved in constraint violation).
             _ => {
                 error!("Postgres operation failed: {:?}", self);
-                "Postgres operation failed".to_string()
+                "Operation failed".to_string()
             }
         }
     }

--- a/crates/server-aws-lambda/tests/basic_query.rs
+++ b/crates/server-aws-lambda/tests/basic_query.rs
@@ -23,7 +23,7 @@ async fn test_basic_query() {
             "statusCode": 200,
             "headers": {},
             "multiValueHeaders": {},
-            "body": "{\"errors\": [{\"message\":\"Postgres operation failed\"}]}"
+            "body": "{\"errors\": [{\"message\":\"Operation failed\"}]}"
         }),
     )
     .await

--- a/integration-tests/one-to-one/no-auth/tests/update-uniqueness-violation.exotest
+++ b/integration-tests/one-to-one/no-auth/tests/update-uniqueness-violation.exotest
@@ -13,7 +13,7 @@ response: |
   {
     "errors": [
       {
-        "message": "Postgres operation failed"
+        "message": "Operation failed"
       }
     ]
   }

--- a/integration-tests/one-to-one/with-auth/tests/update-uniqueness-violation-admin.exotest
+++ b/integration-tests/one-to-one/with-auth/tests/update-uniqueness-violation-admin.exotest
@@ -18,7 +18,7 @@ response: |
   {
     "errors": [
       {
-        "message": "Postgres operation failed"
+        "message": "Operation failed"
       }
     ]
   }

--- a/integration-tests/unique/tests/mutation-violate-primary-email-uniqueness.exotest
+++ b/integration-tests/unique/tests/mutation-violate-primary-email-uniqueness.exotest
@@ -20,7 +20,7 @@ response: |
     {
       "errors": [
         {
-            "message": "Postgres operation failed" 
+            "message": "Operation failed" 
         }
       ]
     }

--- a/integration-tests/unique/tests/mutation-violate-rsvp-uniqueness.exotest
+++ b/integration-tests/unique/tests/mutation-violate-rsvp-uniqueness.exotest
@@ -21,7 +21,7 @@ response: |
     {
       "errors": [
         {
-            "message": "Postgres operation failed"
+            "message": "Operation failed"
         }
       ]
     }

--- a/integration-tests/unique/tests/mutation-violate-secondary-email-uniqueness.exotest
+++ b/integration-tests/unique/tests/mutation-violate-secondary-email-uniqueness.exotest
@@ -30,7 +30,7 @@ response: |
     {
       "errors": [
         {
-            "message": "Postgres operation failed",
+            "message": "Operation failed",
         }
       ]
     }

--- a/integration-tests/unique/tests/mutation-violate-username-uniqueness.exotest
+++ b/integration-tests/unique/tests/mutation-violate-username-uniqueness.exotest
@@ -20,7 +20,7 @@ response: |
     {
       "errors": [
         {
-            "message": "Postgres operation failed"
+            "message": "Operation failed"
         }
       ]
     }

--- a/integration-tests/user-specified-pk/tests/create-duplicate-key.exotest
+++ b/integration-tests/user-specified-pk/tests/create-duplicate-key.exotest
@@ -9,7 +9,7 @@ response: |
   {
     "errors": [
       {
-        "message": "Postgres operation failed"
+        "message": "Operation failed"
       }
     ]
   }


### PR DESCRIPTION
Instead of revealing "Postgres operation failed", return "Operation failed".