### PR TITLE
fix: fix typescript type

### DIFF
--- a/crates/deno-subsystem/deno-model-builder/src/module_skeleton_generator.rs
+++ b/crates/deno-subsystem/deno-model-builder/src/module_skeleton_generator.rs
@@ -407,7 +407,7 @@ trait TypeScriptType {
 impl TypeScriptType for AstFieldType<Typed> {
     fn typescript_type(&self) -> String {
         match self {
-            AstFieldType::Optional(tpe) => format!("{}?", tpe.typescript_type()),
+            AstFieldType::Optional(tpe) => format!("{} | undefined", tpe.typescript_type()),
             AstFieldType::Plain(name, ..) => typescript_base_type(name),
         }
     }
@@ -416,7 +416,7 @@ impl TypeScriptType for AstFieldType<Typed> {
 impl TypeScriptType for ContextFieldType {
     fn typescript_type(&self) -> String {
         match self {
-            ContextFieldType::Optional(typ) => format!("{}?", typ.typescript_type()),
+            ContextFieldType::Optional(typ) => format!("{} | undefined", typ.typescript_type()),
             ContextFieldType::Plain(pt) => typescript_base_type(&pt.name()),
             ContextFieldType::List(typ) => format!("{}[]", typ.typescript_type()),
         }


### PR DESCRIPTION
This fixes a bug in the Typescript type generation for contexts when using optional fields. Currently a context like:
```ts
context AdminContext {
  @header("X-Admin-Secret") adminSecretHeader: String?
  @env("ADMIN_SECRET") adminSecret: String
}
```

generates the following type declaration:
```ts
export interface AdminContext {
	adminSecretHeader: string?
	adminSecret: string
}
```

This isn't valid Typescript syntax, it should either be `adminSecretHeader?: string` or `adminSecretHeader: string | undefined`. I have opted for the latter.