### PR TITLE
Add to test to ensure multi-mutation transactions

### DIFF
--- a/integration-tests/transaction-rollbacks/src/index.exo
+++ b/integration-tests/transaction-rollbacks/src/index.exo
@@ -17,4 +17,7 @@ module RegistrationModule {
         username: String,
         email: String
     ): Boolean
+
+    @access(true)
+    export mutation fail(): Boolean
 }

--- a/integration-tests/transaction-rollbacks/src/user.ts
+++ b/integration-tests/transaction-rollbacks/src/user.ts
@@ -31,3 +31,7 @@ export async function registerUser(exograph: any, username: string, email: strin
     // as the user's request failed, all changes should be rolled back from the database at this point
 
 }
+
+export function fail() {
+    throw new Error("always fails");
+}

--- a/integration-tests/transaction-rollbacks/tests/multi-mutation-rollback.exotest
+++ b/integration-tests/transaction-rollbacks/tests/multi-mutation-rollback.exotest
@@ -20,7 +20,7 @@ stages:
           ]
         }
     
-    # check to make sure queries have been rolled back
+    # ensure mutations have been rolled back
     - operation: |
         query {
             users {

--- a/integration-tests/transaction-rollbacks/tests/multi-mutation-rollback.exotest
+++ b/integration-tests/transaction-rollbacks/tests/multi-mutation-rollback.exotest
@@ -1,0 +1,35 @@
+stages:
+    # attempt to create
+    - operation: |
+        mutation {
+            u1: createUser(data: {username: "u1", email: "u1.example.com"}) {
+                id
+            }
+            u2: createUser(data: {username: "u2", email: "u2.example.com"}) {
+                id
+            }
+            # The next one always fails
+            fail
+        }
+      response: |
+        {
+          "errors": [
+            {
+              "message": "Internal server error"
+            }
+          ]
+        }
+    
+    # check to make sure queries have been rolled back
+    - operation: |
+        query {
+            users {
+                id
+            }
+        }
+      response: |
+        {
+            "data": {
+                "users": []
+            }
+        }

--- a/integration-tests/transaction-rollbacks/tests/rollback.exotest
+++ b/integration-tests/transaction-rollbacks/tests/rollback.exotest
@@ -18,7 +18,7 @@ stages:
           ]
         }
     
-    # check to make sure queries have been rolled back
+    # ensure mutations have been rolled back
     - operation: |
         query {
             users {


### PR DESCRIPTION
The test ensures that when we execute a multi-mutation operation, Exograph executes them in a transaction, and if any of the mutations fail, it rolls back the entire transaction.

We have another test (transaction-rollbacks/rollback) along the same lines, but that involves executing multiple mutations from a Deno function. This test targets directly called mutations.

Fixes #388