### PR TITLE
Only run graphiql build once per subfolder

### DIFF
--- a/libs/exo-deno/build.rs
+++ b/libs/exo-deno/build.rs
@@ -13,4 +13,7 @@ fn main() {
     let snapshot_path = o.join("RUNTIME_SNAPSHOT.bin");
 
     deno_runtime::snapshot::create_runtime_snapshot(snapshot_path, snapshot_options);
+
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=TARGET");
 }


### PR DESCRIPTION
Only run graphiql build once per subfolder

The original change to `build.rs` was buggy in that it recompiled `graphiql` over and over, leading to super high compilation latency.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/exograph/exograph/pull/1067).
* #1068
* __->__ #1067