### PR TITLE
Remove the Xcode override from the CI workflow

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -52,14 +52,6 @@ jobs:
         if: ${{ runner.os != 'Windows' }}
         run: |
           bash ${PWD}/.github/workflows/clear-disk-space.sh
-      - name: Select the latest Xcode version
-        # The default version of Xcode on macos-14 is 15.1, which leads to https://github.com/rust-lang/rust/issues/113783.
-        # So we set up Xcode to use the latest stable version (currently 15.2).
-        # For other macos versions, the latest stable version happens to be the default
-        if: ${{ runner.os == 'macOS' }}
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
       - name: Install deps
         run: ${{ matrix.deps-script }}
       - name: Setup Node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,14 +66,6 @@ jobs:
         if: ${{ runner.os != 'Windows' }}
         run: |
           bash ${PWD}/.github/workflows/clear-disk-space.sh
-      - name: Select the latest Xcode version
-        # The default version of Xcode on macos-14 is 15.1, which leads to https://github.com/rust-lang/rust/issues/113783.
-        # So we set up Xcode to use the latest stable version (currently 15.2).
-        # For other macos versions, the latest stable version happens to be the default
-        if: ${{ runner.os == 'macOS' }}
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
       - name: Install deps
         run: ${{ matrix.deps-script }}
       - name: Setup Node


### PR DESCRIPTION
We no longer need to override the Xcode version since the CI image already has a newer version installed.