### PR TITLE
Propagate errors during access control parsing

### DIFF
--- a/crates/builder/src/lib.rs
+++ b/crates/builder/src/lib.rs
@@ -412,8 +412,20 @@ fn emit_diagnostics(
         ParserError::ModelBuildingError(ModelBuildingError::ExternalResourceParsing(e)) => {
             // This is an error in a JavaScript/TypeScript file, so we
             // have emit it directly to stderr (can't use the emitter, which is tied to exo sources)
-            eprintln!("{}", e)
+            emitter.emit(&[Diagnostic {
+                level: Level::Error,
+                code: None,
+                message: e.to_string(),
+                spans: vec![],
+            }]);
         }
-        _ => {}
+        _ => {
+            emitter.emit(&[Diagnostic {
+                level: Level::Error,
+                code: None,
+                message: format!("{err}"),
+                spans: vec![],
+            }]);
+        }
     }
 }

--- a/crates/cli/src/util/watcher.rs
+++ b/crates/cli/src/util/watcher.rs
@@ -13,7 +13,6 @@ use anyhow::{anyhow, Context, Result};
 use builder::error::ParserError;
 use colored::Colorize;
 use common::env_const::EXO_SERVER_PORT;
-use core_model_builder::error::ModelBuildingError;
 use futures::{future::BoxFuture, FutureExt};
 use notify_debouncer_mini::notify::RecursiveMode;
 use tokio::process::Child;
@@ -152,18 +151,11 @@ where
         }
 
         // server encountered an unrecoverable error while building
-        Err(BuildError::ParserError(ParserError::Generic(e)))
-        | Err(BuildError::ParserError(ParserError::ModelBuildingError(
-            ModelBuildingError::Generic(e),
-        ))) => Err(anyhow!(e)),
         Err(BuildError::UnrecoverableError(e)) => Err(e),
-
         Err(BuildError::ParserError(ParserError::InvalidTrustedDocumentFormat(message))) => {
             println!("Error parsing trusted documents: {}", message.red().bold());
             Ok(None)
         }
-
-        // server encountered a parser error (we don't need to exit the watcher)
-        Err(BuildError::ParserError(_)) => Ok(None),
+        _ => Ok(None), // server encountered a parser error (we don't need to exit the watcher)
     }
 }


### PR DESCRIPTION
We had a few unwrap calls in the access control parsing code. Replace them with proper error handling. Also, fix the error emit logic to consider non-diagnostic errors.

Fixes #1065