### PR TITLE
Fix the persistence of headers in playground

### DIFF
--- a/graphiql/src/App.tsx
+++ b/graphiql/src/App.tsx
@@ -137,6 +137,11 @@ function App() {
 function Core(props: { schema: GraphQLSchema | null; fetcher: Fetcher }) {
   const upstreamGraphQLEndpoint = (window as any).exoUpstreamGraphQLEndpoint;
 
+  // GraphiQL loses the persisted headers when the schema is updated (or the playground is manually
+  // reloaded) So, use the current value of the setting in local storage as the initial value
+  const shouldPersistHeaders =
+    localStorage.getItem("graphiql:shouldPersistHeaders") === "true";
+
   return (
     <>
       <GraphiQL
@@ -145,6 +150,8 @@ function Core(props: { schema: GraphQLSchema | null; fetcher: Fetcher }) {
         isHeadersEditorEnabled={true}
         schema={props.schema}
         toolbar={{ additionalContent: <AuthToolbarButton /> }}
+        shouldPersistHeaders={shouldPersistHeaders}
+        showPersistHeadersSettings={true}
       >
         <GraphiQL.Logo>
           <Logo />


### PR DESCRIPTION
GraphiQL interface resets the value of "shouldPersistHeaders" to `false` upon refreshing the browser (see https://github.com/graphql/graphiql/issues/3369). As a result, on a second refresh, the header value is lost.

The fix reads the value of the `localStorage` key `graphiql:shouldPersistHeaders` and passes that value to the `shouldPersistHeaders` prop of the GraphiQL component.

This change has an unwanted side-effect of creating new tabs if:
- The user has provided a header value
- The user refreshes the browser

See https://github.com/graphql/graphiql/issues/2825 for more details. However, we don't observe the "new tabs" behavior when the UI refreshes automatically on "exo yolo" or "exo dev", so this is still an overall improvement for the typical user of Exograph.

When the mentioned issues are fixed, we should be able to revert this change.