### PR TITLE
fix: fix ExographError usage error

### DIFF
--- a/deno-publish/index.ts
+++ b/deno-publish/index.ts
@@ -50,6 +50,8 @@ export interface Operation {
   query(): Field;
 }
 
-export declare class ExographError extends Error {
-  constructor(message: string);
+declare global {
+  class ExographError extends Error {
+    constructor(message: string);
+  }
 }


### PR DESCRIPTION
This PR fixes https://github.com/exograph/exograph/issues/807. 

Since the JS definition for `ExographError` is automatically provided to the DenoModule at runtime, it should actually be declared as a global. This way it can be used directly without an explicit import, which matches how its defined too.

Did not see another PR for this, feel free to close if theres already another one.