### PR TITLE
Allow external components to control GraphiQL theme

### DIFF
--- a/graphiql/lib/src/Logo.tsx
+++ b/graphiql/lib/src/Logo.tsx
@@ -1,13 +1,9 @@
-import { useTheme } from "./theme";
+import { Theme } from "./theme";
 
 import { default as DarkLogo } from "../public/logo-dark.svg";
 import { default as LightLogo } from "../public/logo-light.svg";
 
-function ExographLogo() {
-  const theme = useTheme();
-
-  // Currently, switching mode in GraphiQL doesn't update the logo, but this will get fixed
-  // when https://github.com/graphql/graphiql/pull/2971 is merged.
+function ExographLogo({ theme }: { theme: Theme }) {
   // Vite treats imports as strings, but Webpack (in Docusaurus configuration) treats them as React components.
   // So, we use `vite-plugin-svgr` in Vite vite to convert SVGs to React components, but we need to cast them to `any` to avoid TypeScript errors.
   const Logo = (theme === "dark" ? DarkLogo : LightLogo) as any;
@@ -24,10 +20,10 @@ function ExographLogo() {
   );
 }
 
-export function Logo() {
+export function Logo({ theme }: { theme: Theme }) {
   return (
     <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
-      <ExographLogo />
+      <ExographLogo theme={theme} />
     </div>
   );
 }


### PR DESCRIPTION
External components can pass explicit theme values to GraphiQL, allowing to sync with their own theme.