### PR TITLE
Optimized transactions

### DIFF
--- a/crates/core-subsystem/core-resolver/src/context/overridden_context.rs
+++ b/crates/core-subsystem/core-resolver/src/context/overridden_context.rs
@@ -70,4 +70,8 @@ impl<'a> OverriddenContext<'a> {
             }
         }
     }
+
+    pub async fn ensure_transaction(&self) {
+        self.base_context.ensure_transaction().await;
+    }
 }

--- a/crates/core-subsystem/core-resolver/src/context/request_context.rs
+++ b/crates/core-subsystem/core-resolver/src/context/request_context.rs
@@ -86,4 +86,16 @@ impl<'a> RequestContext<'a> {
             }
         }
     }
+
+    #[async_recursion]
+    pub async fn ensure_transaction(&self) {
+        match self {
+            RequestContext::User(user_request_context) => {
+                user_request_context.ensure_transaction().await;
+            }
+            RequestContext::Overridden(overridden_context) => {
+                overridden_context.ensure_transaction().await;
+            }
+        }
+    }
 }

--- a/crates/core-subsystem/core-resolver/src/context/user_request_context.rs
+++ b/crates/core-subsystem/core-resolver/src/context/user_request_context.rs
@@ -119,4 +119,12 @@ impl<'a> UserRequestContext<'a> {
             .await?
             .map(Val::from))
     }
+
+    pub async fn ensure_transaction(&self) {
+        self.transaction_holder
+            .as_ref()
+            .lock()
+            .await
+            .ensure_transaction();
+    }
 }

--- a/crates/core-subsystem/core-resolver/src/system_resolver.rs
+++ b/crates/core-subsystem/core-resolver/src/system_resolver.rs
@@ -182,6 +182,10 @@ impl SystemResolver {
             }
         };
 
+        // If multiple operations are present, we need to ensure that we have a transaction
+        if operation.fields.len() > 1 {
+            request_context.ensure_transaction().await;
+        }
         operation
             .resolve_fields(&operation.fields, self, request_context)
             .await

--- a/crates/deno-subsystem/deno-resolver/src/plugin.rs
+++ b/crates/deno-subsystem/deno-resolver/src/plugin.rs
@@ -86,6 +86,10 @@ impl SubsystemResolver for DenoSubsystemResolver {
         request_context: &'a RequestContext<'a>,
         system_resolver: &'a SystemResolver,
     ) -> Result<Option<QueryResponse>, SubsystemResolutionError> {
+        // If the top-level operation is Deno, we can't be sure what the JS code will do, so we must
+        // ensure a transaction.
+        request_context.ensure_transaction().await;
+
         let operation_name = &operation.name;
 
         let deno_operation = match operation_type {

--- a/crates/wasm-subsystem/wasm-resolver/src/plugin.rs
+++ b/crates/wasm-subsystem/wasm-resolver/src/plugin.rs
@@ -69,6 +69,11 @@ impl SubsystemResolver for WasmSubsystemResolver {
         request_context: &'a RequestContext<'a>,
         system_resolver: &'a SystemResolver,
     ) -> Result<Option<QueryResponse>, SubsystemResolutionError> {
+        // If the top-level operation is WASM, we can't be sure what the code will do, so we must
+        // ensure a transaction.
+
+        request_context.ensure_transaction().await;
+
         let operation_name = &field.name;
 
         let operation = match operation_type {

--- a/libs/exo-sql/src/sql/connect/database_client.rs
+++ b/libs/exo-sql/src/sql/connect/database_client.rs
@@ -17,6 +17,28 @@ pub enum DatabaseClient {
     Direct(tokio_postgres::Client),
 }
 
+impl Deref for DatabaseClient {
+    type Target = tokio_postgres::Client;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            #[cfg(feature = "pool")]
+            DatabaseClient::Pooled(client) => client,
+            DatabaseClient::Direct(client) => client,
+        }
+    }
+}
+
+impl DerefMut for DatabaseClient {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            #[cfg(feature = "pool")]
+            DatabaseClient::Pooled(client) => client,
+            DatabaseClient::Direct(client) => client,
+        }
+    }
+}
+
 pub enum TransactionWrapper<'a> {
     #[cfg(feature = "pool")]
     Pooled(deadpool_postgres::Transaction<'a>),

--- a/libs/exo-sql/src/sql/transaction.rs
+++ b/libs/exo-sql/src/sql/transaction.rs
@@ -87,6 +87,10 @@ impl<'a> TransactionScript<'a> {
         self.steps.push(step);
         TransactionStepId(id)
     }
+
+    pub fn needs_transaction(&self) -> bool {
+        self.steps.len() > 1
+    }
 }
 
 #[derive(Debug)]

--- a/libs/exo-sql/src/sql/transaction.rs
+++ b/libs/exo-sql/src/sql/transaction.rs
@@ -9,7 +9,7 @@
 
 use std::fmt::Debug;
 
-use tokio_postgres::{GenericClient, Row, Transaction};
+use tokio_postgres::{GenericClient, Row};
 use tracing::{error, info, instrument};
 
 use crate::{
@@ -60,10 +60,10 @@ impl<'a> TransactionScript<'a> {
         name = "TransactionScript::execute"
         skip_all
         )]
-    pub async fn execute(
+    pub async fn execute<T: tokio_postgres::GenericClient>(
         self,
         database: &Database,
-        tx: &mut Transaction<'_>,
+        tx: &mut T,
     ) -> Result<TransactionStepResult, DatabaseError> {
         let mut transaction_context = TransactionContext { results: vec![] };
 


### PR DESCRIPTION
Avoid setting up transactions in places we are sure that only one database query or mutation will be executed. 

We mark the following case to need transaction boundary.
- If the `TransactionScript` has multiple steps.
- If the incoming operation has multiple top level queries/mutations
- If the incoming operation has an interceptor
- If the incoming operation is a Deno or WASM operation

We could further optimize the last two cases, but as a separate PR.