### PR TITLE
Switch from macOS 11 to macOS 12 in GitHub Actions

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         # For these target platforms
         include:
-          - os: macos-11
+          - os: macos-12
             deps-script: brew install protobuf
             target: x86_64-apple-darwin
             bin_extension: ""

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
           - os: ubuntu-20.04
             deps-script: sudo apt-get install -y protobuf-compiler
             target: x86_64-unknown-linux-gnu
-          - os: macos-11
+          - os: macos-12
             deps-script: brew install protobuf
             target: x86_64-apple-darwin
           - os: macos-14


### PR DESCRIPTION
Due to https://github.com/actions/runner-images/issues/9255, we need to switch from macOS 11 to macOS 12 in GitHub Actions.