### PR TITLE
Do not consider indexed due to unique constraint

### DIFF
--- a/crates/postgres-subsystem/postgres-model-builder/src/type_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/type_builder.rs
@@ -216,7 +216,6 @@ fn expand_type_no_fields(
                     None => indices.push(PhysicalIndex {
                         name: index_name.clone(),
                         columns: HashSet::from_iter([field.column_name.clone()]),
-                        unique: false,
                     }),
                 }
             })

--- a/libs/exo-sql/src/schema/database_spec.rs
+++ b/libs/exo-sql/src/schema/database_spec.rs
@@ -90,7 +90,6 @@ impl DatabaseSpec {
                 .map(|index_spec| PhysicalIndex {
                     name: index_spec.name.to_owned(),
                     columns: index_spec.columns.to_owned(),
-                    unique: index_spec.is_unique,
                 })
                 .collect();
         }
@@ -174,7 +173,6 @@ impl DatabaseSpec {
                         .map(|index| IndexSpec {
                             name: index.name,
                             columns: index.columns.into_iter().collect(),
-                            is_unique: index.unique,
                         })
                         .collect(),
                 )

--- a/libs/exo-sql/src/sql/physical_table.rs
+++ b/libs/exo-sql/src/sql/physical_table.rs
@@ -76,7 +76,6 @@ pub struct PhysicalTable {
 pub struct PhysicalIndex {
     pub name: String,
     pub columns: HashSet<String>,
-    pub unique: bool,
 }
 
 /// The derived implementation of `Debug` is quite verbose, so we implement it manually


### PR DESCRIPTION
Setting up a unique constraint leads to a unique index on those columns, so we don't need to do it ourselves. Fixes a migration issue where the new schema (correctly) doesn't add an index, but reconstructing schema from a real database considers that to be an index. So this leads to an attempt to drop such an index, which fails the migration.