### PR TITLE
Build against our patched Deno 1.41.1

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -70,7 +70,7 @@ jobs:
           key: ${{ matrix.target }}
       - name: Build
         run: |
-          cargo build -p cli -p server-actix --target ${{ matrix.target }} --release --features not_cross
+          cargo build -p cli -p server-actix --target ${{ matrix.target }} --release
       - name: Add Postgres to PATH
         run: |
           if [ "$RUNNER_OS" == "Windows" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,11 +91,11 @@ jobs:
           key: ${{ matrix.target }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build
-        run: cargo build --target ${{ matrix.target }} --features not_cross
+        run: cargo build --target ${{ matrix.target }}
       - name: Run tests
         env:
           RUST_BACKTRACE: 1
-        run: cargo test --workspace --target ${{ matrix.target }} --features not_cross
+        run: cargo test --workspace --target ${{ matrix.target }}
       - name: Run integration tests
         env:
           RUST_BACKTRACE: 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
  "derive_more",
  "encoding_rs",
  "futures-core",
- "http",
+ "http 0.2.11",
  "httparse",
  "httpdate",
  "itoa",
@@ -119,7 +119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22475596539443685426b6bdadb926ad0ecaefdfc5fb05e5e3441f15463c511"
 dependencies = [
  "bytestring",
- "http",
+ "http 0.2.11",
  "regex",
  "serde",
  "tracing",
@@ -373,16 +373,15 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
  "utf8parse",
 ]
 
@@ -412,12 +411,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.2"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -440,12 +439,24 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
+name = "ash"
+version = "0.37.3+1.3.251"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a"
+dependencies = [
+ "libloading 0.7.4",
+]
 
 [[package]]
 name = "asn1-rs"
@@ -488,11 +499,10 @@ dependencies = [
 
 [[package]]
 name = "ast_node"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c09c69dffe06d222d072c878c3afe86eee2179806f20503faec97250268b4c24"
+checksum = "c3e3e06ec6ac7d893a0db7127d91063ad7d9da8988f8a1a256f03729e6eec026"
 dependencies = [
- "pmutil",
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "swc_macros_common",
@@ -633,7 +643,7 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
+ "http 0.2.11",
  "http-body 0.4.6",
  "hyper 0.14.28",
  "itoa",
@@ -659,7 +669,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
+ "http 0.2.11",
  "http-body 0.4.6",
  "mime",
  "rustversion",
@@ -758,6 +768,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +793,15 @@ name = "bitflags"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
@@ -809,6 +843,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "builder"
 version = "0.7.0"
 dependencies = [
@@ -846,6 +890,15 @@ name = "bumpalo"
 version = "3.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
+dependencies = [
+ "allocator-api2",
+]
+
+[[package]]
+name = "bytemuck"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
 
 [[package]]
 name = "byteorder"
@@ -1069,50 +1122,49 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.3"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8f255e4b8027970e78db75e78831229c9815fdbfa67eb1a1b777a62e24b4a0"
+checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.3"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd4f3c17c83b0ba34ffbc4f8bbd74f079413f747f84a6f89292f138057e36ab"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags 1.3.2",
  "clap_lex",
- "strsim 0.10.0",
+ "strsim 0.11.0",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "4.3.1"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6b5c519bab3ea61843a7923d074b04245624bb84a64a8c150f5deb014e388b"
+checksum = "885e4d7d5af40bfb99ae6f9433e292feac98d452dcb3ec3d25dfe7552b77da8c"
 dependencies = [
- "clap 4.3.3",
+ "clap 4.5.2",
 ]
 
 [[package]]
 name = "clap_complete_fig"
-version = "4.3.1"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fee1d30a51305a6c2ed3fc5709be3c8af626c9c958e04dd9ae94e27bcbce9f"
+checksum = "54b3e65f91fabdd23cac3d57d39d5d938b4daabd070c335c006dccb866a61110"
 dependencies = [
- "clap 4.3.3",
+ "clap 4.5.2",
  "clap_complete",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "cli"
@@ -1122,7 +1174,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "builder",
- "clap 4.3.3",
+ "clap 4.5.2",
  "colored",
  "common",
  "core-model-builder",
@@ -1154,6 +1206,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9a0700e0127ba15d1d52dd742097f821cd9c65939303a44d970465040a297"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,6 +1238,43 @@ dependencies = [
  "codemap",
  "termcolor",
 ]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "color-print"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a858372ff14bab9b1b30ea504f2a4bc534582aee3e42ba2d41d2a7baba63d5d"
+dependencies = [
+ "color-print-proc-macro",
+]
+
+[[package]]
+name = "color-print-proc-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e37866456a721d0a404439a1adae37a31be4e0055590d053dfe6981e05003f"
+dependencies = [
+ "nom 7.1.3",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -1266,6 +1364,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "cooked-waker"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147be55d677052dabc6b22252d5dd0fd4c29c8c27aa4f2fbef0f94aa003b406f"
+
+[[package]]
 name = "cookie"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,6 +1395,17 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
+]
 
 [[package]]
 name = "core-model"
@@ -1327,7 +1442,7 @@ dependencies = [
  "core-model-builder",
  "core-plugin-shared",
  "core-resolver",
- "libloading",
+ "libloading 0.7.4",
  "thiserror",
 ]
 
@@ -1673,6 +1788,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "d3d12"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16e44ab292b1dddfdaf7be62cfd8877df52f2f3fde5858d95bab606be259f20"
+dependencies = [
+ "bitflags 2.4.2",
+ "libloading 0.8.3",
+ "winapi",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1742,8 +1868,8 @@ dependencies = [
 
 [[package]]
 name = "deno"
-version = "1.38.5"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "1.41.1"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "async-trait",
  "base32",
@@ -1752,13 +1878,13 @@ dependencies = [
  "bytes",
  "cache_control",
  "chrono",
- "clap 4.3.3",
+ "clap 4.5.2",
  "clap_complete",
  "clap_complete_fig",
+ "color-print",
  "console_static_text",
  "dashmap",
  "data-encoding",
- "data-url",
  "deno_ast",
  "deno_cache_dir",
  "deno_config",
@@ -1768,20 +1894,18 @@ dependencies = [
  "deno_npm",
  "deno_runtime",
  "deno_semver",
+ "deno_terminal",
  "deno_virtual_fs",
  "dissimilar",
  "dotenvy",
- "encoding_rs",
- "env_logger",
- "fastwebsockets",
+ "env_logger 0.10.0",
  "flate2",
  "fs3",
  "fwdansi",
  "glibc_version",
  "glob",
  "hex",
- "http",
- "hyper 0.14.28",
+ "ignore",
  "import_map",
  "indexmap 2.2.5",
  "jsonc-parser",
@@ -1790,19 +1914,24 @@ dependencies = [
  "libc",
  "libz-sys",
  "log",
- "monch 0.4.3",
+ "monch",
  "napi_sym",
  "nix 0.26.2",
  "notify 5.0.0",
  "once_cell",
+ "open",
+ "p256",
  "percent-encoding",
+ "phf",
  "pin-project",
  "quick-junit",
  "rand",
  "regex",
+ "reqwest",
  "ring 0.17.8",
  "serde",
  "serde_json",
+ "spki",
  "tar",
  "text_lines",
  "thiserror",
@@ -1810,6 +1939,7 @@ dependencies = [
  "tokio-util",
  "twox-hash",
  "typed-arena",
+ "unicode-width",
  "uuid",
  "walkdir",
  "winapi",
@@ -1880,6 +2010,7 @@ dependencies = [
  "indexmap 2.2.5",
  "maybe-owned",
  "serde_json",
+ "test-log",
  "thiserror",
  "tokio",
 ]
@@ -1894,14 +2025,17 @@ dependencies = [
 
 [[package]]
 name = "deno_ast"
-version = "0.31.6"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7b09db895527a94de1305455338926cd2a7003231ba589b7b7b57e8da344f2"
+checksum = "58d986a1df3f1538ffa04162b5c5f00b856121391b860dc003bde2a6a741e878"
 dependencies = [
  "anyhow",
- "base64 0.13.1",
+ "base64 0.21.7",
  "deno_media_type",
+ "deno_terminal",
  "dprint-swc-ext",
+ "once_cell",
+ "percent-encoding",
  "serde",
  "swc_atoms",
  "swc_bundler",
@@ -1911,7 +2045,6 @@ dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",
  "swc_ecma_codegen_macros",
- "swc_ecma_dep_graph",
  "swc_ecma_loader",
  "swc_ecma_parser",
  "swc_ecma_transforms_base",
@@ -1929,13 +2062,14 @@ dependencies = [
  "swc_visit",
  "swc_visit_macros",
  "text_lines",
+ "unicode-width",
  "url",
 ]
 
 [[package]]
 name = "deno_broadcast_channel"
-version = "0.121.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "0.134.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1945,8 +2079,8 @@ dependencies = [
 
 [[package]]
 name = "deno_cache"
-version = "0.59.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "0.72.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1958,9 +2092,9 @@ dependencies = [
 
 [[package]]
 name = "deno_cache_dir"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbb245d9a3719b5eb2b5195aaaa25108c3c93d1762b181a20fb1af1c7703eaf"
+checksum = "6cf517bddfd22d79d0f284500318e3f9aea193536c2b61cbf6ce7b50a85f1b6a"
 dependencies = [
  "anyhow",
  "deno_media_type",
@@ -1968,20 +2102,34 @@ dependencies = [
  "log",
  "once_cell",
  "parking_lot",
- "ring 0.17.8",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
  "url",
 ]
 
 [[package]]
+name = "deno_canvas"
+version = "0.9.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
+dependencies = [
+ "deno_core",
+ "deno_webgpu",
+ "image",
+ "serde",
+ "tokio",
+]
+
+[[package]]
 name = "deno_config"
-version = "0.6.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c6b9137fcc5c6f81d12214fc31cdddf2c64d0667a5458803e081ddd856d5b6"
+checksum = "ebbc05e20df2d5b8562205f9b0c296bc528e833b0de126d489781952e13d939f"
 dependencies = [
  "anyhow",
+ "glob",
+ "import_map",
  "indexmap 2.2.5",
  "jsonc-parser",
  "log",
@@ -1993,25 +2141,31 @@ dependencies = [
 
 [[package]]
 name = "deno_console"
-version = "0.127.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "0.140.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "deno_core",
 ]
 
 [[package]]
 name = "deno_core"
-version = "0.232.0"
+version = "0.265.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229ffd108e028b148a1a5a6122f771bc7c37094170226f44b8b93b3a9b79d114"
+checksum = "f40a3dc5c31b35feedda9304ceff8b541dd5c8d7deeb69eb6036f8fa65bfdf08"
 dependencies = [
  "anyhow",
+ "bincode",
+ "bit-set",
+ "bit-vec",
  "bytes",
+ "cooked-waker",
+ "deno_core_icudata",
  "deno_ops",
  "deno_unsync 0.3.2",
  "futures",
  "libc",
  "log",
+ "memoffset 0.9.0",
  "parking_lot",
  "pin-project",
  "serde",
@@ -2019,15 +2173,22 @@ dependencies = [
  "serde_v8",
  "smallvec",
  "sourcemap 7.0.1",
+ "static_assertions",
  "tokio",
  "url",
  "v8",
 ]
 
 [[package]]
+name = "deno_core_icudata"
+version = "0.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13951ea98c0a4c372f162d669193b4c9d991512de9f2381dd161027f34b26b1"
+
+[[package]]
 name = "deno_cron"
-version = "0.7.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "0.20.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2040,8 +2201,8 @@ dependencies = [
 
 [[package]]
 name = "deno_crypto"
-version = "0.141.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "0.154.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2058,6 +2219,7 @@ dependencies = [
  "once_cell",
  "p256",
  "p384",
+ "p521",
  "rand",
  "ring 0.17.8",
  "rsa",
@@ -2074,25 +2236,27 @@ dependencies = [
 
 [[package]]
 name = "deno_fetch"
-version = "0.151.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "0.164.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "bytes",
  "data-url",
  "deno_core",
  "deno_tls",
  "dyn-clone",
- "http",
+ "http 0.2.11",
+ "pin-project",
  "reqwest",
  "serde",
+ "serde_json",
  "tokio",
  "tokio-util",
 ]
 
 [[package]]
 name = "deno_ffi"
-version = "0.114.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "0.127.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "deno_core",
  "dlopen2",
@@ -2108,10 +2272,11 @@ dependencies = [
 
 [[package]]
 name = "deno_fs"
-version = "0.37.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "0.50.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "async-trait",
+ "base32",
  "deno_core",
  "deno_io",
  "filetime",
@@ -2120,6 +2285,7 @@ dependencies = [
  "log",
  "nix 0.26.2",
  "rand",
+ "rayon",
  "serde",
  "tokio",
  "winapi",
@@ -2127,32 +2293,37 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.61.1"
+version = "0.69.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076c0b611c10901456b78c837408b9c40fe0c3602e767307d986f46f0cc56b51"
+checksum = "a9d04f8bc8d8a40369e8549d15f6b315ffe025d0048fcd3c541f90647471f670"
 dependencies = [
  "anyhow",
  "async-trait",
  "data-url",
  "deno_ast",
  "deno_semver",
+ "deno_unsync 0.3.2",
+ "encoding_rs",
  "futures",
  "import_map",
  "indexmap 2.2.5",
- "monch 0.4.3",
+ "log",
+ "monch",
  "once_cell",
  "parking_lot",
  "regex",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
+ "twox-hash",
  "url",
 ]
 
 [[package]]
 name = "deno_http"
-version = "0.124.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "0.137.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "async-compression",
  "async-trait",
@@ -2164,11 +2335,13 @@ dependencies = [
  "deno_net",
  "deno_websocket",
  "flate2",
- "fly-accept-encoding",
- "http",
+ "http 0.2.11",
+ "http 1.1.0",
  "httparse",
  "hyper 0.14.28",
- "hyper 1.0.0-rc.4",
+ "hyper 1.1.0",
+ "hyper-util",
+ "itertools",
  "memmem",
  "mime",
  "once_cell",
@@ -2186,22 +2359,24 @@ dependencies = [
 
 [[package]]
 name = "deno_io"
-version = "0.37.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "0.50.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "async-trait",
  "deno_core",
  "filetime",
  "fs3",
  "once_cell",
+ "os_pipe",
+ "rand",
  "tokio",
  "winapi",
 ]
 
 [[package]]
 name = "deno_kv"
-version = "0.35.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "0.48.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2233,13 +2408,13 @@ dependencies = [
 
 [[package]]
 name = "deno_lockfile"
-version = "0.17.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd29f62e6dec60e585f579df3e9c2fc562aadf881319152974bc442a9042077"
+checksum = "8835418ae924f25ab20f508bf6240193b22d893519d44432b670a27b8fb1efeb"
 dependencies = [
- "ring 0.17.8",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
 ]
 
@@ -2256,11 +2431,11 @@ dependencies = [
 
 [[package]]
 name = "deno_napi"
-version = "0.57.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "0.70.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "deno_core",
- "libloading",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -2278,8 +2453,8 @@ dependencies = [
 
 [[package]]
 name = "deno_net"
-version = "0.119.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "0.132.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "deno_core",
  "deno_tls",
@@ -2296,8 +2471,8 @@ dependencies = [
 
 [[package]]
 name = "deno_node"
-version = "0.64.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "0.77.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "aead-gcm-stream",
  "aes",
@@ -2317,10 +2492,10 @@ dependencies = [
  "ecb",
  "elliptic-curve",
  "errno 0.2.8",
- "h2",
+ "h2 0.3.24",
  "hex",
  "hkdf",
- "http",
+ "http 0.2.11",
  "idna 0.3.0",
  "indexmap 2.2.5",
  "k256",
@@ -2329,6 +2504,7 @@ dependencies = [
  "libz-sys",
  "md-5",
  "md4",
+ "nix 0.26.2",
  "num-bigint",
  "num-bigint-dig",
  "num-integer",
@@ -2339,6 +2515,7 @@ dependencies = [
  "p384",
  "path-clean",
  "pbkdf2 0.12.2",
+ "pin-project-lite",
  "rand",
  "regex",
  "reqwest",
@@ -2350,19 +2527,21 @@ dependencies = [
  "sha-1",
  "sha2",
  "signature",
+ "simd-json",
  "tokio",
  "typenum",
  "url",
  "winapi",
+ "windows-sys 0.48.0",
  "x25519-dalek",
  "x509-parser",
 ]
 
 [[package]]
 name = "deno_npm"
-version = "0.15.3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718b0b55031643de7808f8b426661b22a685820f1f459e028776bcc49e07b881"
+checksum = "53a333104d3fb6aa52e499384e523aefc09d3ac8ecd05ca7f65f856044fbcb09"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2370,16 +2549,16 @@ dependencies = [
  "deno_semver",
  "futures",
  "log",
- "monch 0.4.3",
+ "monch",
  "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "deno_ops"
-version = "0.108.0"
+version = "0.141.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7dde627916f8539f3f0d2e754dda40810c8ca4d655f2eaac1ef54785a12fd27"
+checksum = "86efc44027a9d370fa677988cb463fb8c9a48c5d8b53e91431a69a44540a6c11"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2 1.0.78",
@@ -2392,13 +2571,14 @@ dependencies = [
 
 [[package]]
 name = "deno_runtime"
-version = "0.135.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "0.148.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "console_static_text",
  "deno_ast",
  "deno_broadcast_channel",
  "deno_cache",
+ "deno_canvas",
  "deno_console",
  "deno_core",
  "deno_cron",
@@ -2412,9 +2592,11 @@ dependencies = [
  "deno_napi",
  "deno_net",
  "deno_node",
+ "deno_terminal",
  "deno_tls",
  "deno_url",
  "deno_web",
+ "deno_webgpu",
  "deno_webidl",
  "deno_websocket",
  "deno_webstorage",
@@ -2425,8 +2607,11 @@ dependencies = [
  "flate2",
  "fs3",
  "fwdansi",
- "http",
+ "http 1.1.0",
+ "http-body-util",
  "hyper 0.14.28",
+ "hyper 1.1.0",
+ "hyper-util",
  "libc",
  "log",
  "netif",
@@ -2436,14 +2621,15 @@ dependencies = [
  "once_cell",
  "regex",
  "ring 0.17.8",
+ "rustyline",
  "serde",
  "signal-hook-registry",
- "termcolor",
  "tokio",
  "tokio-metrics",
  "uuid",
  "which 4.4.2",
  "winapi",
+ "windows-sys 0.48.0",
  "winres",
 ]
 
@@ -2453,7 +2639,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b49e14effd9df8ed261f7a1a34ac19bbaf0fa940c59bd19a6d8313cf41525e1c"
 dependencies = [
- "monch 0.5.0",
+ "monch",
  "once_cell",
  "serde",
  "thiserror",
@@ -2461,15 +2647,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "deno_terminal"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e6337d4e7f375f8b986409a76fbeecfa4bd8a1343e63355729ae4befa058eaf"
+dependencies = [
+ "once_cell",
+ "termcolor",
+]
+
+[[package]]
 name = "deno_tls"
-version = "0.114.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "0.127.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "deno_core",
  "deno_native_certs",
  "once_cell",
  "rustls",
  "rustls-pemfile 1.0.4",
+ "rustls-tokio-stream",
  "rustls-webpki",
  "serde",
  "webpki-roots",
@@ -2495,8 +2692,8 @@ dependencies = [
 
 [[package]]
 name = "deno_url"
-version = "0.127.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "0.140.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "deno_core",
  "serde",
@@ -2506,7 +2703,7 @@ dependencies = [
 [[package]]
 name = "deno_virtual_fs"
 version = "1.38.2"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -2520,8 +2717,8 @@ dependencies = [
 
 [[package]]
 name = "deno_web"
-version = "0.158.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "0.171.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -2537,26 +2734,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "deno_webgpu"
+version = "0.107.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
+dependencies = [
+ "deno_core",
+ "raw-window-handle",
+ "serde",
+ "tokio",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
 name = "deno_webidl"
-version = "0.127.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "0.140.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "deno_core",
 ]
 
 [[package]]
 name = "deno_websocket"
-version = "0.132.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "0.145.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "bytes",
  "deno_core",
  "deno_net",
  "deno_tls",
  "fastwebsockets",
- "h2",
- "http",
- "hyper 0.14.28",
+ "h2 0.4.2",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.1.0",
+ "hyper-util",
  "once_cell",
  "rustls-tokio-stream",
  "serde",
@@ -2565,8 +2778,8 @@ dependencies = [
 
 [[package]]
 name = "deno_webstorage"
-version = "0.122.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "0.135.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "deno_core",
  "deno_web",
@@ -2823,10 +3036,11 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dprint-swc-ext"
-version = "0.13.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f24ce6b89a06ae3eb08d5d4f88c05d0aef1fa58e2eba8dd92c97b84210c25"
+checksum = "5bad772f9e49af3a613fcddf1671d1e2e877e0a6d94f2b7162bfea4ac8140bee"
 dependencies = [
+ "allocator-api2",
  "bumpalo",
  "num-bigint",
  "rustc-hash",
@@ -2960,6 +3174,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "enum-as-inner"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2969,6 +3189,15 @@ dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -2982,6 +3211,16 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c012a26a7f605efc424dd53697843a72be7dc86ad2d01f7814337794a12231d"
+dependencies = [
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -3022,11 +3261,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
+
+[[package]]
 name = "exo-deno"
 version = "0.7.0"
 dependencies = [
  "async-trait",
  "ctor",
+ "deno",
  "deno_ast",
  "deno_core",
  "deno_fs",
@@ -3041,6 +3287,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "test-log",
  "thiserror",
  "tokio",
  "tracing",
@@ -3118,12 +3365,14 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fastwebsockets"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c35f166afb94b7f8e9449d0ad866daca111ba4053f3b1960bb480ca4382c63"
+checksum = "f63dd7b57f9b33b1741fa631c9522eb35d43e96dcca4a6a91d5e4ca7c93acdc1"
 dependencies = [
  "base64 0.21.7",
- "hyper 0.14.28",
+ "http-body-util",
+ "hyper 1.1.0",
+ "hyper-util",
  "pin-project",
  "rand",
  "sha1",
@@ -3142,6 +3391,15 @@ dependencies = [
  "cfg-if 1.0.0",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
+dependencies = [
+ "simd-adler32",
 ]
 
 [[package]]
@@ -3196,14 +3454,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "fly-accept-encoding"
-version = "0.2.0"
+name = "float-cmp"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3afa7516fdcfd8e5e93a938f8fec857785ced190a1f62d842d1fe1ffbe22ba8"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
- "http",
- "itertools",
- "thiserror",
+ "num-traits",
 ]
 
 [[package]]
@@ -3211,6 +3467,33 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -3223,11 +3506,10 @@ dependencies = [
 
 [[package]]
 name = "from_variant"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ec5dc38ee19078d84a692b1c41181ff9f94331c76cee66ff0208c770b5e54f"
+checksum = "3a0b11eeb173ce52f84ebd943d42e58813a2ebb78a6a3ff0a243b71c5199cd7b"
 dependencies = [
- "pmutil",
  "proc-macro2 1.0.78",
  "swc_macros_common",
  "syn 2.0.52",
@@ -3266,9 +3548,9 @@ dependencies = [
 
 [[package]]
 name = "fslock"
-version = "0.1.8"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57eafdd0c16f57161105ae1b98a1238f97645f2f588438b2949c99a2af9616bf"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
 dependencies = [
  "libc",
  "winapi",
@@ -3441,6 +3723,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
 name = "glibc_version"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3454,6 +3747,93 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "globset"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata 0.4.5",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "glow"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "gpu-alloc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
+dependencies = [
+ "bitflags 2.4.2",
+ "gpu-alloc-types",
+]
+
+[[package]]
+name = "gpu-alloc-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
+dependencies = [
+ "bitflags 2.4.2",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40fe17c8a05d60c38c0a4e5a3c802f2f1ceb66b76c67d96ffb34bef0475a7fad"
+dependencies = [
+ "backtrace",
+ "log",
+ "presser",
+ "thiserror",
+ "winapi",
+ "windows",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
+dependencies = [
+ "bitflags 2.4.2",
+ "gpu-descriptor-types",
+ "hashbrown 0.14.3",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf0b36e6f090b7e1d8a4b49c0cb81c1f8376f72198c65dd3ad9ff3556b8b78c"
+dependencies = [
+ "bitflags 2.4.2",
+]
 
 [[package]]
 name = "group"
@@ -3477,12 +3857,41 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.11",
  "indexmap 2.2.5",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31d030e59af851932b72ceebadf4a2b5986dba4c3b99dd2493f8273a0f151943"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.1.0",
+ "indexmap 2.2.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "halfbrown"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8588661a8607108a5ca69cab034063441a0413a0b041c13618a7dd348021ef6f"
+dependencies = [
+ "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -3545,6 +3954,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "hkdf"
@@ -3618,24 +4033,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.11",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "http-body"
-version = "1.0.0-rc.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951dfc2e32ac02d67c90c0d65bd27009a635dc9b381a2cc7d284ab01e3a0150d"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
 dependencies = [
  "bytes",
- "http",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -3685,8 +4124,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
+ "h2 0.3.24",
+ "http 0.2.11",
  "http-body 0.4.6",
  "httparse",
  "httpdate",
@@ -3701,22 +4140,21 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.0.0-rc.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d280a71f348bcc670fc55b02b63c53a04ac0bf2daff2980795aeaf53edae10e6"
+checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
- "http",
- "http-body 1.0.0-rc.2",
+ "h2 0.4.2",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
  "tokio",
- "tracing",
  "want",
 ]
 
@@ -3727,7 +4165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
+ "http 0.2.11",
  "hyper 0.14.28",
  "rustls",
  "tokio",
@@ -3747,6 +4185,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdea9aac0dbe5a9240d68cfd9501e2db94222c6dc06843e06640b9e07f0fdc67"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.1.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3757,7 +4213,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -3813,13 +4269,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
-name = "import_map"
-version = "0.17.0"
+name = "ignore"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e5bf51a0adfdc08afcb9e5a1c8f8c804227ec50d493c65e57e6d117d594bd1b"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
 dependencies = [
- "indexmap 1.9.3",
+ "globset",
+ "lazy_static",
  "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
+name = "image"
+version = "0.24.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "num-traits",
+ "png",
+]
+
+[[package]]
+name = "import_map"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "696717335b077e26921a60be7b7bdc15d1246074f1ac79d9e8560792535f7d07"
+dependencies = [
+ "indexmap 2.2.5",
+ "log",
+ "percent-encoding",
  "serde",
  "serde_json",
  "url",
@@ -3852,7 +4339,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -4007,6 +4493,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "is-macro"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4027,6 +4522,16 @@ dependencies = [
  "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -4097,9 +4602,9 @@ dependencies = [
 
 [[package]]
 name = "jsonc-parser"
-version = "0.21.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b56a20e76235284255a09fcd1f45cf55d3c524ea657ebd3854735925c57743d"
+checksum = "7725c320caac8c21d8228c1d055af27a995d371f78cc763073d3e068323641b5"
 dependencies = [
  "serde_json",
 ]
@@ -4144,6 +4649,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading 0.8.3",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
 name = "kqueue"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4172,7 +4694,7 @@ dependencies = [
  "async-stream",
  "bytes",
  "futures",
- "http",
+ "http 0.2.11",
  "hyper 0.14.28",
  "lambda_runtime_api_client",
  "serde",
@@ -4189,7 +4711,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b54698c666ffe503cb51fa66e4567e53e806128a10359de7095999d925a771ed"
 dependencies = [
- "http",
+ "http 0.2.11",
  "hyper 0.14.28",
  "tokio",
  "tower-service",
@@ -4240,6 +4762,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
+name = "lexical-core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-util"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4272,6 +4858,16 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+dependencies = [
+ "cfg-if 1.0.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -4506,6 +5102,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "metal"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
+dependencies = [
+ "bitflags 2.4.2",
+ "block",
+ "core-graphics-types",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4534,6 +5145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -4547,12 +5159,6 @@ dependencies = [
  "wasi",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "monch"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4519a88847ba2d5ead3dc53f1060ec6a571de93f325d9c5c4968147382b1cbc3"
 
 [[package]]
 name = "monch"
@@ -4573,9 +5179,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d02c0b00610773bb7fc61d85e13d86c7858cbdf00e1a120bfc41bc055dbaa0e"
 
 [[package]]
+name = "naga"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae585df4b6514cf8842ac0f1ab4992edc975892704835b549cf818dc0191249e"
+dependencies = [
+ "bit-set",
+ "bitflags 2.4.2",
+ "codespan-reporting",
+ "hexf-parse",
+ "indexmap 2.2.5",
+ "log",
+ "num-traits",
+ "rustc-hash",
+ "serde",
+ "spirv",
+ "termcolor",
+ "thiserror",
+ "unicode-xid 0.2.4",
+]
+
+[[package]]
 name = "napi_sym"
-version = "0.57.0"
-source = "git+https://github.com/exograph/deno.git?branch=patched_1_38_5#a40891fe13589f826b4d7473d918e1e83fa34c44"
+version = "0.70.0"
+source = "git+https://github.com/exograph/deno.git?branch=patched_1_41_1#2bcad1e2877c4cd08466a7c0706e7c7192acf5ae"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
@@ -4620,6 +5247,15 @@ name = "nextest-workspace-hack"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d906846a98739ed9d73d66e62c2641eef8321f1734b7a1156ab045a0248fb2b3"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "nix"
@@ -4878,6 +5514,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
+ "objc_exception",
+]
+
+[[package]]
+name = "objc_exception"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -4929,6 +5575,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "open"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449f0ff855d85ddbf1edd5b646d65249ead3f5e422aaa86b7d2d0b049b103e32"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4977,7 +5634,7 @@ checksum = "7f51189ce8be654f9b5f7e70e49967ed894e84a06fc35c6c042e64ac1fc5399e"
 dependencies = [
  "async-trait",
  "bytes",
- "http",
+ "http 0.2.11",
  "opentelemetry 0.21.0",
  "reqwest",
 ]
@@ -5004,7 +5661,7 @@ checksum = "f24cda83b20ed2433c68241f918d0f6fdec8b1d43b7a9590ab4420c5095ca930"
 dependencies = [
  "async-trait",
  "futures-core",
- "http",
+ "http 0.2.11",
  "opentelemetry 0.21.0",
  "opentelemetry-http",
  "opentelemetry-proto",
@@ -5097,6 +5754,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57119c3b893986491ec9aa85056780d3a0f3cf4da7cc09dd3650dbd6c6738fb9"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5141,6 +5808,20 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core",
  "sha2",
 ]
 
@@ -5250,9 +5931,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
@@ -5441,6 +6122,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.17.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5607,6 +6301,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
 name = "prettyplease"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5689,6 +6389,12 @@ checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "profiling"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d84d1d7a6ac92673717f9f6d1518374ef257669c24ebc5ac25d5033828be58"
 
 [[package]]
 name = "prost"
@@ -5819,6 +6525,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce082a9940a7ace2ad4a8b7d0b1eac6aa378895f18be598230c5f2284ac05426"
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5847,6 +6563,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "range-alloc"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
 
 [[package]]
 name = "raw-window-handle"
@@ -5892,6 +6614,26 @@ dependencies = [
  "getrandom",
  "libredox",
  "thiserror",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4846d4c50d1721b1a3bef8af76924eef20d5e723647333798c1b519b3a9473f"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fddb4f8d99b0a2ebafc65a87a69a7b9875e4b1ae1f00db265d300ef7f28bccc"
+dependencies = [
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5959,9 +6701,9 @@ checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
  "async-compression",
  "base64 0.21.7",
@@ -5969,8 +6711,8 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
+ "h2 0.3.24",
+ "http 0.2.11",
  "http-body 0.4.6",
  "hyper 0.14.28",
  "hyper-rustls",
@@ -5987,8 +6729,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-rustls",
  "tokio-socks",
@@ -6101,6 +6841,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64 0.21.7",
+ "bitflags 2.4.2",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -6255,12 +7007,13 @@ checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
 
 [[package]]
 name = "rustls-tokio-stream"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897937c68ff975d028e8cc07bc887f2d5a9ec2bc952549f40db9a91dc557974c"
+checksum = "ded7a36e8ac05b8ada77a84c5ceec95361942ee9dedb60a82f93f788a791aae8"
 dependencies = [
  "futures",
  "rustls",
+ "socket2",
  "tokio",
 ]
 
@@ -6279,6 +7032,28 @@ name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
+name = "rustyline"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a2d683a4ac90aeef5b1013933f6d977bd37d51ff3f4dad829d4931a7e6be86"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if 1.0.0",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.27.1",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "winapi",
+]
 
 [[package]]
 name = "ryu"
@@ -6498,9 +7273,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.141.0"
+version = "0.174.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc689cb316d67b200e9f7449ce76cceb7e483e0f828d1a9c3d057c4367b6c26e"
+checksum = "1f15fc8c65ebdf37ec94b72dacad9622ad8e04a7cf7504060a709eb21ed02b88"
 dependencies = [
  "bytes",
  "derive_more",
@@ -6668,6 +7443,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simd-json"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2faf8f101b9bc484337a6a6b0409cf76c139f2fb70a9e3aee6b6774be7bfbf76"
+dependencies = [
+ "getrandom",
+ "halfbrown",
+ "lexical-core",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "value-trait",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6711,6 +7508,15 @@ name = "slice-group-by"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
+
+[[package]]
+name = "slotmap"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallbitvec"
@@ -6790,6 +7596,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spirv"
+version = "0.2.0+1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830"
+dependencies = [
+ "bitflags 1.3.2",
+ "num-traits",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6832,11 +7648,10 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_enum"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fa4d4f81d7c05b9161f8de839975d3326328b8ba2831164b465524cc2f55252"
+checksum = "1b650ea2087d32854a0f20b837fc56ec987a1cb4f758c9757e1171ee9812da63"
 dependencies = [
- "pmutil",
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "swc_macros_common",
@@ -6877,9 +7692,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "strum"
@@ -6937,9 +7752,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "swc_atoms"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a9e1b6d97f27b6abe5571f8fe3bdbd2fa987299fc2126450c7cde6214896ef"
+checksum = "7d538eaaa6f085161d088a04cf0a3a5a52c5a7f2b3bd9b83f73f058b0ed357c0"
 dependencies = [
  "hstr",
  "once_cell",
@@ -6949,13 +7764,13 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.222.62"
+version = "0.225.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dc457de4306480ef5f2b54aa23f8d93ff476991de6e1db453bc94c56af732b0"
+checksum = "21736fd17b258d4324f576e1d151d997fd5370a04b68dcb59f3e5050828de33f"
 dependencies = [
  "anyhow",
  "crc",
- "indexmap 1.9.3",
+ "indexmap 2.2.5",
  "is-macro",
  "once_cell",
  "parking_lot",
@@ -6978,10 +7793,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_common"
-version = "0.33.9"
+name = "swc_cached"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ccb656cd57c93614e4e8b33a60e75ca095383565c1a8d2bbe6a1103942831e0"
+checksum = "630c761c74ac8021490b78578cc2223aa4a568241e26505c27bf0e4fd4ad8ec2"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "dashmap",
+ "once_cell",
+ "regex",
+ "serde",
+]
+
+[[package]]
+name = "swc_common"
+version = "0.33.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85e8b15d0fb87691e27c8f3cf953748db3ccd2a39e165d6d5275a48fb0d29e3"
 dependencies = [
  "ast_node",
  "better_scoped_tls",
@@ -7005,23 +7834,24 @@ dependencies = [
 
 [[package]]
 name = "swc_config"
-version = "0.1.7"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba1c7a40d38f9dd4e9a046975d3faf95af42937b34b2b963be4d8f01239584b"
+checksum = "ce837c5eae1cb200a310940de989fd9b3d12ed62d7752bc69b39ef8aa775ec04"
 dependencies = [
- "indexmap 1.9.3",
+ "anyhow",
+ "indexmap 2.2.5",
  "serde",
  "serde_json",
+ "swc_cached",
  "swc_config_macro",
 ]
 
 [[package]]
 name = "swc_config_macro"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5b5aaca9a0082be4515f0fbbecc191bf5829cd25b5b9c0a2810f6a2bb0d6829"
+checksum = "8b2574f75082322a27d990116cd2a24de52945fc94172b24ca0b3e9e2a6ceb6b"
 dependencies = [
- "pmutil",
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "swc_macros_common",
@@ -7030,9 +7860,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.110.10"
+version = "0.112.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3d416121da2d56bcbd1b1623725a68890af4552fef0c6d1e4bfa92776ccd6a"
+checksum = "36226eb87bfd2f5620bde04f149a4b869ab34e78496d60cb0d8eb9da765d0732"
 dependencies = [
  "bitflags 2.4.2",
  "is-macro",
@@ -7048,9 +7878,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.146.32"
+version = "0.148.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b37ef40385cc2e294ece3d42048dcda6392838724dd5f02ff8da3fa105271"
+checksum = "5ba8669ab28bb5d1e65c1e8690257c026745ac368e0101c2c6544d4a03afc95e"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -7067,11 +7897,10 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen_macros"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcdff076dccca6cc6a0e0b2a2c8acfb066014382bc6df98ec99e755484814384"
+checksum = "394b8239424b339a12012ceb18726ed0244fce6bf6345053cb9320b2791dcaa5"
 dependencies = [
- "pmutil",
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "swc_macros_common",
@@ -7079,35 +7908,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_ecma_dep_graph"
-version = "0.113.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fc6ac1a84afe910182dcda33d70a16545e6058529d51afb63bd6be8764370f"
-dependencies = [
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_visit",
-]
-
-[[package]]
 name = "swc_ecma_loader"
-version = "0.45.10"
+version = "0.45.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31cf7549feec3698d0110a0a71ae547f31ae272dc92db3285ce126d6dcbdadf3"
+checksum = "d0058cf970880f5382effe43eb2b727a73ba09ae41922fa140c2c3fa6ca9b2d1"
 dependencies = [
  "anyhow",
  "pathdiff",
  "serde",
+ "swc_atoms",
  "swc_common",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.141.26"
+version = "0.143.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9590deff1b29aafbff8901b9d38d00211393f6b17b5cab878562db89a8966d88"
+checksum = "20823cac99a9adbd4c03fb5e126aaccbf92446afedad99252a0e1fc76e2ffc43"
 dependencies = [
  "either",
  "new_debug_unreachable",
@@ -7127,13 +7945,13 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.134.42"
+version = "0.137.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d74ca42a400257d8563624122813c1849c3d87e7abe3b9b2ed7514c76f64ad2f"
+checksum = "66539401f619730b26d380a120b91b499f80cbdd9bb15d00aa73bc3a4d4cc394"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.4.2",
- "indexmap 1.9.3",
+ "indexmap 2.2.5",
  "once_cell",
  "phf",
  "rustc-hash",
@@ -7150,9 +7968,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.123.43"
+version = "0.126.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e68880cf7d65b93e0446b3ee079f33d94e0eddac922f75b736a6ea7669517c0"
+checksum = "ebf9048e687b746d2bbe6149601c3eedd819fef08d7657e5fddcef99b22febba"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7164,11 +7982,10 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_macros"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8188eab297da773836ef5cf2af03ee5cca7a563e1be4b146f8141452c28cc690"
+checksum = "17e309b88f337da54ef7fe4c5b99c2c522927071f797ee6c9fb8b6bf2d100481"
 dependencies = [
- "pmutil",
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "swc_macros_common",
@@ -7177,12 +7994,12 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.195.54"
+version = "0.198.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808ae9b4a291d73adf36d543f07d5a64a5c121a72c5d5f66898415d1b396b1d1"
+checksum = "17889816334ce9d05ab0c292f93514fdd863b8537a35852dda609ebe3f48071d"
 dependencies = [
  "dashmap",
- "indexmap 1.9.3",
+ "indexmap 2.2.5",
  "once_cell",
  "petgraph",
  "rustc-hash",
@@ -7201,9 +8018,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.168.52"
+version = "0.171.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17e1f409e026be953fabb327923ebc5fdc7c664bcac036b76107834798640ed"
+checksum = "35f0a72ee781aa9208836046fd2c12e483f5515898858511b68863290cb97b45"
 dependencies = [
  "either",
  "rustc-hash",
@@ -7221,13 +8038,13 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.180.52"
+version = "0.183.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa7f368a80f28eeaa0f529cff6fb5d7578ef10a60be25bfd2582cb3f8ff5c9e"
+checksum = "f0ec75c1194365abe4d44d94e58f918ec853469ecd39733b381a089cfdcdee1a"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.7",
  "dashmap",
- "indexmap 1.9.3",
+ "indexmap 2.2.5",
  "once_cell",
  "serde",
  "sha-1",
@@ -7245,9 +8062,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.185.52"
+version = "0.188.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa2950c85abb4d555e092503ad2fa4f6dec0ee36a719273fb7a7bb29ead9ab6"
+checksum = "fec5e95a9c840eb13562884123eaa627cb6e05e0461c94a2ce69ae7e70313010"
 dependencies = [
  "ryu-js",
  "serde",
@@ -7262,11 +8079,11 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.124.32"
+version = "0.127.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a4a0baf6cfa490666a9fe23a17490273f843d19ebc1d6ec89d64c3f8ccdb80"
+checksum = "14482e455df85486d68a51533a31645d511e56df93a35cadf0eabbe7abe96b98"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap 2.2.5",
  "num_cpus",
  "once_cell",
  "rustc-hash",
@@ -7280,9 +8097,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.96.10"
+version = "0.98.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba962f0becf83bab12a17365dface5a4f636c9e1743d479e292b96910a753743"
+checksum = "df0127694c36d656ea9eab5c170cdd8ab398246ae2a335de26961c913a4aca47"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -7294,11 +8111,10 @@ dependencies = [
 
 [[package]]
 name = "swc_eq_ignore_macros"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a95d367e228d52484c53336991fdcf47b6b553ef835d9159db4ba40efb0ee8"
+checksum = "695a1d8b461033d32429b5befbf0ad4d7a2c4d6ba9cd5ba4e0645c615839e8e4"
 dependencies = [
- "pmutil",
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "syn 2.0.52",
@@ -7306,11 +8122,11 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.21.9"
+version = "0.21.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8117f6d10bbcb30cb3e549d6fa7637cb6d7c713cb71b2ce1808105a6825c788d"
+checksum = "91bea847755eb7b131edb83c1a437d353e9d25cabd92ac27655420dd13c7267b"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap 2.2.5",
  "petgraph",
  "rustc-hash",
  "swc_common",
@@ -7318,9 +8134,9 @@ dependencies = [
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "0.22.11"
+version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de8f0ac33ef7486723a3acdd9c4541dac79f0433bf878b9075826bca1163d83e"
+checksum = "1f1469d9d6d5c6f3b469348262ab6bda2c8a9d8e3db7298d9f71f6d17986895d"
 dependencies = [
  "auto_impl",
  "petgraph",
@@ -7331,11 +8147,10 @@ dependencies = [
 
 [[package]]
 name = "swc_macros_common"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a273205ccb09b51fabe88c49f3b34c5a4631c4c00a16ae20e03111d6a42e832"
+checksum = "50176cfc1cbc8bb22f41c6fe9d1ec53fbe057001219b5954961b8ad0f336fce9"
 dependencies = [
- "pmutil",
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "syn 2.0.52",
@@ -7343,9 +8158,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit"
-version = "0.5.7"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87c337fbb2d191bf371173dea6a957f01899adb8f189c6c31b122a6cfc98fc3"
+checksum = "358e246dedeb4ae8efacebcce1360dc2f9b6c0b4c1ad8b737cc60f5b6633691a"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -7353,9 +8168,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit_macros"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f322730fb82f3930a450ac24de8c98523af7d34ab8cb2f46bcb405839891a99"
+checksum = "fbbbb9d77d5112f90ed7ea00477135b16c4370c872b93a0b63b766e8710650ad"
 dependencies = [
  "Inflector",
  "pmutil",
@@ -7417,27 +8232,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "system-interface"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7489,6 +8283,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b319995299c65d522680decf80f2c108d85b861d81dfe340a10d16cee29d9e6"
+dependencies = [
+ "env_logger 0.11.2",
+ "test-log-macros",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8f546451eaa38373f549093fe9fd05e7d2bade739e2ddf834b9968621d60107"
+dependencies = [
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -7850,8 +8665,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2",
- "http",
+ "h2 0.3.24",
+ "http 0.2.11",
  "http-body 0.4.6",
  "hyper 0.14.28",
  "hyper-timeout",
@@ -8072,7 +8887,7 @@ dependencies = [
  "anyhow",
  "cc",
  "dirs 3.0.2",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
  "regex",
  "serde",
@@ -8385,14 +9200,14 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.81.0"
+version = "0.83.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75f5f378b9b54aff3b10da8170d26af4cfd217f644cf671badcd13af5db4beb"
+checksum = "9f6c8a960dd2eb74b22eda64f7e9f3d1688f82b80202828dc0425ebdeda826ef"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "fslock",
  "once_cell",
- "which 4.4.2",
+ "which 5.0.0",
 ]
 
 [[package]]
@@ -8406,6 +9221,18 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "value-trait"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad8db98c1e677797df21ba03fca7d3bf9bec3ca38db930954e4fe6e1ea27eb4"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
+]
 
 [[package]]
 name = "vcpkg"
@@ -8661,9 +9488,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -9129,6 +9956,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
+name = "wgpu-core"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef91c1d62d1e9e81c79e600131a258edf75c9531cbdbde09c44a011a47312726"
+dependencies = [
+ "arrayvec",
+ "bit-vec",
+ "bitflags 2.4.2",
+ "codespan-reporting",
+ "log",
+ "naga",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "ron",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "thiserror",
+ "web-sys",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84ecc802da3eb67b4cf3dd9ea6fe45bbb47ef13e6c49c5c3240868a9cc6cdd9"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags 2.4.2",
+ "block",
+ "core-graphics-types",
+ "d3d12",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-alloc",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading 0.8.3",
+ "log",
+ "metal",
+ "naga",
+ "objc",
+ "once_cell",
+ "parking_lot",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "rustc-hash",
+ "smallvec",
+ "thiserror",
+ "wasm-bindgen",
+ "web-sys",
+ "wgpu-types",
+ "winapi",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d5ed5f0edf0de351fe311c53304986315ce866f394a2e6df0c4b3c70774bcdd"
+dependencies = [
+ "bitflags 2.4.2",
+ "js-sys",
+ "serde",
+ "web-sys",
+]
+
+[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9262,6 +10167,25 @@ dependencies = [
  "target-lexicon",
  "wasmparser 0.112.0",
  "wasmtime-environ",
+]
+
+[[package]]
+name = "windows"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
+dependencies = [
+ "windows-core 0.51.1",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -9578,6 +10502,12 @@ dependencies = [
  "linux-raw-sys",
  "rustix",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,15 +58,15 @@ chrono = { version = "0.4.22", default-features = false, features = ["clock"] }
 codemap = "0.1.3"
 codemap-diagnostic = "0.1.1"
 ctor = "0.2.6"
-deno = { git = "https://github.com/exograph/deno.git", branch = "patched_1_38_5" }
-deno_ast = "0.31.6"
-deno_core = "0.232.0"
-deno_fs = { git = "https://github.com/exograph/deno.git", branch = "patched_1_38_5" }
-deno_graph = "=0.61.1"
-deno_runtime = { git = "https://github.com/exograph/deno.git", branch = "patched_1_38_5" }
-deno_virtual_fs = { git = "https://github.com/exograph/deno.git", branch = "patched_1_38_5" }
-deno_semver = "0.5.1"
-deno_npm = "0.15.2"
+deno = { git = "https://github.com/exograph/deno.git", branch = "patched_1_41_1" }
+deno_ast = "0.34.1"
+deno_core = "0.265.0"
+deno_fs = { git = "https://github.com/exograph/deno.git", branch = "patched_1_41_1" }
+deno_graph = "=0.69.6"
+deno_runtime = { git = "https://github.com/exograph/deno.git", branch = "patched_1_41_1" }
+deno_virtual_fs = { git = "https://github.com/exograph/deno.git", branch = "patched_1_41_1" }
+deno_semver = "=0.5.4"
+deno_npm = "=0.17.0"
 futures = "0.3.29"
 heck = "0.4.0"
 include_dir = "0.7.2"
@@ -84,6 +84,7 @@ reqwest = { version = "0.11.4", default-features = false, features = [
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 tempfile = "3.0.0"
+test-log = "0.2.15"
 thiserror = "1.0.31"
 tracing = "0.1"
 tokio = "1"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -9,10 +9,6 @@ repository = "https://github.com/exograph/exograph"
 name = "exo"
 path = "src/main.rs"
 
-[features]
-cross = ["testing/cross"]
-not_cross = ["testing/not_cross"]
-
 [dependencies]
 colored.workspace = true
 tokio.workspace = true

--- a/crates/common/src/env_const.rs
+++ b/crates/common/src/env_const.rs
@@ -62,10 +62,7 @@ pub fn get_deployment_mode() -> Result<DeploymentMode, EnvError> {
 }
 
 pub fn is_production() -> bool {
-    match get_deployment_mode() {
-        Ok(DeploymentMode::Prod) | Err(_) => true,
-        _ => false,
-    }
+    matches!(get_deployment_mode(), Ok(DeploymentMode::Prod) | Err(_))
 }
 
 pub fn get_enforce_trusted_documents() -> bool {

--- a/crates/deno-subsystem/deno-resolver-dynamic/Cargo.toml
+++ b/crates/deno-subsystem/deno-resolver-dynamic/Cargo.toml
@@ -8,12 +8,6 @@ publish = false
 core-plugin-interface = { path = "../../core-subsystem/core-plugin-interface" }
 deno-resolver = { path = "../deno-resolver" }
 
-[features]
-cross = ["deno-resolver/cross"]
-not_cross = ["deno-resolver/not_cross"]
-
-[dev-dependencies]
-
 [lib]
 crate-type = ["cdylib"]
 doctest = false

--- a/crates/deno-subsystem/deno-resolver/Cargo.toml
+++ b/crates/deno-subsystem/deno-resolver/Cargo.toml
@@ -25,14 +25,10 @@ exo-deno = { path = "../../../libs/exo-deno" }
 core-plugin-interface = { path = "../../core-subsystem/core-plugin-interface" }
 deno-model = { path = "../deno-model" }
 
-[features]
-cross = ["exo-deno/cross"]
-not_cross = ["exo-deno/not_cross"]
-
 [dev-dependencies]
 tokio.workspace = true
 builder = { path = "../../builder" }
-
+test-log.workspace = true
 
 [lib]
 crate-type = ["lib"]

--- a/crates/deno-subsystem/deno-resolver/extension/__init.js
+++ b/crates/deno-subsystem/deno-resolver/extension/__init.js
@@ -1,0 +1,3 @@
+import * as exograph from "exograph:ops";
+
+exograph;

--- a/crates/deno-subsystem/deno-resolver/extension/exograph.js
+++ b/crates/deno-subsystem/deno-resolver/extension/exograph.js
@@ -33,43 +33,6 @@ globalThis.ExographExtension = ({
         return op_exograph_add_header(header, value)
     },
 
-    setCookie: function (
-        cookie
-    ) {
-        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
-        let cookieString = `${encodeURIComponent(cookie.name)}=${encodeURIComponent(cookie.value)}`;
-
-        if (cookie.expires) {
-            cookieString += `; Expires=${cookie.expires.toUTCString()}`
-        }
-
-        if (cookie.maxAge) {
-            cookieString += `; Max-Age=${cookie.maxAge}`
-        }
-
-        if (cookie.domain) {
-            cookieString += `; Domain=${cookie.domain}`
-        }
-
-        if (cookie.path) {
-            cookieString += `; Path=${cookie.path}`
-        }
-
-        if (cookie.secure) {
-            cookieString += `; Secure`
-        }
-
-        if (cookie.httpOnly) {
-            cookieString += `; HttpOnly`
-        }
-
-        if (cookie.sameSite) {
-            cookieString += `; SameSite=${cookie.sameSite}`
-        }
-
-        return op_exograph_add_header("Set-Cookie", cookieString)
-    },
-
     executeQueryPriv: async function (query_string, variables, context_override) {
         const result = await op_exograph_execute_query_priv(query_string, variables, context_override);
         return result;

--- a/crates/deno-subsystem/deno-resolver/extension/exograph.js
+++ b/crates/deno-subsystem/deno-resolver/extension/exograph.js
@@ -6,15 +6,31 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
+const {
+    op_exograph_execute_query,
+    op_exograph_execute_query_priv,
+    op_exograph_add_header,
+    op_exograph_version,
+    op_operation_name,
+    op_operation_query,
+    op_operation_proceed,
+} = Deno.core.ensureFastOps();
 
-({
+export function exograph_version() {
+    return op_exograph_version();
+}
+
+// TODO: There's a lot of duplication between the shim code and the extension.
+// Ideally we'd get rid of the shim code and just expose the code directly from the extension.
+//
+globalThis.ExographExtension = ({
     executeQuery: async function (query_string, variables) {
-        const result = await ExographExtension.executeQuery(query_string, variables);
+        const result = await op_exograph_execute_query(query_string, variables);
         return result;
     },
 
     addResponseHeader: function (header, value) {
-        return ExographExtension.addResponseHeader(header, value)
+        return op_exograph_add_header(header, value)
     },
 
     setCookie: function (
@@ -51,6 +67,23 @@
             cookieString += `; SameSite=${cookie.sameSite}`
         }
 
-        return ExographExtension.addResponseHeader("Set-Cookie", cookieString)
+        return op_exograph_add_header("Set-Cookie", cookieString)
+    },
+
+    executeQueryPriv: async function (query_string, variables, context_override) {
+        const result = await op_exograph_execute_query_priv(query_string, variables, context_override);
+        return result;
+    },
+})
+
+globalThis.ExographOperation = ({
+    name: function () {
+        return op_operation_name()
+    },
+    proceed: async function () {
+        return await op_operation_proceed()
+    },
+    query: function () {
+        return op_operation_query()
     }
 })

--- a/crates/deno-subsystem/deno-resolver/src/exograph_ops.rs
+++ b/crates/deno-subsystem/deno-resolver/src/exograph_ops.rs
@@ -98,6 +98,12 @@ pub async fn op_exograph_execute_query_priv(
 
 #[op2]
 #[string]
+pub fn op_exograph_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+#[op2]
+#[string]
 pub fn op_operation_name(state: &mut OpState) -> Result<String, AnyError> {
     // try to read the intercepted operation name out of Deno's GothamStorage
     if let Some(InterceptedOperationInfo { name, .. }) = state.borrow() {

--- a/crates/deno-subsystem/deno-resolver/src/operation_shim.js
+++ b/crates/deno-subsystem/deno-resolver/src/operation_shim.js
@@ -8,13 +8,13 @@
 // by the Apache License, Version 2.0.
 
 ({
-  name: function () {
-      return Deno[Deno.internal].core.ops.op_operation_name()
-  },
-  proceed: async function () {
-      return await Deno[Deno.internal].core.opAsync("op_operation_proceed")
-  },
-  query: function () {
-      return Deno[Deno.internal].core.ops.op_operation_query()
-  }
+    name: function () {
+        return ExographOperation.name()
+    },
+    proceed: async function () {
+        return await ExographOperation.proceed()
+    },
+    query: function () {
+        return ExographOperation.query()
+    }
 })

--- a/crates/deno-subsystem/deno-resolver/src/test_js/test_exograph_extension.js
+++ b/crates/deno-subsystem/deno-resolver/src/test_js/test_exograph_extension.js
@@ -7,9 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-({
-    executeQueryPriv: async function (query_string, variables, context_override) {
-        const result = await ExographExtension.executeQueryPriv(query_string, variables, context_override);
-        return result;
-    },
-})
+import { exograph_version } from "exograph:ops";
+
+export function exographVersion() {
+    return exograph_version()
+}

--- a/crates/server-actix/Cargo.toml
+++ b/crates/server-actix/Cargo.toml
@@ -16,9 +16,6 @@ static-postgres-resolver = ["server-common/static-postgres-resolver"]
 static-deno-resolver = ["server-common/static-deno-resolver"]
 static-wasm-resolver = ["server-common/static-wasm-resolver"]
 
-cross = ["server-common/cross"]
-not_cross = ["server-common/not_cross"]
-
 [dependencies]
 async-trait.workspace = true
 actix-web = { version = "4.5.1", default-features = false, features = [

--- a/crates/server-aws-lambda/Cargo.toml
+++ b/crates/server-aws-lambda/Cargo.toml
@@ -40,8 +40,6 @@ default = [
   "static-deno-resolver",
   "static-wasm-resolver",
 ]
-cross = ["server-common/cross"]
-not_cross = ["server-common/not_cross"]
 
 [[bin]]
 name = "bootstrap"

--- a/crates/server-common/Cargo.toml
+++ b/crates/server-common/Cargo.toml
@@ -17,8 +17,6 @@ wasm-resolver = { path = "../wasm-subsystem/wasm-resolver", optional = true }
 static-postgres-resolver = ["postgres-resolver"]
 static-deno-resolver = ["deno-resolver"]
 static-wasm-resolver = ["wasm-resolver"]
-cross = ["deno-resolver/cross"]
-not_cross = ["deno-resolver/not_cross"]
 
 [lib]
 doctest = false

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -13,8 +13,6 @@ default = [
   "static-deno-resolver",
   "static-wasm-resolver",
 ]
-cross = ["exo-deno/cross"]
-not_cross = ["exo-deno/not_cross"]
 
 [dependencies]
 anyhow.workspace = true

--- a/libs/exo-deno/Cargo.toml
+++ b/libs/exo-deno/Cargo.toml
@@ -19,7 +19,7 @@ deno_runtime = { workspace = true, features = ["include_js_files_for_snapshottin
 [dependencies]
 thiserror.workspace = true
 async-trait.workspace = true
-deno_runtime = { workspace = true }
+deno_runtime.workspace = true
 deno_core.workspace = true
 deno_fs.workspace = true
 deno_virtual_fs.workspace = true

--- a/libs/exo-deno/Cargo.toml
+++ b/libs/exo-deno/Cargo.toml
@@ -10,16 +10,16 @@ doctest = false
 [features]
 default = []
 typescript-loader = ["dep:deno_ast"]
-cross = [
-  "deno_runtime/dont_create_runtime_snapshot",
-  "deno_runtime/__runtime_js_sources",
-]
-not_cross = ["deno_runtime/include_js_files_for_snapshotting"]
+
+[build-dependencies]
+deno.workspace = true
+deno_core.workspace = true
+deno_runtime = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 
 [dependencies]
 thiserror.workspace = true
 async-trait.workspace = true
-deno_runtime.workspace = true
+deno_runtime = { workspace = true }
 deno_core.workspace = true
 deno_fs.workspace = true
 deno_virtual_fs.workspace = true
@@ -40,3 +40,4 @@ tempfile.workspace = true
 
 [dev-dependencies]
 ctor.workspace = true
+test-log.workspace = true

--- a/libs/exo-deno/build.rs
+++ b/libs/exo-deno/build.rs
@@ -1,0 +1,16 @@
+fn main() {
+    use deno_runtime::ops::bootstrap::SnapshotOptions;
+    use std::path::PathBuf;
+
+    let snapshot_options = SnapshotOptions {
+        deno_version: deno::version::deno().to_string(),
+        ts_version: deno::version::TYPESCRIPT.to_string(),
+        v8_version: deno_core::v8_version(),
+        target: std::env::var("TARGET").unwrap(),
+    };
+
+    let o = PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
+    let snapshot_path = o.join("RUNTIME_SNAPSHOT.bin");
+
+    deno_runtime::snapshot::create_runtime_snapshot(snapshot_path, snapshot_options);
+}

--- a/libs/exo-deno/src/lib.rs
+++ b/libs/exo-deno/src/lib.rs
@@ -27,6 +27,12 @@ mod typescript_module_loader;
 
 pub use deno_core;
 
+static RUNTIME_SNAPSHOT: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/RUNTIME_SNAPSHOT.bin"));
+
+pub(crate) fn deno_snapshot() -> &'static [u8] {
+    RUNTIME_SNAPSHOT
+}
+
 #[cfg(test)]
 use ctor::ctor;
 

--- a/libs/exo-deno/src/test_js/_init.js
+++ b/libs/exo-deno/src/test_js/_init.js
@@ -1,0 +1,3 @@
+import * as through_rust from "test:through_rust";
+
+through_rust;

--- a/libs/exo-deno/src/test_js/through_rust.js
+++ b/libs/exo-deno/src/test_js/through_rust.js
@@ -1,0 +1,12 @@
+const {
+    op_rust_impl,
+    op_async_rust_impl,
+} = Deno.core.ensureFastOps();
+
+export function rust_impl(value) {
+    return op_rust_impl(value);
+}
+
+export function async_rust_impl(value) {
+    return op_async_rust_impl(value);
+}

--- a/libs/exo-deno/src/test_js/through_rust.js
+++ b/libs/exo-deno/src/test_js/through_rust.js
@@ -7,6 +7,6 @@ export function rust_impl(value) {
     return op_rust_impl(value);
 }
 
-export function async_rust_impl(value) {
+export async function async_rust_impl(value) {
     return op_async_rust_impl(value);
 }

--- a/libs/exo-deno/src/test_js/through_rust_fn.js
+++ b/libs/exo-deno/src/test_js/through_rust_fn.js
@@ -6,11 +6,12 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
+import { rust_impl, async_rust_impl } from "test:through_rust";
 
 export function syncUsingRegisteredFunction(value) {
-  return Deno[Deno.internal].core.ops.rust_impl(value)
+  return rust_impl(value)
 }
 
-export async function asyncUsingRegisteredFunction(value) {
-  return Deno[Deno.internal].core.opAsync("async_rust_impl", value)
+export function asyncUsingRegisteredFunction(value) {
+  return async_rust_impl(value)
 }

--- a/libs/exo-deno/src/test_js/through_rust_fn.js
+++ b/libs/exo-deno/src/test_js/through_rust_fn.js
@@ -12,6 +12,6 @@ export function syncUsingRegisteredFunction(value) {
   return rust_impl(value)
 }
 
-export function asyncUsingRegisteredFunction(value) {
+export async function asyncUsingRegisteredFunction(value) {
   return async_rust_impl(value)
 }


### PR DESCRIPTION
This commit removes the 'cross' feature and we now build our own snapshot in exo-deno/build.rs, since deno_runtime no longer has a snapshotting feature built in.

We now expose deno_module test "ops" from Rust via extension esm files Deno is moving away from allowing user code to invoke "ops" directly and using `Deno[Deno.internal].core.ops` now fails. This is done for the tests in deno_module and also for the functionality that Exograph exposes to users via shims. The shim code now calls ESM code exposed via a Deno extension created in exo_execution.

This is a bit unwieldy, with multiple JS files essentially doing the same thing, so we should look to improve how it is done in future, ideally removing the shim files and working directly with the extension.