### PR TITLE
Switch to macos-13 to build x86 target

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         # For these target platforms
         include:
-          - os: macos-12
+          - os: macos-13
             deps-script: brew install protobuf
             target: x86_64-apple-darwin
             bin_extension: ""

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
           - os: ubuntu-20.04
             deps-script: sudo apt-get install -y protobuf-compiler
             target: x86_64-unknown-linux-gnu
-          - os: macos-12
+          - os: macos-13
             deps-script: brew install protobuf
             target: x86_64-apple-darwin
           - os: macos-14

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
             deps-script: sudo apt-get install -y protobuf-compiler
             target: x86_64-unknown-linux-gnu
           - os: macos-13
-            deps-script: brew install protobuf
+            deps-script: brew install protobuf postgresql@14
             target: x86_64-apple-darwin
           - os: macos-14
             deps-script: brew install protobuf postgresql@14


### PR DESCRIPTION
According to https://github.com/actions/runner-images/issues/9255, macos-12 is going to be deprecated soon.