### PR TITLE
Support queries by unique fields

### DIFF
--- a/crates/postgres-subsystem/postgres-model-builder/src/builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/builder.rs
@@ -20,7 +20,6 @@ use crate::shallow::Shallow;
 use super::{
     resolved_builder::{ResolvedCompositeType, ResolvedType},
     system_builder::SystemContextBuilding,
-    type_builder::ResolvedTypeEnv,
 };
 
 // TODO: Ensure it works for all builders (this one makes the assumption that it is building only input types)
@@ -73,7 +72,6 @@ pub trait Builder {
 
     fn build_expanded(
         &self,
-        resolved_env: &ResolvedTypeEnv,
         building: &mut SystemContextBuilding,
     ) -> Result<(), ModelBuildingError>;
 }

--- a/crates/postgres-subsystem/postgres-model-builder/src/create_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/create_mutation_builder.rs
@@ -32,7 +32,6 @@ use super::{
     naming::{ToPostgresMutationNames, ToPostgresTypeNames},
     resolved_builder::{ResolvedCompositeType, ResolvedType},
     system_builder::SystemContextBuilding,
-    type_builder::ResolvedTypeEnv,
 };
 
 pub struct CreateMutationBuilder;
@@ -53,7 +52,6 @@ impl Builder for CreateMutationBuilder {
 
     fn build_expanded(
         &self,
-        resolved_env: &ResolvedTypeEnv,
         building: &mut SystemContextBuilding,
     ) -> Result<(), ModelBuildingError> {
         let creation_access_is_false = |entity_type: &EntityType| -> bool {
@@ -65,14 +63,9 @@ impl Builder for CreateMutationBuilder {
 
         for (_, entity_type) in building.entity_types.iter() {
             if !creation_access_is_false(entity_type) {
-                for (existing_id, expanded_type) in self.expanded_data_type(
-                    entity_type,
-                    resolved_env,
-                    building,
-                    Some(entity_type),
-                    None,
-                    false,
-                )? {
+                for (existing_id, expanded_type) in
+                    self.expanded_data_type(entity_type, building, Some(entity_type), None, false)?
+                {
                     building.mutation_types[existing_id] = expanded_type;
                 }
             }

--- a/crates/postgres-subsystem/postgres-model-builder/src/delete_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/delete_mutation_builder.rs
@@ -28,7 +28,6 @@ use super::{
     query_builder,
     resolved_builder::{ResolvedCompositeType, ResolvedType},
     system_builder::SystemContextBuilding,
-    type_builder::ResolvedTypeEnv,
 };
 
 pub struct DeleteMutationBuilder;
@@ -46,7 +45,6 @@ impl Builder for DeleteMutationBuilder {
     /// Expand the mutation input types as well as build the mutation
     fn build_expanded(
         &self,
-        _resolved_env: &ResolvedTypeEnv,
         building: &mut SystemContextBuilding,
     ) -> Result<(), ModelBuildingError> {
         // Since there are no special input types for deletion, no expansion is needed

--- a/crates/postgres-subsystem/postgres-model-builder/src/mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/mutation_builder.rs
@@ -44,7 +44,6 @@ use super::{
     reference_input_type_builder::ReferenceInputTypeBuilder,
     resolved_builder::{ResolvedCompositeType, ResolvedType},
     system_builder::SystemContextBuilding,
-    type_builder::ResolvedTypeEnv,
     update_mutation_builder::UpdateMutationBuilder,
 };
 
@@ -70,15 +69,12 @@ pub fn build_shallow(
 }
 
 /// Expand the mutation input types as well as build the mutation
-pub fn build_expanded(
-    resolved_env: &ResolvedTypeEnv,
-    building: &mut SystemContextBuilding,
-) -> Result<(), ModelBuildingError> {
-    ReferenceInputTypeBuilder {}.build_expanded(resolved_env, building)?; // Used by many...
+pub fn build_expanded(building: &mut SystemContextBuilding) -> Result<(), ModelBuildingError> {
+    ReferenceInputTypeBuilder {}.build_expanded(building)?; // Used by many...
 
-    CreateMutationBuilder {}.build_expanded(resolved_env, building)?;
-    UpdateMutationBuilder {}.build_expanded(resolved_env, building)?;
-    DeleteMutationBuilder {}.build_expanded(resolved_env, building)?;
+    CreateMutationBuilder {}.build_expanded(building)?;
+    UpdateMutationBuilder {}.build_expanded(building)?;
+    DeleteMutationBuilder {}.build_expanded(building)?;
 
     Ok(())
 }
@@ -381,7 +377,6 @@ pub trait DataParamBuilder<D> {
     fn expanded_data_type(
         &self,
         entity_type: &EntityType,
-        resolved_env: &ResolvedTypeEnv,
         building: &SystemContextBuilding,
         top_level_type: Option<&EntityType>,
         container_type: Option<&EntityType>,
@@ -403,7 +398,6 @@ pub trait DataParamBuilder<D> {
                         entity_type,
                         field,
                         field_type,
-                        resolved_env,
                         building,
                         top_level_type,
                         Some(entity_type),
@@ -464,7 +458,6 @@ pub trait DataParamBuilder<D> {
         entity_type: &EntityType,
         _field: &PostgresField<EntityType>,
         field_type: &EntityType,
-        resolved_env: &ResolvedTypeEnv,
         building: &SystemContextBuilding,
         top_level_type: Option<&EntityType>,
         _container_type: Option<&EntityType>,
@@ -486,7 +479,6 @@ pub trait DataParamBuilder<D> {
             // If not already expanded
             self.expanded_data_type(
                 field_type,
-                resolved_env,
                 building,
                 top_level_type,
                 new_container_type,

--- a/crates/postgres-subsystem/postgres-model-builder/src/naming.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/naming.rs
@@ -9,6 +9,7 @@
 
 use heck::ToLowerCamelCase;
 use heck::ToSnakeCase;
+use heck::ToUpperCamelCase;
 use postgres_model::types::EntityType;
 
 /// A type with both singular and plural versions of itself.
@@ -45,6 +46,10 @@ pub(super) trait ToPostgresQueryName {
     fn collection_query(&self) -> String;
     /// Aggregate query name (e.g. `concertAgg`)
     fn aggregate_query(&self) -> String;
+
+    /// Unique query name (e.g. `concertByTitle`)
+    /// `constraint_name` is the name of the unique constraint in the database (possibly in snake case or camel case)
+    fn unique_query(&self, constraint_name: &str) -> String;
 }
 
 fn to_query(name: &str) -> String {
@@ -62,6 +67,14 @@ impl<T: ToPlural> ToPostgresQueryName for T {
 
     fn aggregate_query(&self) -> String {
         format!("{}Agg", self.collection_query())
+    }
+
+    fn unique_query(&self, constraint_name: &str) -> String {
+        format!(
+            "{}By{}",
+            self.pk_query(),
+            constraint_name.to_upper_camel_case()
+        )
     }
 }
 

--- a/crates/postgres-subsystem/postgres-model-builder/src/reference_input_type_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/reference_input_type_builder.rs
@@ -25,7 +25,6 @@ use super::{
     naming::ToPostgresTypeNames,
     resolved_builder::{ResolvedCompositeType, ResolvedType},
     system_builder::SystemContextBuilding,
-    type_builder::ResolvedTypeEnv,
 };
 
 pub struct ReferenceInputTypeBuilder;
@@ -42,7 +41,6 @@ impl Builder for ReferenceInputTypeBuilder {
     /// Expand the mutation input types as well as build the mutation
     fn build_expanded(
         &self,
-        _resolved_env: &ResolvedTypeEnv,
         building: &mut SystemContextBuilding,
     ) -> Result<(), ModelBuildingError> {
         for (_, entity_type) in building.entity_types.iter() {

--- a/crates/postgres-subsystem/postgres-model-builder/src/resolved_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/resolved_builder.rs
@@ -13,6 +13,8 @@
 //! column name, here that information is encoded into an attribute of `ResolvedType`.
 //! If no @column is provided, the encoded information is set to an appropriate default value.
 
+use std::collections::HashMap;
+
 use codemap::Span;
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
 
@@ -187,6 +189,21 @@ impl ResolvedCompositeType {
 
     pub fn field_by_column_name(&self, column_name: &str) -> Option<&ResolvedField> {
         self.fields.iter().find(|f| f.column_name == column_name)
+    }
+
+    pub fn unique_constraints(&self) -> HashMap<String, Vec<&ResolvedField>> {
+        let mut unique_constraints: HashMap<String, Vec<&ResolvedField>> = HashMap::new();
+
+        for field in self.fields.iter() {
+            for unique_constraint in field.unique_constraints.iter() {
+                unique_constraints
+                    .entry(unique_constraint.clone())
+                    .or_default()
+                    .push(field);
+            }
+        }
+
+        unique_constraints
     }
 }
 

--- a/crates/postgres-subsystem/postgres-model-builder/src/system_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/system_builder.rs
@@ -26,7 +26,7 @@ use postgres_model::{
     mutation::PostgresMutation,
     order::OrderByParameterType,
     predicate::PredicateParameterType,
-    query::{AggregateQuery, CollectionQuery, PkQuery},
+    query::{AggregateQuery, CollectionQuery, PkQuery, UniqueQuery},
     subsystem::PostgresSubsystem,
     types::{EntityType, MutationType, PostgresPrimitiveType},
 };
@@ -67,6 +67,7 @@ pub fn build(
             pk_queries: building.pk_queries,
             collection_queries: building.collection_queries,
             aggregate_queries: building.aggregate_queries,
+            unique_queries: building.unique_queries,
             database: building.database,
             mutation_types: building.mutation_types.values(),
             mutations: building.mutations,
@@ -121,8 +122,8 @@ fn build_expanded(
     aggregate_type_builder::build_expanded(resolved_env, building)?;
 
     // Finally expand queries, mutations, and module methods
-    query_builder::build_expanded(building);
-    mutation_builder::build_expanded(resolved_env, building)?;
+    query_builder::build_expanded(resolved_env, building);
+    mutation_builder::build_expanded(building)?;
 
     Ok(())
 }
@@ -140,6 +141,7 @@ pub struct SystemContextBuilding {
     pub pk_queries: MappedArena<PkQuery>,
     pub collection_queries: MappedArena<CollectionQuery>,
     pub aggregate_queries: MappedArena<AggregateQuery>,
+    pub unique_queries: MappedArena<UniqueQuery>,
 
     pub mutation_types: MappedArena<MutationType>,
     pub mutations: MappedArena<PostgresMutation>,

--- a/crates/postgres-subsystem/postgres-model-builder/src/update_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/update_mutation_builder.rs
@@ -33,7 +33,6 @@ use super::{
     query_builder,
     resolved_builder::{ResolvedCompositeType, ResolvedType},
     system_builder::SystemContextBuilding,
-    type_builder::ResolvedTypeEnv,
 };
 
 pub struct UpdateMutationBuilder;
@@ -56,7 +55,6 @@ impl Builder for UpdateMutationBuilder {
     /// Expand the mutation input types as well as build the mutation
     fn build_expanded(
         &self,
-        resolved_env: &ResolvedTypeEnv,
         building: &mut SystemContextBuilding,
     ) -> Result<(), ModelBuildingError> {
         let update_access_is_false = |entity_type: &EntityType| -> bool {
@@ -70,14 +68,9 @@ impl Builder for UpdateMutationBuilder {
         };
         for (_, entity_type) in building.entity_types.iter() {
             if !update_access_is_false(entity_type) {
-                for (existing_id, expanded_type) in self.expanded_data_type(
-                    entity_type,
-                    resolved_env,
-                    building,
-                    Some(entity_type),
-                    None,
-                    false,
-                )? {
+                for (existing_id, expanded_type) in
+                    self.expanded_data_type(entity_type, building, Some(entity_type), None, false)?
+                {
                     building.mutation_types[existing_id] = expanded_type;
                 }
             }
@@ -200,7 +193,6 @@ impl DataParamBuilder<DataParameter> for UpdateMutationBuilder {
         entity_type: &EntityType,
         field: &PostgresField<EntityType>,
         field_type: &EntityType,
-        resolved_env: &ResolvedTypeEnv,
         building: &SystemContextBuilding,
         top_level_type: Option<&EntityType>,
         container_type: Option<&EntityType>,
@@ -274,7 +266,6 @@ impl DataParamBuilder<DataParameter> for UpdateMutationBuilder {
                 &self
                     .expanded_data_type(
                         field_type,
-                        resolved_env,
                         building,
                         top_level_type,
                         container_type,

--- a/crates/postgres-subsystem/postgres-model/src/predicate.rs
+++ b/crates/postgres-subsystem/postgres-model/src/predicate.rs
@@ -72,6 +72,7 @@ pub enum PredicateParameterTypeKind {
         field_params: Vec<PredicateParameter>, // {where: {id: .., name: ..}} such as AccountFilter
         logical_op_params: Vec<PredicateParameter>, // logical operator predicates like `and: [{name: ..}, {id: ..}]`
     },
+    Reference(Vec<PredicateParameter>), // {venue: {id: 3}}
 }
 
 impl Parameter for PredicateParameter {
@@ -87,7 +88,8 @@ impl Parameter for PredicateParameter {
 impl TypeDefinitionProvider<PostgresSubsystem> for PredicateParameterType {
     fn type_definition(&self, _system: &PostgresSubsystem) -> TypeDefinition {
         match &self.kind {
-            PredicateParameterTypeKind::Operator(parameters) => {
+            PredicateParameterTypeKind::Operator(parameters)
+            | PredicateParameterTypeKind::Reference(parameters) => {
                 let fields = parameters
                     .iter()
                     .map(|parameter| default_positioned(parameter.input_value()))

--- a/crates/postgres-subsystem/postgres-model/src/query.rs
+++ b/crates/postgres-subsystem/postgres-model/src/query.rs
@@ -75,3 +75,20 @@ impl OperationParameters for AggregateQueryParameters {
         vec![&self.predicate_param]
     }
 }
+
+/// Query by unique constrained parameters such as `userByEmail(email: "hello@example.com")` or `userByFirstAndLastName(firstName: "John", lastName: "Doe")`
+pub type UniqueQuery = PostgresOperation<UniqueQueryParameters>;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct UniqueQueryParameters {
+    pub predicate_params: Vec<PredicateParameter>,
+}
+
+impl OperationParameters for UniqueQueryParameters {
+    fn introspect(&self) -> Vec<&dyn Parameter> {
+        self.predicate_params
+            .iter()
+            .map(|p| p as &dyn Parameter)
+            .collect()
+    }
+}

--- a/crates/postgres-subsystem/postgres-model/src/subsystem.rs
+++ b/crates/postgres-subsystem/postgres-model/src/subsystem.rs
@@ -18,7 +18,7 @@ use super::{
 use crate::{
     access::{DatabaseAccessPrimitiveExpression, InputAccessPrimitiveExpression},
     aggregate::AggregateType,
-    query::{AggregateQuery, CollectionQuery},
+    query::{AggregateQuery, CollectionQuery, UniqueQuery},
     types::{EntityType, MutationType, PostgresPrimitiveType},
 };
 use core_plugin_interface::{
@@ -49,6 +49,7 @@ pub struct PostgresSubsystem {
     pub pk_queries: MappedArena<PkQuery>,
     pub collection_queries: MappedArena<CollectionQuery>,
     pub aggregate_queries: MappedArena<AggregateQuery>,
+    pub unique_queries: MappedArena<UniqueQuery>,
 
     // mutation related
     pub mutation_types: SerializableSlab<MutationType>, // create, update, delete input types such as `PersonUpdateInput`
@@ -79,9 +80,15 @@ impl PostgresSubsystem {
             .iter()
             .map(|query| query.1.field_definition(self));
 
+        let unique_queries_defn = self
+            .unique_queries
+            .iter()
+            .map(|(_, query)| query.field_definition(self));
+
         pk_queries_defn
             .chain(collection_queries_defn)
             .chain(aggregate_queries_defn)
+            .chain(unique_queries_defn)
             .collect()
     }
 
@@ -135,6 +142,7 @@ impl Default for PostgresSubsystem {
             pk_queries: MappedArena::default(),
             collection_queries: MappedArena::default(),
             aggregate_queries: MappedArena::default(),
+            unique_queries: MappedArena::default(),
             mutation_types: SerializableSlab::new(),
             mutations: MappedArena::default(),
 

--- a/crates/postgres-subsystem/postgres-resolver/src/plugin/subsystem_resolver.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/plugin/subsystem_resolver.rs
@@ -54,11 +54,16 @@ impl SubsystemResolver for PostgresSubsystemResolver {
                     Some(query) => {
                         Some(query.resolve(field, request_context, &self.subsystem).await)
                     }
-                    None => match self.subsystem.aggregate_queries.get_by_key(operation_name) {
+                    None => match self.subsystem.unique_queries.get_by_key(operation_name) {
                         Some(query) => {
                             Some(query.resolve(field, request_context, &self.subsystem).await)
                         }
-                        None => None,
+                        None => match self.subsystem.aggregate_queries.get_by_key(operation_name) {
+                            Some(query) => {
+                                Some(query.resolve(field, request_context, &self.subsystem).await)
+                            }
+                            None => None,
+                        },
                     },
                 },
             },

--- a/integration-tests/unique/src/index.exo
+++ b/integration-tests/unique/src/index.exo
@@ -18,7 +18,7 @@ module RsvpModule {
     @unique("primary_email", "secondary_email") emailDomain: String 
 
     rsvps: Set<Rsvp>?
-    InternalRsvps: Set<InternalRsvp>?
+    internalRsvps: Set<InternalRsvp>?
   }
 
   @access(true)

--- a/integration-tests/unique/tests/init-user.gql
+++ b/integration-tests/unique/tests/init-user.gql
@@ -5,29 +5,35 @@ operation: |
         $secondaryEmailId: String!
         $emailDomain: String!,
         $initial_event_rsvp: String!
+        $initial_internal_event_rsvp: String!
     ) {
         createUser(data: {
             username: $username,
             primaryEmailId: $primaryEmailId,
             secondaryEmailId: $secondaryEmailId,
-            emailDomain: $emailDomain
+            emailDomain: $emailDomain,
             rsvps: [
                 { event: $initial_event_rsvp }
+            ],
+            internalRsvps: [
+                { event: $initial_internal_event_rsvp }
             ]
         }) {
             id @bind(name: "alice_user_id")
+            rsvps {
+                id @bind(name: "alice_rsvp_id")
+            }
+            internalRsvps {
+                id @bind(name: "alice_internal_rsvp_id")
+            }
         }
     }
 variable: |
     {
         "username": "Alice02",
-
-        // alice@example.com
         "primaryEmailId": "alice",
-
-        // alice2@example.com
         "secondaryEmailId": "alice2",
-
         "emailDomain": "example.com",
-        "initial_event_rsvp": "Concert1"
+        "initial_event_rsvp": "Concert1",
+        "initial_internal_event_rsvp": "InternalConcert1"
     }

--- a/integration-tests/unique/tests/query/unique.exotest
+++ b/integration-tests/unique/tests/query/unique.exotest
@@ -1,0 +1,86 @@
+operation: |
+  query($userId: Int!) @unordered {
+    byUsernameExisting: userByUsername(username: "Alice02") {
+      id
+    }
+    byUsernameNonExisting: userByUsername(username: "non-existing-user") {
+      id
+    }
+
+    userByPrimaryEmailExisting: userByPrimaryEmail(primaryEmailId: "alice", emailDomain: "example.com") {
+      id
+    }
+    userByPrimaryEmailNonExisting: userByPrimaryEmail(primaryEmailId: "non-existing-user", emailDomain: "example.com") {
+      id
+    }
+    userByPrimaryEmailNonExistingDomain: userByPrimaryEmail(primaryEmailId: "alice", emailDomain: "non-existing-domain.com") {
+      id
+    }
+    
+    userBySecondaryEmailExisting: userBySecondaryEmail(secondaryEmailId: "alice2", emailDomain: "example.com") {
+      id
+    }
+    userBySecondaryEmailNonExisting: userBySecondaryEmail(secondaryEmailId: "non-existing-user", emailDomain: "example.com") {
+      id
+    }
+    userBySecondaryEmailNonExistingDomain: userBySecondaryEmail(secondaryEmailId: "alice2", emailDomain: "non-existing-domain.com") {
+      id
+    }
+
+    rsvpByEventRsvpExisting: rsvpByEventRsvp(user: {id: $userId}, event: "Concert1") {
+      id
+    }
+    rsvpByEventRsvpNonExistingUser: rsvpByEventRsvp(user: {id: 100}, event: "Concert1") {
+      id
+    }
+    rsvpByEventRsvpNonExistingEvent: rsvpByEventRsvp(user: {id: $userId}, event: "non-existing-event") {
+      id
+    }
+
+    internalRsvpByEventRsvpExisting: internalRsvpByEventRsvp(user: {id: $userId}, event: "InternalConcert1") {
+      id
+    }
+    internalRsvpByEventRsvpNonExistingUser: internalRsvpByEventRsvp(user: {id: 100}, event: "InternalConcert1") {
+      id
+    }
+    internalRsvpByEventRsvpNonExistingEvent: internalRsvpByEventRsvp(user: {id: $userId}, event: "non-existing-event") {
+      id
+    }
+  }
+variable: |
+  {
+    "userId": $.alice_user_id
+  }
+response: |
+  {
+    "data": {
+      "byUsernameExisting": {
+        "id": $.alice_user_id
+      },
+      "byUsernameNonExisting": null,
+
+      "userByPrimaryEmailExisting": {
+        "id": $.alice_user_id
+      },
+      "userByPrimaryEmailNonExisting": null,
+      "userByPrimaryEmailNonExistingDomain": null,
+
+      "userBySecondaryEmailExisting": {
+        "id": $.alice_user_id
+      },
+      "userBySecondaryEmailNonExisting": null,
+      "userBySecondaryEmailNonExistingDomain": null,
+
+      "rsvpByEventRsvpExisting": {
+        "id": $.alice_rsvp_id[0]
+      },
+      "rsvpByEventRsvpNonExistingUser": null,
+      "rsvpByEventRsvpNonExistingEvent": null,
+
+      "internalRsvpByEventRsvpExisting": {
+        "id": $.alice_internal_rsvp_id[0]
+      },
+      "internalRsvpByEventRsvpNonExistingUser": null,
+      "internalRsvpByEventRsvpNonExistingEvent": null
+    }
+  }


### PR DESCRIPTION
We now support queries that take unique fields as arguments and return a single optional object.

For each unique constraint on a Postgres type, we generate a query for the following form:
```
<entityName-lowerCamelCase>By<uniqueConstraintName-upperCamelCase>([<uniqueConstraintFieldsImplicitEqualsPredicate>])
```

Consider the following type:
```exo
type User {
  ...
  @unique username: String
  @unique("primary_email") primaryEmailId: String
  @unique("secondary_email") secondaryEmailId: String?
  @unique("primary_email", "secondary_email") emailDomain: String
}
```

For this, generate the following queries:
```graphql
userByUsername(username: String!): User
userByPrimaryEmail(primaryEmailId: String!, emailDomain: String!): User
userBySecondaryEmail(secondaryEmailId: String!, emailDomain: String!): User
```

Consider the following type, which includes a unique constraint on a foreign key:
```exo
type Rsvp {
  ...
  @unique("eventRsvp") event: String
  @unique("eventRsvp")  user: User
}
```

We generate the following query:
```graphql
rsvpByEventRsvp(event: String!, user: UserUniqueFiler!): Rsvp
```

The `UserUniqueFilter` input type is as follows:
```graphql
input UserUniqueFilter {
  id: Int!
}
```

This commit also fixes the return type for pk-queries to return an optional object.

Fixes #945