### PR TITLE
Permit integration tests to trust all documents

### DIFF
--- a/crates/testing/src/execution/integration_test.rs
+++ b/crates/testing/src/execution/integration_test.rs
@@ -442,7 +442,7 @@ pub async fn run_query(
         operations_payload,
         server,
         request_context,
-        TrustedDocumentEnforcement::Enforce,
+        TrustedDocumentEnforcement::DoNotEnforce,
     )
     .await;
 


### PR DESCRIPTION
This way, server developers can test more than what current clients need and make it easy to allow clients to ask for more trusted documents.