### PR TITLE
Allow JWT support to be compiled on WebAssembly

### DIFF
--- a/crates/builder/src/builder/system_builder.rs
+++ b/crates/builder/src/builder/system_builder.rs
@@ -13,7 +13,6 @@ use core_model_builder::typechecker::typ::TypecheckedSystem;
 use core_plugin_interface::interface::SubsystemBuilder;
 use core_plugin_shared::serializable_system::SerializableSubsystem;
 use core_plugin_shared::serializable_system::SerializableSystem;
-use core_plugin_shared::system_serializer::SystemSerializer;
 use core_plugin_shared::trusted_documents::TrustedDocuments;
 
 /// Build a [ModelSystem] given an [AstSystem].
@@ -37,7 +36,7 @@ pub async fn build(
     subsystem_builders: &[Box<dyn SubsystemBuilder + Send + Sync>],
     typechecked_system: TypecheckedSystem,
     trusted_documents: TrustedDocuments,
-) -> Result<Vec<u8>, ModelBuildingError> {
+) -> Result<SerializableSystem, ModelBuildingError> {
     let base_system = core_model_builder::builder::system_builder::build(&typechecked_system)?;
 
     let mut subsystem_interceptions = vec![];
@@ -81,12 +80,10 @@ pub async fn build(
         OperationKind::Mutation,
     );
 
-    let system = SerializableSystem {
+    Ok(SerializableSystem {
         subsystems,
         query_interception_map,
         mutation_interception_map,
         trusted_documents,
-    };
-
-    system.serialize().map_err(ModelBuildingError::Serialize)
+    })
 }

--- a/crates/builder/wasm-sysroot/stddef.h
+++ b/crates/builder/wasm-sysroot/stddef.h
@@ -1,0 +1,1 @@
+typedef long unsigned int size_t;

--- a/crates/builder/wasm-sysroot/stdint.h
+++ b/crates/builder/wasm-sysroot/stdint.h
@@ -7,3 +7,11 @@ typedef unsigned char uint8_t;
 typedef unsigned short uint16_t;
 typedef unsigned long uint32_t;
 typedef unsigned long long uint64_t;
+
+typedef unsigned long int	uintptr_t;
+
+# define UINT8_C(c)	c
+# define UINT32_C(c)	c ## U
+# define UINT64_C(c)	c ## ULL
+
+# define SIZE_MAX		(4294967295UL)

--- a/crates/cli/src/commands/schema/util.rs
+++ b/crates/cli/src/commands/schema/util.rs
@@ -21,11 +21,9 @@ pub(crate) async fn create_postgres_system(
     model_file: impl AsRef<Path>,
     trusted_documents_dir: Option<&Path>,
 ) -> Result<PostgresSubsystem, ParserError> {
-    let serialized_system =
-        build_system_with_static_builders(model_file.as_ref(), trusted_documents_dir).await?;
-    let system = SerializableSystem::deserialize(serialized_system)?;
-
-    deserialize_postgres_subsystem(system)
+    deserialize_postgres_subsystem(
+        build_system_with_static_builders(model_file.as_ref(), trusted_documents_dir).await?,
+    )
 }
 
 fn deserialize_postgres_subsystem(

--- a/crates/core-subsystem/core-resolver/Cargo.toml
+++ b/crates/core-subsystem/core-resolver/Cargo.toml
@@ -7,7 +7,8 @@ publish = false
 [features]
 default = []
 test-context = []
-jwt = ["jsonwebtoken", "reqwest", "oidc-jwt-validator"]
+jwt = ["jsonwebtoken"]
+oidc = ["jwt", "reqwest", "oidc-jwt-validator"]
 
 [dependencies]
 async-graphql-parser.workspace = true

--- a/crates/core-subsystem/core-resolver/Cargo.toml
+++ b/crates/core-subsystem/core-resolver/Cargo.toml
@@ -7,8 +7,7 @@ publish = false
 [features]
 default = []
 test-context = []
-jwt = ["jsonwebtoken"]
-oidc = ["jwt", "reqwest", "oidc-jwt-validator"]
+oidc = ["reqwest", "oidc-jwt-validator"]
 
 [dependencies]
 async-graphql-parser.workspace = true
@@ -19,7 +18,7 @@ async-trait.workspace = true
 bytes.workspace = true
 futures.workspace = true
 serde_json = { workspace = true, features = ["preserve_order"] }
-jsonwebtoken = { workspace = true, optional = true }
+jsonwebtoken = { workspace = true }
 reqwest = { workspace = true, optional = true }
 oidc-jwt-validator = { version = "0.2.3", optional = true }
 serde.workspace = true
@@ -49,4 +48,3 @@ core-plugin-interface = { path = "../core-plugin-interface" }
 
 [lib]
 doctest = false
-

--- a/crates/core-subsystem/core-resolver/src/context/mod.rs
+++ b/crates/core-subsystem/core-resolver/src/context/mod.rs
@@ -15,7 +15,6 @@ mod request;
 mod request_context;
 mod user_request_context;
 
-#[cfg(feature = "jwt")]
 pub use provider::jwt::{JwtAuthenticator, LOCAL_JWT_SECRET};
 
 pub use error::ContextExtractionError;

--- a/crates/core-subsystem/core-resolver/src/context/provider/jwt/authenticator.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/jwt/authenticator.rs
@@ -56,20 +56,17 @@ pub enum JwtConfigurationError {
 impl JwtAuthenticator {
     pub async fn new_from_env() -> Result<Option<Self>, JwtConfigurationError> {
         let secret = LOCAL_JWT_SECRET.with(|local_jwt_secret| {
-            local_jwt_secret
-                .borrow()
-                .clone()
-                .or_else(|| {
-                    #[cfg(not(target_family = "wasm"))]
-                    {
-                        env::var(EXO_JWT_SECRET).ok()
-                    }
+            local_jwt_secret.borrow().clone().or_else(|| {
+                #[cfg(not(target_family = "wasm"))]
+                {
+                    env::var(EXO_JWT_SECRET).ok()
+                }
 
-                    #[cfg(target_family = "wasm")]
-                    {
-                        None
-                    }
-                })
+                #[cfg(target_family = "wasm")]
+                {
+                    None
+                }
+            })
         });
 
         #[cfg(feature = "oidc")]

--- a/crates/core-subsystem/core-resolver/src/context/provider/jwt/authenticator.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/jwt/authenticator.rs
@@ -1,6 +1,8 @@
 use std::cell::RefCell;
+#[cfg(not(target_family = "wasm"))]
 use std::env;
 
+#[cfg(not(target_family = "wasm"))]
 use common::env_const::{EXO_JWT_SECRET, EXO_OIDC_URL};
 use jsonwebtoken::{decode, DecodingKey, Validation};
 use serde_json::Value;
@@ -11,11 +13,13 @@ use tracing::error;
 use crate::context::error::ContextExtractionError;
 use crate::context::request::Request;
 
+#[cfg(feature = "oidc")]
 use super::oidc::Oidc;
 
 // we spawn many resolvers concurrently in integration tests
 thread_local! {
     pub static LOCAL_JWT_SECRET: RefCell<Option<String>> =  const { RefCell::new(None) };
+    #[cfg(feature = "oidc")]
     pub static LOCAL_OIDC_URL: RefCell<Option<String>> =  const {RefCell::new(None) };
 }
 
@@ -23,6 +27,7 @@ thread_local! {
 /// It can be either a secret or a OIDC url
 pub enum JwtAuthenticator {
     Secret(String),
+    #[cfg(feature = "oidc")]
     Oidc(Oidc),
 }
 
@@ -54,19 +59,37 @@ impl JwtAuthenticator {
             local_jwt_secret
                 .borrow()
                 .clone()
-                .or_else(|| env::var(EXO_JWT_SECRET).ok())
+                .or_else(|| {
+                    #[cfg(not(target_family = "wasm"))]
+                    {
+                        env::var(EXO_JWT_SECRET).ok()
+                    }
+
+                    #[cfg(target_family = "wasm")]
+                    {
+                        None
+                    }
+                })
         });
 
+        #[cfg(feature = "oidc")]
         let oidc_url =
             LOCAL_OIDC_URL.with(|url| url.borrow().clone().or_else(|| env::var(EXO_OIDC_URL).ok()));
 
+        #[cfg(not(feature = "oidc"))]
+        let oidc_url: Option<String> = None;
+
         match (secret, oidc_url) {
             (Some(secret), None) => Ok(Some(JwtAuthenticator::Secret(secret))),
+            #[cfg(feature = "oidc")]
             (None, Some(oidc_url)) => Ok(Some(JwtAuthenticator::Oidc(Oidc::new(oidc_url).await?))),
+            #[cfg(feature = "oidc")]
             (Some(_), Some(_)) => {
                 Err(JwtConfigurationError::InvalidSetup(format!("Both {EXO_JWT_SECRET} and {EXO_OIDC_URL} are set. Only one of them can be set at a time")))
             }
             (None, None) => Ok(None),
+            #[cfg(not(feature = "oidc"))]
+            (_, Some(_)) => unreachable!()
         }
     }
 
@@ -88,6 +111,7 @@ impl JwtAuthenticator {
             )
             .map_err(map_jwt_error)?
             .claims),
+            #[cfg(feature = "oidc")]
             JwtAuthenticator::Oidc(oidc) => oidc.validate(token).await.map_err(|err| match err {
                 oidc_jwt_validator::ValidationError::ValidationFailed(err) => map_jwt_error(err),
                 err => {

--- a/crates/core-subsystem/core-resolver/src/context/provider/jwt/extractor.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/jwt/extractor.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+#[cfg(not(target_family = "wasm"))]
 use common::env_const::{EXO_JWT_SECRET, EXO_OIDC_URL};
 use serde_json::Value;
 use tokio::sync::OnceCell;
@@ -33,6 +34,12 @@ impl JwtExtractor {
         if let Some(jwt_authenticator) = self.jwt_authenticator.as_ref() {
             jwt_authenticator.extract_authentication(request).await
         } else {
+            #[cfg(target_family = "wasm")]
+            warn!(
+                "JWT secret or OIDC URL is not set, not parsing JWT tokens"
+            );
+
+            #[cfg(not(target_family = "wasm"))]
             warn!(
                 "{} or {} is not set, not parsing JWT tokens",
                 EXO_JWT_SECRET, EXO_OIDC_URL

--- a/crates/core-subsystem/core-resolver/src/context/provider/jwt/extractor.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/jwt/extractor.rs
@@ -35,9 +35,7 @@ impl JwtExtractor {
             jwt_authenticator.extract_authentication(request).await
         } else {
             #[cfg(target_family = "wasm")]
-            warn!(
-                "JWT secret or OIDC URL is not set, not parsing JWT tokens"
-            );
+            warn!("JWT secret or OIDC URL is not set, not parsing JWT tokens");
 
             #[cfg(not(target_family = "wasm"))]
             warn!(

--- a/crates/core-subsystem/core-resolver/src/context/provider/jwt/mod.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/jwt/mod.rs
@@ -9,6 +9,7 @@
 
 mod authenticator;
 mod extractor;
+#[cfg(feature = "oidc")]
 mod oidc;
 
 pub use authenticator::JwtAuthenticator;

--- a/crates/core-subsystem/core-resolver/src/context/provider/mod.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/mod.rs
@@ -11,6 +11,5 @@ pub(crate) mod cookie;
 pub(crate) mod environment;
 pub(crate) mod header;
 pub(crate) mod ip;
-#[cfg(feature = "jwt")]
 pub(crate) mod jwt;
 pub(crate) mod query;

--- a/crates/core-subsystem/core-resolver/src/context/user_request_context.rs
+++ b/crates/core-subsystem/core-resolver/src/context/user_request_context.rs
@@ -15,7 +15,6 @@ use exo_sql::TransactionHolder;
 
 use crate::{system_resolver::SystemResolver, value::Val};
 
-#[cfg(feature = "jwt")]
 use super::provider::jwt::JwtExtractor;
 use super::provider::{
     cookie::CookieExtractor, environment::EnvironmentContextExtractor, header::HeaderExtractor,
@@ -52,7 +51,6 @@ impl<'a> UserRequestContext<'a> {
             Box::new(HeaderExtractor),
             Box::new(IpExtractor),
             Box::new(CookieExtractor::new()),
-            #[cfg(feature = "jwt")]
             Box::new(JwtExtractor::new(system_resolver.jwt_authenticator.clone())),
         ];
 

--- a/crates/core-subsystem/core-resolver/src/system_resolver.rs
+++ b/crates/core-subsystem/core-resolver/src/system_resolver.rs
@@ -29,7 +29,6 @@ use thiserror::Error;
 use tokio::runtime::Handle;
 use tracing::{error, instrument, warn};
 
-#[cfg(feature = "jwt")]
 use crate::context::provider::jwt::JwtAuthenticator;
 
 use crate::{
@@ -62,7 +61,6 @@ pub struct SystemResolver {
     mutation_interception_map: InterceptionMap,
     trusted_documents: TrustedDocuments,
     schema: Schema,
-    #[cfg(feature = "jwt")]
     pub jwt_authenticator: Arc<Option<JwtAuthenticator>>,
     pub env: HashMap<String, String>,
     normal_query_depth_limit: usize,
@@ -77,8 +75,7 @@ impl SystemResolver {
         mutation_interception_map: InterceptionMap,
         trusted_documents: TrustedDocuments,
         schema: Schema,
-        #[cfg(feature = "jwt")] jwt_authenticator: Arc<Option<JwtAuthenticator>>,
-        #[cfg(not(feature = "jwt"))] jwt_authenticator: Arc<Option<()>>,
+        jwt_authenticator: Arc<Option<JwtAuthenticator>>,
         env: HashMap<String, String>,
         normal_query_depth_limit: usize,
         introspection_query_depth_limit: usize,
@@ -94,16 +91,12 @@ impl SystemResolver {
             }
         };
 
-        #[cfg(not(feature = "jwt"))]
-        assert!(jwt_authenticator.is_none());
-
         Self {
             subsystem_resolvers,
             query_interception_map,
             mutation_interception_map,
             trusted_documents,
             schema,
-            #[cfg(feature = "jwt")]
             jwt_authenticator,
             env,
             normal_query_depth_limit,

--- a/crates/core-subsystem/core-resolver/src/validation/document_validator.rs
+++ b/crates/core-subsystem/core-resolver/src/validation/document_validator.rs
@@ -111,9 +111,6 @@ mod tests {
     use super::*;
 
     use async_graphql_parser::parse_query;
-    use core_plugin_shared::{
-        serializable_system::SerializableSystem, system_serializer::SystemSerializer,
-    };
     use exo_sql::DatabaseClient;
 
     macro_rules! assert_debug {
@@ -845,7 +842,7 @@ mod tests {
         model_str: &str,
         file_name: String,
     ) -> Box<dyn core_plugin_interface::core_resolver::plugin::SubsystemResolver> {
-        let serialized_system = builder::build_system_from_str(
+        let system = builder::build_system_from_str(
             model_str,
             file_name,
             vec![Box::new(
@@ -854,7 +851,6 @@ mod tests {
         )
         .await
         .unwrap();
-        let system = SerializableSystem::deserialize(serialized_system).unwrap();
 
         let subsystem_id = "postgres";
 

--- a/crates/postgres-subsystem/postgres-model-builder/src/test_utils.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/test_utils.rs
@@ -20,14 +20,13 @@ pub(crate) async fn create_postgres_system_from_str(
     model_str: &str,
     file_name: String,
 ) -> Result<PostgresSubsystem, ModelSerializationError> {
-    let serialized_system = builder::build_system_from_str(
+    let system = builder::build_system_from_str(
         model_str,
         file_name,
         vec![Box::new(crate::PostgresSubsystemBuilder {})],
     )
     .await
     .unwrap();
-    let system = SerializableSystem::deserialize(serialized_system)?;
 
     deserialize_postgres_subsystem(system)
 }

--- a/crates/postgres-subsystem/postgres-model/src/migration.rs
+++ b/crates/postgres-subsystem/postgres-model/src/migration.rs
@@ -1604,9 +1604,7 @@ mod tests {
         model_str: &str,
         file_name: String,
     ) -> Result<PostgresSubsystem, ModelSerializationError> {
-        use core_plugin_interface::system_serializer::SystemSerializer;
-
-        let serialized_system = builder::build_system_from_str(
+        let system = builder::build_system_from_str(
             model_str,
             file_name,
             vec![Box::new(
@@ -1615,7 +1613,6 @@ mod tests {
         )
         .await
         .unwrap();
-        let system = SerializableSystem::deserialize(serialized_system)?;
 
         deserialize_postgres_subsystem(system)
     }

--- a/crates/postgres-subsystem/postgres-resolver/src/test_utils.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/test_utils.rs
@@ -21,7 +21,7 @@ pub(crate) async fn create_postgres_system_from_str(
     model_str: &str,
     file_name: String,
 ) -> Result<PostgresSubsystem, ModelSerializationError> {
-    let serialized_system = builder::build_system_from_str(
+    let system = builder::build_system_from_str(
         model_str,
         file_name,
         vec![Box::new(
@@ -30,7 +30,6 @@ pub(crate) async fn create_postgres_system_from_str(
     )
     .await
     .unwrap();
-    let system = SerializableSystem::deserialize(serialized_system)?;
 
     deserialize_postgres_subsystem(system)
 }

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -5,8 +5,7 @@ edition.workspace = true
 publish = false
 
 [features]
-jwt = ["core-resolver/jwt"]
-oidc = ["jwt", "core-resolver/oidc"]
+oidc = ["core-resolver/oidc"]
 
 [dependencies]
 async-recursion.workspace = true

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [features]
 jwt = ["core-resolver/jwt"]
+oidc = ["jwt", "core-resolver/oidc"]
 
 [dependencies]
 async-recursion.workspace = true

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -18,9 +18,8 @@ mod system_loader;
 #[cfg(not(target_family = "wasm"))]
 pub mod graphiql;
 pub use root_resolver::{
-    create_system_resolver, create_system_resolver_from_serialized_bytes,
-    create_system_resolver_or_exit, get_endpoint_http_path, get_playground_http_path, resolve,
-    resolve_in_memory, ResponseStream,
+    create_system_resolver, create_system_resolver_from_system, create_system_resolver_or_exit,
+    get_endpoint_http_path, get_playground_http_path, resolve, resolve_in_memory, ResponseStream,
 };
 pub use system_loader::{
     introspection_mode, IntrospectionMode, LOCAL_ALLOW_INTROSPECTION, LOCAL_ENVIRONMENT,

--- a/crates/resolver/src/root_resolver.rs
+++ b/crates/resolver/src/root_resolver.rs
@@ -15,6 +15,7 @@ use crate::system_loader::{StaticLoaders, SystemLoadingError};
 
 #[cfg(not(target_family = "wasm"))]
 use common::env_const::is_production;
+use core_plugin_shared::serializable_system::SerializableSystem;
 use core_plugin_shared::trusted_documents::TrustedDocumentEnforcement;
 use core_resolver::QueryResponse;
 
@@ -201,11 +202,11 @@ pub async fn create_system_resolver(
     }
 }
 
-pub async fn create_system_resolver_from_serialized_bytes(
-    bytes: Vec<u8>,
+pub async fn create_system_resolver_from_system(
+    system: SerializableSystem,
     static_loaders: StaticLoaders,
 ) -> Result<SystemResolver, SystemLoadingError> {
-    SystemLoader::load_from_bytes(bytes, static_loaders).await
+    SystemLoader::load_from_system(system, static_loaders).await
 }
 
 pub async fn create_system_resolver_or_exit(

--- a/crates/resolver/src/system_loader.rs
+++ b/crates/resolver/src/system_loader.rs
@@ -13,7 +13,6 @@ use std::sync::Arc;
 #[cfg(not(target_family = "wasm"))]
 use common::env_const::EXO_INTROSPECTION;
 use common::EnvError;
-#[cfg(feature = "jwt")]
 use core_resolver::context::JwtAuthenticator;
 use introspection_resolver::IntrospectionResolver;
 use thiserror::Error;
@@ -118,13 +117,9 @@ impl SystemLoader {
 
         let (normal_query_depth_limit, introspection_query_depth_limit) = query_depth_limits()?;
 
-        #[cfg(feature = "jwt")]
         let authenticator = JwtAuthenticator::new_from_env()
             .await
             .map_err(|e| SystemLoadingError::Config(e.to_string()))?;
-
-        #[cfg(not(feature = "jwt"))]
-        let authenticator = None;
 
         Ok(SystemResolver::new(
             subsystem_resolvers,

--- a/crates/resolver/src/system_loader.rs
+++ b/crates/resolver/src/system_loader.rs
@@ -49,20 +49,10 @@ impl SystemLoader {
         let serialized_system = SerializableSystem::deserialize_reader(read)
             .map_err(SystemLoadingError::ModelSerializationError)?;
 
-        Self::process(serialized_system, static_loaders).await
+        Self::load_from_system(serialized_system, static_loaders).await
     }
 
-    pub async fn load_from_bytes(
-        bytes: Vec<u8>,
-        static_loaders: StaticLoaders,
-    ) -> Result<SystemResolver, SystemLoadingError> {
-        let serialized_system = SerializableSystem::deserialize(bytes)
-            .map_err(SystemLoadingError::ModelSerializationError)?;
-
-        Self::process(serialized_system, static_loaders).await
-    }
-
-    async fn process(
+    pub async fn load_from_system(
         serialized_system: SerializableSystem,
         mut static_loaders: StaticLoaders,
     ) -> Result<SystemResolver, SystemLoadingError> {

--- a/crates/server-aws-lambda/tests/common.rs
+++ b/crates/server-aws-lambda/tests/common.rs
@@ -12,7 +12,7 @@
 use std::sync::Arc;
 
 use ::common::env_const::{EXO_CHECK_CONNECTION_ON_STARTUP, EXO_POSTGRES_URL};
-use resolver::create_system_resolver_from_serialized_bytes;
+use resolver::create_system_resolver_from_system;
 use serde_json::Value;
 use server_aws_lambda::resolve;
 use server_common::create_static_loaders;
@@ -31,7 +31,7 @@ pub async fn test_query(json_input: Value, exo_model: &str, expected: Value) {
         .await
         .unwrap();
     let system_resolver = Arc::new(
-        create_system_resolver_from_serialized_bytes(model_system, create_static_loaders())
+        create_system_resolver_from_system(model_system, create_static_loaders())
             .await
             .unwrap(),
     );

--- a/crates/server-common/Cargo.toml
+++ b/crates/server-common/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 common = { path = "../common", features = ["opentelemetry"] }
-resolver = { path = "../resolver", features = ["jwt"] }
+resolver = { path = "../resolver", features = ["oidc"] }
 core-resolver = { path = "../core-subsystem/core-resolver" }
 core-plugin-interface = { path = "../core-subsystem/core-plugin-interface" }
 postgres-resolver = { path = "../postgres-subsystem/postgres-resolver", features = ["network", "bigdecimal", "vector"], optional = true }

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -38,7 +38,7 @@ exo-sql = { path = "../../libs/exo-sql", features = [ "tls", "postgres-url", "te
 exo-deno = { path = "../../libs/exo-deno", features = ["typescript-loader"] }
 
 core-resolver = { path = "../core-subsystem/core-resolver" }
-resolver = { path = "../resolver", features = ["jwt"] }
+resolver = { path = "../resolver", features = ["oidc"] }
 
 core-plugin-interface = { path = "../core-subsystem/core-plugin-interface" }
 


### PR DESCRIPTION
Allow JWT support to be compiled on WebAssembly

Compile with:
```
TARGET_CFLAGS=-I$PWD/crates/builder/wasm-sysroot cargo build -p resolver --target wasm32-unknown-unknown --no-default-features --features jwt
```
