### PR TITLE
Make migration-related structs serializable [skip ci]

### DIFF
--- a/crates/postgres-subsystem/postgres-model/src/migration.rs
+++ b/crates/postgres-subsystem/postgres-model/src/migration.rs
@@ -15,13 +15,14 @@ use exo_sql::{
     schema::{database_spec::DatabaseSpec, issue::WithIssues, op::SchemaOp, spec::diff},
     DatabaseClient,
 };
+use serde::Serialize;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct Migration {
     pub statements: Vec<MigrationStatement>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct MigrationStatement {
     pub statement: String,
     pub is_destructive: bool,


### PR DESCRIPTION
This allows external systems to transfer migration information across container boundaries.