### PR TITLE
Fix an issue with the npm module integration test

### DIFF
--- a/integration-tests/services/npm-module/src/test_ops.ts
+++ b/integration-tests/services/npm-module/src/test_ops.ts
@@ -1,6 +1,8 @@
 import Color from "npm:color"; // CommonJS
 import tinycolor from "npm:tinycolor2"; // ESM
-import { Resend } from "npm:resend"; // Module with namespace (indirectly "@react-email/render")
+import { Resend } from "npm:resend@2"; // Module with namespace (indirectly "@react-email/render")
+
+// We use a fixed version of "resend", since 3.0 has a bug (https://github.com/resend/resend-node/issues/303)
 
 // Needed to trigger dynamic import
 const resend = new Resend('fake-api-key');


### PR DESCRIPTION
The latest version of resend has a bug that prevents loading the module (https://github.com/resend/resend-node/issues/303), so we pin the version to 2.x.

As a side-effect, we now have a test that exercises version pinning.