### PR TITLE
Allow update mutations to pass null for optional relations

### DIFF
--- a/integration-tests/optional-relation/src/index.exo
+++ b/integration-tests/optional-relation/src/index.exo
@@ -1,0 +1,18 @@
+// Notification has an optional event
+@postgres
+module NotificationDatabase {
+  @access(true)
+  type Notification {
+    @pk id: Int = autoIncrement()
+    title: String
+    description: String
+    event: Event?
+  }
+
+  @access(true)
+  type Event {
+    @pk id: Int = autoIncrement()
+    title: String
+    notifications: Set<Notification>?
+  }
+}

--- a/integration-tests/optional-relation/tests/init.gql
+++ b/integration-tests/optional-relation/tests/init.gql
@@ -1,0 +1,24 @@
+stages:
+    - operation: |
+        mutation {
+            e1: createEvent(data: {title: "E1"}) {
+                id @bind(name: "e1Id")
+            }
+            e2: createEvent(data: {title: "E2"}) {
+                id @bind(name: "e2Id")
+            }
+        }
+    - operation: |
+        mutation($e1Id: Int!, $e2Id: Int!) {
+            n1: createNotification(data: {title: "N1", description: "N1-desc", event: {id: $e1Id}}) {
+                id @bind(name: "n1id")
+            }
+            n2: createNotification(data: {title: "N2", description: "N2-desc", event: {id: $e2Id}}) {
+                id @bind(name: "n2id")
+            }
+        }  
+      variable: |
+        {
+            "e1Id": $.e1Id,
+            "e2Id": $.e2Id
+        }      

--- a/integration-tests/optional-relation/tests/reset-relation.exotest
+++ b/integration-tests/optional-relation/tests/reset-relation.exotest
@@ -1,0 +1,52 @@
+stages:
+  - operation: |
+      mutation resetEvent($eId: Int!) {
+          updateNotification(id: $eId, data: {title: "N1-updated", event: null}) {
+            id
+            event
+          }
+      }
+    variable: |
+      {
+          "eId": $.e1Id,
+      }   
+    response: |
+      {
+        "data": {
+          "updateNotification": {
+            "id": 1,
+            "event": null
+          }
+        }
+      }
+  - operation: |
+      query {
+          notifications @unordered {
+            id
+            title
+            event {
+              id
+              title
+            }
+          }
+      }  
+    response: |
+      {
+        "data": {
+          "notifications": [
+            {
+              "id": $.n1id,
+              "title": "N1-updated",
+              "event": null
+            },
+            {
+              "id": $.n2id,
+              "title": "N2",
+              "event": {
+                "id": $.e2Id,
+                "title": "E2"
+              }
+            }
+          ]
+        }
+      }


### PR DESCRIPTION
This makes it possible to reset an optional relation with an update mutation:

```graphql
mutation resetEvent {
  updateNotification(id: 1, data: {title: "N1-updated", event: null}) {
    id
    event
  }
}
```