### PR TITLE
Use macos-14 runner for GitHub actions

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -16,6 +16,7 @@ on:
     branches: ["main"]
     tags:
       - "*"
+  pull_request:
 
 jobs:
   # Build and package all the things

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -18,7 +18,7 @@ on:
       - "*"
 
 jobs:
-  # Build and packages all the things
+  # Build and package all the things
   build-artifacts:
     strategy:
       fail-fast: false
@@ -28,6 +28,10 @@ jobs:
           - os: macos-11
             deps-script: brew install protobuf
             target: x86_64-apple-darwin
+            bin_extension: ""
+          - os: macos-14
+            deps-script: brew install protobuf
+            target: aarch64-apple-darwin
             bin_extension: ""
           - os: ubuntu-20.04
             deps-script: sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -30,7 +30,7 @@ jobs:
             target: x86_64-apple-darwin
             bin_extension: ""
           - os: macos-14
-            deps-script: brew install protobuf
+            deps-script: brew install protobuf postgresql@14
             target: aarch64-apple-darwin
             bin_extension: ""
           - os: ubuntu-20.04

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -49,6 +49,14 @@ jobs:
         if: ${{ runner.os != 'Windows' }}
         run: |
           bash ${PWD}/.github/workflows/clear-disk-space.sh
+      - name: Select the latest Xcode version
+        # The default version of Xcode on macos-14 is 15.1, which leads to https://github.com/rust-lang/rust/issues/113783.
+        # So we set up Xcode to use the latest stable version (currently 15.2).
+        # For other macos versions, the latest stable version happens to be the default
+        if: ${{ runner.os == 'macOS' }}
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
       - name: Install deps
         run: ${{ matrix.deps-script }}
       - name: Setup Node

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -16,7 +16,6 @@ on:
     branches: ["main"]
     tags:
       - "*"
-  pull_request:
 
 jobs:
   # Build and package all the things

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
             deps-script: brew install protobuf
             target: x86_64-apple-darwin
           - os: macos-14
-            deps-script: brew install protobuf
+            deps-script: brew install protobuf postgresql@14
             target: aarch64-apple-darwin
           - os: windows-2019
             deps-script: choco install protoc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,9 @@ jobs:
           - os: macos-11
             deps-script: brew install protobuf
             target: x86_64-apple-darwin
+          - os: macos-14
+            deps-script: brew install protobuf
+            target: aarch64-apple-darwin
           - os: windows-2019
             deps-script: choco install protoc
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,9 @@ jobs:
         run: |
           bash ${PWD}/.github/workflows/clear-disk-space.sh
       - name: Select the latest Xcode version
+        # The default version of Xcode on macos-14 is 15.1, which leads to https://github.com/rust-lang/rust/issues/113783.
+        # So we set up Xcode to use the latest stable version (currently 15.2).
+        # For other macos versions, the latest stable version happens to be the default
         if: ${{ runner.os == 'macOS' }}
         uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -72,7 +75,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - name: Add Postgres to PATH
         run: |
           if [ "$RUNNER_OS" == "Windows" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,11 @@ jobs:
         if: ${{ runner.os != 'Windows' }}
         run: |
           bash ${PWD}/.github/workflows/clear-disk-space.sh
+      - name: Select the latest Xcode version
+        if: ${{ runner.os == 'macOS' }}
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
       - name: Install deps
         run: ${{ matrix.deps-script }}
       - name: Setup Node


### PR DESCRIPTION
Earlier, we used to build and release binaries for aarch64-apple-darwin from a local machine. With https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/ we can now use GitHub actions, instead.