### PR TITLE
Namespace unique constraint per type

### DIFF
--- a/crates/cli/src/commands/schema/migration.rs
+++ b/crates/cli/src/commands/schema/migration.rs
@@ -1013,16 +1013,16 @@ mod tests {
                     false,
                 ),
                 (
-                    r#"ALTER TABLE "rsvps" ADD CONSTRAINT "email_event_id" UNIQUE ("email", "event_id");"#,
+                    r#"ALTER TABLE "rsvps" ADD CONSTRAINT "unique_constraint_rsvp_email_event_id" UNIQUE ("email", "event_id");"#,
                     false,
                 ),
             ],
             vec![(
-                r#"ALTER TABLE "rsvps" ADD CONSTRAINT "email_event_id" UNIQUE ("email", "event_id");"#,
+                r#"ALTER TABLE "rsvps" ADD CONSTRAINT "unique_constraint_rsvp_email_event_id" UNIQUE ("email", "event_id");"#,
                 false,
             )],
             vec![(
-                r#"ALTER TABLE "rsvps" DROP CONSTRAINT "email_event_id";"#,
+                r#"ALTER TABLE "rsvps" DROP CONSTRAINT "unique_constraint_rsvp_email_event_id";"#,
                 false,
             )],
         ).await
@@ -1061,7 +1061,7 @@ mod tests {
                     false,
                 ),
                 (
-                    r#"ALTER TABLE "rsvps" ADD CONSTRAINT "email_event_id" UNIQUE ("email");"#,
+                    r#"ALTER TABLE "rsvps" ADD CONSTRAINT "unique_constraint_rsvp_email_event_id" UNIQUE ("email");"#,
                     false,
                 ),
             ],
@@ -1075,27 +1075,27 @@ mod tests {
                     false,
                 ),
                 (
-                    r#"ALTER TABLE "rsvps" ADD CONSTRAINT "email_event_id" UNIQUE ("email", "event_id");"#,
+                    r#"ALTER TABLE "rsvps" ADD CONSTRAINT "unique_constraint_rsvp_email_event_id" UNIQUE ("email", "event_id");"#,
                     false,
                 ),
             ],
             vec![
                 (
-                    r#"ALTER TABLE "rsvps" DROP CONSTRAINT "email_event_id";"#,
+                    r#"ALTER TABLE "rsvps" DROP CONSTRAINT "unique_constraint_rsvp_email_event_id";"#,
                     false,
                 ),
                 (
-                    r#"ALTER TABLE "rsvps" ADD CONSTRAINT "email_event_id" UNIQUE ("email", "event_id");"#,
+                    r#"ALTER TABLE "rsvps" ADD CONSTRAINT "unique_constraint_rsvp_email_event_id" UNIQUE ("email", "event_id");"#,
                     false,
                 ),
             ],
             vec![
                 (
-                    r#"ALTER TABLE "rsvps" DROP CONSTRAINT "email_event_id";"#,
+                    r#"ALTER TABLE "rsvps" DROP CONSTRAINT "unique_constraint_rsvp_email_event_id";"#,
                     false,
                 ),
                 (
-                    r#"ALTER TABLE "rsvps" ADD CONSTRAINT "email_event_id" UNIQUE ("email");"#,
+                    r#"ALTER TABLE "rsvps" ADD CONSTRAINT "unique_constraint_rsvp_email_event_id" UNIQUE ("email");"#,
                     false,
                 ),
             ],

--- a/crates/postgres-subsystem/postgres-model-builder/src/resolved_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/resolved_builder.rs
@@ -661,9 +661,6 @@ fn compute_column_info(
             },
         };
 
-        let unique_constraint_computed_name =
-            format!("unique_constraint_{}_{}", enclosing_type.name, field.name)
-                .to_ascii_lowercase();
         let unique_constraints = field
             .annotations
             .get("unique")
@@ -673,7 +670,7 @@ fn compute_column_info(
                     AstExpr::StringList(string_list, _) => string_list.clone(),
                     _ => panic!("Not a string nor a string list when specifying unique"),
                 },
-                AstAnnotationParams::None => vec![unique_constraint_computed_name.clone()],
+                AstAnnotationParams::None => vec![field.name.clone()],
                 AstAnnotationParams::Map(_, _) => panic!(),
             })
             .unwrap_or_default();
@@ -778,7 +775,8 @@ fn compute_column_info(
                             _ => {
                                 let unique_constraints =
                                     if matches!(cardinality, Cardinality::ZeroOrOne) {
-                                        vec![unique_constraint_computed_name]
+                                        // Add an explicit unique constraint to enforce one-to-one constraint
+                                        vec![field.name.clone()]
                                     } else {
                                         unique_constraints
                                     };

--- a/integration-tests/unique/src/index.exo
+++ b/integration-tests/unique/src/index.exo
@@ -3,17 +3,18 @@ module RsvpModule {
   @access(true)
   type Rsvp {
     @pk id: Int = autoIncrement()
-    @unique("one_rsvp_per_user") event: String 
-    @unique("one_rsvp_per_user")  user: User 
+    @unique("event_rsvp") event: String 
+    @unique("event_rsvp")  user: User
+    count: Int = 1
   }
 
   @access(true)
   type User {
     @pk id: Int = autoIncrement()
     @unique username: String 
-    @unique("unique_email_primary") primary_email_id: String 
-    @unique("unique_email_secondary") secondary_email_id: String? 
-    @unique("unique_email_primary", "unique_email_secondary") email_domain: String 
+    @unique("primary_email") primaryEmailId: String 
+    @unique("secondary_email") secondaryEmailId: String? 
+    @unique("primary_email", "secondary_email") emailDomain: String 
 
     rsvps: Set<Rsvp>?
   }

--- a/integration-tests/unique/src/index.exo
+++ b/integration-tests/unique/src/index.exo
@@ -3,8 +3,9 @@ module RsvpModule {
   @access(true)
   type Rsvp {
     @pk id: Int = autoIncrement()
-    @unique("event_rsvp") event: String 
-    @unique("event_rsvp")  user: User
+    // Use camelCase for unique constraint name to ensure dealing with either camelCase (here) or snake_case (in `User`)
+    @unique("eventRsvp") event: String
+    @unique("eventRsvp")  user: User
     count: Int = 1
   }
 
@@ -17,5 +18,15 @@ module RsvpModule {
     @unique("primary_email", "secondary_email") emailDomain: String 
 
     rsvps: Set<Rsvp>?
+    InternalRsvps: Set<InternalRsvp>?
+  }
+
+  @access(true)
+  type InternalRsvp {
+    @pk id: Int = autoIncrement()
+    // Use the same name for unique constraint as in `Rsvp` to test for correct handling of using type names for namespacing
+    @unique("eventRsvp") event: String
+    @unique("eventRsvp")  user: User
+    count: Int = 1
   }
 }

--- a/integration-tests/unique/tests/init-user.gql
+++ b/integration-tests/unique/tests/init-user.gql
@@ -1,16 +1,16 @@
 operation: |
     mutation(
         $username: String!, 
-        $primary_email_id: String!,
-        $secondary_email_id: String!
-        $email_domain: String!,
+        $primaryEmailId: String!,
+        $secondaryEmailId: String!
+        $emailDomain: String!,
         $initial_event_rsvp: String!
     ) {
         createUser(data: {
             username: $username,
-            primary_email_id: $primary_email_id,
-            secondary_email_id: $secondary_email_id,
-            email_domain: $email_domain
+            primaryEmailId: $primaryEmailId,
+            secondaryEmailId: $secondaryEmailId,
+            emailDomain: $emailDomain
             rsvps: [
                 { event: $initial_event_rsvp }
             ]
@@ -23,11 +23,11 @@ variable: |
         "username": "Alice02",
 
         // alice@example.com
-        "primary_email_id": "alice",
+        "primaryEmailId": "alice",
 
         // alice2@example.com
-        "secondary_email_id": "alice2",
+        "secondaryEmailId": "alice2",
 
-        "email_domain": "example.com",
+        "emailDomain": "example.com",
         "initial_event_rsvp": "Concert1"
     }

--- a/integration-tests/unique/tests/mutation-normal-insert.exotest
+++ b/integration-tests/unique/tests/mutation-normal-insert.exotest
@@ -1,9 +1,9 @@
 operation: |
-    mutation($new_username: String!, $new_email_id: String!, $new_email_domain: String!) {
+    mutation($new_username: String!, $new_email_id: String!, $new_emailDomain: String!) {
         createUser(data: {
             username: $new_username,
-            primary_email_id: $new_email_id,
-            email_domain: $new_email_domain,
+            primaryEmailId: $new_email_id,
+            emailDomain: $new_emailDomain,
             rsvps: [
                 {
                     event: "Concert2"
@@ -22,7 +22,7 @@ variable: |
 
         // bob@example.com
         "new_email_id": "bob",
-        "new_email_domain": "example.com"
+        "new_emailDomain": "example.com"
     }
 response: |
     {

--- a/integration-tests/unique/tests/mutation-violate-primary-email-uniqueness.exotest
+++ b/integration-tests/unique/tests/mutation-violate-primary-email-uniqueness.exotest
@@ -1,9 +1,9 @@
 operation: |
-    mutation($new_username: String!, $new_email_id: String!, $new_email_domain: String!) {
+    mutation($new_username: String!, $new_email_id: String!, $new_emailDomain: String!) {
         createUser(data: {
             username: $new_username,
-            primary_email_id: $new_email_id,
-            email_domain: $new_email_domain
+            primaryEmailId: $new_email_id,
+            emailDomain: $new_emailDomain
         }) {
             id
         }
@@ -14,7 +14,7 @@ variable: |
 
         // alice@example.com
         "new_email_id": "alice",
-        "new_email_domain": "example.com"
+        "new_emailDomain": "example.com"
     }
 response: |
     {

--- a/integration-tests/unique/tests/mutation-violate-rsvp-uniqueness.exotest
+++ b/integration-tests/unique/tests/mutation-violate-rsvp-uniqueness.exotest
@@ -1,9 +1,9 @@
 operation: |
-    mutation($new_username: String!, $new_email_id: String!, $new_email_domain: String!) {
+    mutation($new_username: String!, $new_email_id: String!, $new_emailDomain: String!) {
         createUser(data: {
             username: $new_username,
-            primary_email_id: $new_email_id,
-            email_domain: $new_email_domain
+            primaryEmailId: $new_email_id,
+            emailDomain: $new_emailDomain
             rsvps: [ { event: "Concert2" }, { event: "Concert2" } ]
         }) {
             id
@@ -15,7 +15,7 @@ variable: |
 
         // bob@example.com
         "new_email_id": "bob",
-        "new_email_domain": "example.com"
+        "new_emailDomain": "example.com"
     }
 response: |
     {

--- a/integration-tests/unique/tests/mutation-violate-secondary-email-uniqueness.exotest
+++ b/integration-tests/unique/tests/mutation-violate-secondary-email-uniqueness.exotest
@@ -1,15 +1,15 @@
 operation: |
     mutation(
         $new_username: String!, 
-        $new_primary_email_id: String!, 
-        $new_secondary_email_id: String!,
-        $new_email_domain: String!
+        $new_primaryEmailId: String!, 
+        $new_secondaryEmailId: String!,
+        $new_emailDomain: String!
     ) {
         createUser(data: {
             username: $new_username,
-            primary_email_id: $new_primary_email_id
-            secondary_email_id: $new_secondary_email_id,
-            email_domain: $new_email_domain
+            primaryEmailId: $new_primaryEmailId
+            secondaryEmailId: $new_secondaryEmailId,
+            emailDomain: $new_emailDomain
         }) {
             id
         }
@@ -19,12 +19,12 @@ variable: |
         "new_username": "Bob04",
 
         // bob@example.com
-        "new_primary_email_id": "bob",
+        "new_primaryEmailId": "bob",
 
         // alice2@example.com
-        "new_secondary_email_id": "alice2",
+        "new_secondaryEmailId": "alice2",
 
-        "new_email_domain": "example.com"
+        "new_emailDomain": "example.com"
     }
 response: |
     {

--- a/integration-tests/unique/tests/mutation-violate-username-uniqueness.exotest
+++ b/integration-tests/unique/tests/mutation-violate-username-uniqueness.exotest
@@ -1,9 +1,9 @@
 operation: |
-    mutation($new_username: String!, $new_email_id: String!, $new_email_domain: String!) {
+    mutation($new_username: String!, $new_email_id: String!, $new_emailDomain: String!) {
         createUser(data: {
             username: $new_username,
-            primary_email_id: $new_email_id,
-            email_domain: $new_email_domain
+            primaryEmailId: $new_email_id,
+            emailDomain: $new_emailDomain
         }) {
             id
         }
@@ -14,7 +14,7 @@ variable: |
 
         // another.alice@example.com
         "new_email_id": "another.alice",
-        "new_email_domain": "example.com"
+        "new_emailDomain": "example.com"
     }
 response: |
     {


### PR DESCRIPTION
Earlier, we assumed the unique names (to the `unique()` annotations) to be globally unique, which is overly restrictive (and will interfere with a solution for #945). This change namespaces each name with the type name.

With this change, the following is now valid:

```exo
@postgres
module RsvpModule {
  type Rsvp {
    ...
    @unique("eventRsvp") event: String
    @unique("eventRsvp")  user: User
    count: Int = 1
  }

  type InternalRsvp {
    ...
    @unique("eventRsvp") event: String
    @unique("eventRsvp")  user: User
  }

  ...
}
```