### PR TITLE
feat: improve typing for query execution

### DIFF
--- a/deno-publish/index.ts
+++ b/deno-publish/index.ts
@@ -39,6 +39,11 @@ export interface Exograph {
 export type ContextOverride = Record<string, any> | undefined;
 
 export interface ExographPriv extends Exograph {
+  executeQueryPriv<T = any>(query: string): Promise<T>;
+  executeQueryPriv<
+    T = any, 
+    V extends AnyVariables = AnyVariables
+  >(query: string, variables: V): Promise<T>;
   executeQueryPriv<
     T = any, 
     V extends AnyVariables = AnyVariables, 

--- a/deno-publish/index.ts
+++ b/deno-publish/index.ts
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 
+export type AnyVariables = Record<string, any> | undefined;
+
 export interface Exograph {
-  executeQuery(query: string, variable?: { [key: string]: any }): Promise<any>;
+  executeQuery<T = any>(query: string): Promise<T>;
+  executeQuery<T = any, V extends AnyVariables = AnyVariables>(
+    query: string,
+    variables: V
+  ): Promise<T>;
   addResponseHeader(name: string, value: string): Promise<void>;
   setCookie(cookie: {
     name: string,
@@ -30,8 +36,14 @@ export interface Exograph {
   }): Promise<void>;
 }
 
+export type ContextOverride = Record<string, any> | undefined;
+
 export interface ExographPriv extends Exograph {
-  executeQueryPriv(query: string, variable?: { [key: string]: any }, contextOverride?: { [key: string]: any }): Promise<any>;
+  executeQueryPriv<
+    T = any, 
+    V extends AnyVariables = AnyVariables, 
+    C extends ContextOverride = ContextOverride
+  >(query: string, variables: V, contextOverride: C): Promise<T>;
 }
 
 export type JsonObject = { [Key in string]?: JsonValue };


### PR DESCRIPTION
This PR improves the typing for the `executeQuery` and `executeQueryPriv` methods. It adds optional type parameters to enable well-typed queries and responses. Allowing the methods to be used like:

```ts
import type { Exograph } from "../generated/exograph-modified.d.ts";

interface VenuesQuery {
  venues: Array<{ name: string }>;
}

interface VenuesQueryVariables {
  param: string;
}

const venuesDocument = /* GraphQL */ `
query venues($param: String!) {
	venues(where: {name: {eq: $param}}) {
		 name
	}
}
`;

export async function process(exograph: Exograph): Promise<string> {
  const venues = await exograph.executeQuery<VenuesQuery, VenuesQueryVariables>(
    venuesDocument,
    {
      param: "Foo",
      // wrongParam: 'value' - Error: Object literal may only specify known properties
    },
  );

  // venues.venues.map(v => v.nonExistent).join(','); - Error: Property 'nonExistent' does not exist

  return venues.venues.map((v) => v.name).join(",");
}
```

You can also pair it with tools like [GraphQL Codegen](https://the-guild.dev/graphql/codegen) to automatically generate the types for your graphql queries based on the schema served by Exograph:

```ts
import type { Exograph } from "../generated/exograph-modified.d.ts"
import { VenuesQuery, VenuesQueryVariables } from "../generated/graphql.d.ts";

const venuesDocument = /* GraphQL */ `
query venues($param: String!) {
	venues(where: {name: {eq: $param}}) {
		 name
	}
}
`;

export async function process(exograph: Exograph): Promise<string> {
  const venues = await exograph.executeQuery<VenuesQuery, VenuesQueryVariables>(
    venuesDocument,
    {
      param: "Foo",
      // wrongParam: 'value' - Error: Object literal may only specify known properties
    },
  );

  // venues.venues.map(v => v.nonExistent).join(','); - Error: Property 'nonExistent' does not exist

  return venues.venues.map((v) => v.name).join(",");
}
```

This is helpful for a large project with a lot of deno modules, where Typescript can help you find issues with your queries, especially if you change the underlying schema and the queries need to be updated.