### PR TITLE
Consider indices only for non-pk columns during migration

### DIFF
--- a/libs/exo-sql/src/schema/table_spec.rs
+++ b/libs/exo-sql/src/schema/table_spec.rs
@@ -141,7 +141,7 @@ impl TableSpec {
         let WithIssues {
             issues: indices_issues,
             value: indices,
-        } = IndexSpec::from_live_db(client, &table_name).await?;
+        } = IndexSpec::from_live_db(client, &table_name, &columns).await?;
         issues.extend(indices_issues);
 
         Ok(WithIssues {


### PR DESCRIPTION
Instead, let the database handle the index creation for primary keys. Otherwise, the diff algorithm will try to drop the index (which will not succeed).