### PR TITLE
Perform queries with one roundtrip to the database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3377,6 +3377,7 @@ dependencies = [
  "maybe-owned",
  "multiplatform_test",
  "once_cell",
+ "pg_bigdecimal",
  "postgres_array",
  "rand",
  "regex",
@@ -3394,6 +3395,7 @@ dependencies = [
  "typed-generational-arena",
  "url",
  "urlencoding",
+ "uuid",
  "wasm-bindgen-test",
  "wasm-bindgen-test-macro",
  "which 5.0.0",
@@ -6113,16 +6115,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pgvector"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f4c0c07ceb64a0020f2f0e610cfe51122d2e72723499f0154877b7c76c8c31"
-dependencies = [
- "bytes",
- "postgres",
-]
-
-[[package]]
 name = "phf"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6345,6 +6337,23 @@ dependencies = [
  "byteorder",
  "bytes",
  "fallible-iterator 0.2.0",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.6"
+source = "git+https://github.com/exograph/rust-postgres?branch=exograph#f3976680c6d7004b04b3ba39f90f2956ce6d7010"
+dependencies = [
+ "base64 0.22.0",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
  "getrandom",
  "hmac",
  "md-5",
@@ -6372,11 +6381,8 @@ dependencies = [
  "futures",
  "indexmap 2.2.5",
  "maybe-owned",
- "pg_bigdecimal",
- "pgvector",
  "postgres-model",
  "postgres-model-builder",
- "postgres-types",
  "resolver",
  "serde",
  "serde_json",
@@ -6399,13 +6405,12 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d2234cdee9408b523530a9b6d2d6b373d1db34f6a8e51dc03ded1828d7fb67c"
+source = "git+https://github.com/exograph/rust-postgres?branch=exograph#f3976680c6d7004b04b3ba39f90f2956ce6d7010"
 dependencies = [
  "bytes",
  "chrono",
  "fallible-iterator 0.2.0",
- "postgres-protocol",
+ "postgres-protocol 0.6.6 (git+https://github.com/exograph/rust-postgres?branch=exograph)",
  "serde",
  "serde_json",
  "uuid",
@@ -6419,7 +6424,7 @@ checksum = "2667c8b8c3a857620d87fc5172972c3385254a7563a5ab303bc9a41a16a7bf4e"
 dependencies = [
  "bytes",
  "fallible-iterator 0.2.0",
- "postgres-protocol",
+ "postgres-protocol 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres-types",
 ]
 
@@ -8665,8 +8670,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d340244b32d920260ae7448cb72b6e238bddc3d4f7603394e7dd46ed8e48f5b8"
+source = "git+https://github.com/exograph/rust-postgres?branch=exograph#f3976680c6d7004b04b3ba39f90f2956ce6d7010"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -8679,7 +8683,7 @@ dependencies = [
  "percent-encoding",
  "phf",
  "pin-project-lite",
- "postgres-protocol",
+ "postgres-protocol 0.6.6 (git+https://github.com/exograph/rust-postgres?branch=exograph)",
  "postgres-types",
  "rand",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
   "libs/exo-deno",
   "libs/exo-sql",
   "libs/exo-wasm",
-  "libs/exo-env"
+  "libs/exo-env",
 ]
 
 # The default workspace member to run `cargo` commands on (we exclude server-aws-lambda here, since we don't need to build it during normal development)
@@ -42,7 +42,7 @@ default-members = [
   "libs/exo-deno",
   "libs/exo-sql",
   "libs/exo-wasm",
-  "libs/exo-env"
+  "libs/exo-env",
 ]
 
 resolver = "2"
@@ -97,6 +97,7 @@ tree-sitter = "0.20.10"
 tree-sitter-c2rust = "0.20.11-pre.1"
 tree-sitter-cli = "0.20.8"
 typed-generational-arena = { version = "0.2.5", features = ["serde"] }
+uuid = "1.1.2"
 url = "2.3.1"
 wasmtime = "13.0.0"
 wasmtime-wasi = "13.0.0"
@@ -106,6 +107,10 @@ which = "5.0.0"
 wasm-bindgen-test = "0.3.42"
 wasm-bindgen-test-macro = "0.3.42"
 multiplatform_test = "0.0.0"
+
+[patch.crates-io]
+tokio-postgres = { git = "https://github.com/exograph/rust-postgres", branch = "exograph" }
+postgres-types = { git = "https://github.com/exograph/rust-postgres", branch = "exograph" }
 
 # reduce binary size, does not affect stack traces
 [profile.dev]

--- a/crates/postgres-subsystem/postgres-resolver-dynamic/Cargo.toml
+++ b/crates/postgres-subsystem/postgres-resolver-dynamic/Cargo.toml
@@ -6,7 +6,10 @@ publish = false
 
 [dependencies]
 core-plugin-interface = { path = "../../core-subsystem/core-plugin-interface" }
-postgres-resolver = { path = "../postgres-resolver", features = ["network", "bigdecimal", "vector"] }
+postgres-resolver = { path = "../postgres-resolver", features = [
+  "network",
+  "bigdecimal",
+] }
 
 [dev-dependencies]
 

--- a/crates/postgres-subsystem/postgres-resolver/Cargo.toml
+++ b/crates/postgres-subsystem/postgres-resolver/Cargo.toml
@@ -11,8 +11,7 @@ network = [
     "exo-sql/testing",
     "exo-sql/pool",
 ]
-bigdecimal = ["pg_bigdecimal"]
-vector = ["pgvector"]
+bigdecimal = ["exo-sql/bigdecimal"]
 
 [dependencies]
 async-graphql-parser.workspace = true
@@ -27,12 +26,9 @@ thiserror = "1.0.32"
 tokio.workspace = true
 tokio-postgres = { workspace = true, default-features = false }
 tracing.workspace = true
-postgres-types = "0.2"
 base64 = "0.13"
 chrono.workspace = true
-pg_bigdecimal = { version = "0.1.4", optional = true }
-uuid = "1.1.2"
-pgvector = { version = "0.3", features = ["postgres"], optional = true }
+uuid.workspace = true
 
 exo-sql = { path = "../../../libs/exo-sql" }
 exo-env = { path = "../../../libs/exo-env" }

--- a/crates/postgres-subsystem/postgres-resolver/src/abstract_operation_resolver.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/abstract_operation_resolver.rs
@@ -12,7 +12,7 @@ use exo_sql::AbstractOperation;
 use core_plugin_interface::core_resolver::{
     context::RequestContext, QueryResponse, QueryResponseBody,
 };
-use postgres_types::FromSqlOwned;
+use tokio_postgres::types::FromSqlOwned;
 use tokio_postgres::Row;
 
 use crate::{

--- a/crates/postgres-subsystem/postgres-resolver/src/util.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/util.rs
@@ -9,8 +9,6 @@
 
 use indexmap::IndexMap;
 
-#[cfg(feature = "pgvector")]
-use pgvector::Vector;
 use postgres_model::types::EntityType;
 
 use core_plugin_interface::core_model::types::OperationReturnType;
@@ -21,7 +19,6 @@ use postgres_model::{
     subsystem::PostgresSubsystem,
 };
 
-#[cfg(feature = "pgvector")]
 use crate::postgres_execution_error::PostgresExecutionError;
 
 pub type Arguments = IndexMap<String, Val>;
@@ -44,11 +41,10 @@ pub(crate) fn get_argument_field<'a>(argument_value: &'a Val, field_name: &str) 
     }
 }
 
-#[cfg(feature = "pgvector")]
 pub(super) fn to_pg_vector(
     value: &Val,
     parameter_name: &str,
-) -> Result<Vector, PostgresExecutionError> {
+) -> Result<Vec<f32>, PostgresExecutionError> {
     let vec_value: Vec<f32> = match value {
         Val::List(vector) => vector
             .iter()
@@ -66,7 +62,7 @@ pub(super) fn to_pg_vector(
         )),
     }?;
 
-    Ok(Vector::from(vec_value))
+    Ok(vec_value)
 }
 
 ///

--- a/crates/server-common/Cargo.toml
+++ b/crates/server-common/Cargo.toml
@@ -12,7 +12,6 @@ core-plugin-interface = { path = "../core-subsystem/core-plugin-interface" }
 postgres-resolver = { path = "../postgres-subsystem/postgres-resolver", features = [
   "network",
   "bigdecimal",
-  "vector",
 ], optional = true }
 deno-resolver = { path = "../deno-subsystem/deno-resolver", optional = true }
 wasm-resolver = { path = "../wasm-subsystem/wasm-resolver", optional = true }

--- a/libs/exo-sql/Cargo.toml
+++ b/libs/exo-sql/Cargo.toml
@@ -16,10 +16,13 @@ tls = [
 postgres-url = ["tokio-postgres/runtime"]
 testing = ["which", "tempfile"]
 pool = ["deadpool-postgres"]
+bigdecimal = ["pg_bigdecimal"]
 
 [dependencies]
 bytes.workspace = true
+pg_bigdecimal = { version = "0.1.4", optional = true }
 futures.workspace = true
+uuid.workspace = true
 tokio-postgres = { workspace = true, features = [
   "with-chrono-0_4",
   "with-serde_json-1",
@@ -41,12 +44,14 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["rt"] }
 tracing.workspace = true
 typed-generational-arena.workspace = true
-url = "2.2.2"
+url.workspace = true
 
 which = { workspace = true, optional = true }
 rand.workspace = true
 tempfile = { workspace = true, optional = true }
 urlencoding = "2.1.2"
+
+serde_json.workspace = true
 
 common = { path = "../../crates/common" } # Until we remove database_client's dependency on env vars
 
@@ -56,7 +61,6 @@ features = ["js", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"]
 default-features = false
 
 [dev-dependencies]
-serde_json.workspace = true
 wasm-bindgen-test.workspace = true
 wasm-bindgen-test-macro.workspace = true
 multiplatform_test.workspace = true

--- a/libs/exo-sql/src/lib.rs
+++ b/libs/exo-sql/src/lib.rs
@@ -78,3 +78,6 @@ pub use sql::{
     vector::{VectorDistanceFunction, DEFAULT_VECTOR_SIZE},
     SQLBytes, SQLParam, SQLParamContainer,
 };
+
+#[cfg(feature = "bigdecimal")]
+pub use pg_bigdecimal::BigDecimal;

--- a/libs/exo-sql/src/sql/connect/database_client_manager.rs
+++ b/libs/exo-sql/src/sql/connect/database_client_manager.rs
@@ -89,7 +89,7 @@ impl DatabaseClientManager {
         }
         #[cfg(not(feature = "pool"))]
         {
-            Self::from_db_url_direct(url, check_connection).await
+            Self::from_url_direct(url, check_connection).await
         }
     }
 

--- a/libs/exo-sql/src/sql/delete.rs
+++ b/libs/exo-sql/src/sql/delete.rs
@@ -94,11 +94,9 @@ impl<'a> TemplateDelete<'a> {
                         column_id: nesting_relation.foreign_column_id,
                         table_alias: None,
                     },
-                    Column::Param(SQLParamContainer::new(transaction_context.resolve_value(
-                        prev_step_id,
-                        row_index,
-                        0,
-                    ))),
+                    Column::Param(SQLParamContainer::from_sql_value(
+                        transaction_context.resolve_value(prev_step_id, row_index, 0),
+                    )),
                 );
 
                 Delete {

--- a/libs/exo-sql/src/sql/expression_builder.rs
+++ b/libs/exo-sql/src/sql/expression_builder.rs
@@ -7,12 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::sync::Arc;
-
 use maybe_owned::MaybeOwned;
 
-use super::SQLBuilder;
-use crate::{Database, SQLParam};
+use super::{sql_param::SQLParamWithType, SQLBuilder};
+use crate::Database;
 
 /// A trait for types that can build themselves into an SQL expression.
 ///
@@ -27,7 +25,7 @@ pub trait ExpressionBuilder {
     /// want to assert on the generated SQL without going through the whole process of creating an
     /// SQLBuilder, then building the SQL expression into it, and finally extracting the SQL string
     /// and params.
-    fn to_sql(&self, database: &Database) -> (String, Vec<Arc<dyn SQLParam>>)
+    fn to_sql(&self, database: &Database) -> (String, Vec<SQLParamWithType>)
     where
         Self: Sized,
     {

--- a/libs/exo-sql/src/sql/function.rs
+++ b/libs/exo-sql/src/sql/function.rs
@@ -45,6 +45,7 @@ impl ExpressionBuilder for Function {
                 distance_function.build(database, builder);
                 builder.push_space();
                 builder.push_param(target.param());
+                builder.push_str("::vector");
             }
         }
     }

--- a/libs/exo-sql/src/sql/insert.rs
+++ b/libs/exo-sql/src/sql/insert.rs
@@ -87,7 +87,7 @@ impl<'a> TemplateInsert<'a> {
                     .map(|col| match col {
                         ProxyColumn::Concrete(col) => col.as_ref().into(),
                         ProxyColumn::Template { col_index, step_id } => {
-                            MaybeOwned::Owned(Column::Param(SQLParamContainer::new(
+                            MaybeOwned::Owned(Column::Param(SQLParamContainer::from_sql_value(
                                 transaction_context.resolve_value(*step_id, row_index, *col_index),
                             )))
                         }

--- a/libs/exo-sql/src/sql/limit.rs
+++ b/libs/exo-sql/src/sql/limit.rs
@@ -20,6 +20,6 @@ impl ExpressionBuilder for Limit {
     /// Build expression of the form `LIMIT <limit>`
     fn build(&self, _database: &Database, builder: &mut SQLBuilder) {
         builder.push_str("LIMIT ");
-        builder.push_param(Arc::new(self.0))
+        builder.push_param((Arc::new(self.0), tokio_postgres::types::Type::INT8));
     }
 }

--- a/libs/exo-sql/src/sql/offset.rs
+++ b/libs/exo-sql/src/sql/offset.rs
@@ -9,6 +9,8 @@
 
 use std::sync::Arc;
 
+use tokio_postgres::types::Type;
+
 use crate::Database;
 
 use super::{ExpressionBuilder, SQLBuilder};
@@ -20,6 +22,6 @@ impl ExpressionBuilder for Offset {
     /// Build expression of the form `OFFSET <offset>`
     fn build(&self, _database: &Database, builder: &mut SQLBuilder) {
         builder.push_str("OFFSET ");
-        builder.push_param(Arc::new(self.0))
+        builder.push_param((Arc::new(self.0), Type::INT8))
     }
 }

--- a/libs/exo-sql/src/sql/predicate.rs
+++ b/libs/exo-sql/src/sql/predicate.rs
@@ -354,7 +354,7 @@ mod tests {
         let age_column_id = database.get_column_id(people_table_id, "age").unwrap();
 
         let age_col = Column::physical(age_column_id, None);
-        let age_value_col = Column::Param(SQLParamContainer::new(5));
+        let age_value_col = Column::Param(SQLParamContainer::i32(5));
 
         let predicate = Predicate::Eq(age_col, age_value_col);
 
@@ -377,8 +377,8 @@ mod tests {
         let name_col_id = database.get_column_id(people_table_id, "name").unwrap();
         let age_col_id = database.get_column_id(people_table_id, "age").unwrap();
 
-        let name_value_col = Column::Param(SQLParamContainer::new("foo"));
-        let age_value_col = Column::Param(SQLParamContainer::new(5));
+        let name_value_col = Column::Param(SQLParamContainer::str("foo"));
+        let age_value_col = Column::Param(SQLParamContainer::i32(5));
 
         let name_predicate =
             ConcretePredicate::Eq(Column::physical(name_col_id, None), name_value_col);
@@ -412,7 +412,7 @@ mod tests {
 
         fn title_test_data(title_col_id: ColumnId) -> (Column, Column) {
             let title_col = Column::physical(title_col_id, None);
-            let title_value_col = Column::Param(SQLParamContainer::new("utawaku"));
+            let title_value_col = Column::Param(SQLParamContainer::str("utawaku"));
 
             (title_col, title_value_col)
         }
@@ -488,14 +488,14 @@ mod tests {
                 "#,
             )
             .unwrap();
-            let json_value_col = Column::Param(SQLParamContainer::new(json_value.clone()));
+            let json_value_col = Column::Param(SQLParamContainer::json(json_value.clone()));
 
             (json_col, Arc::new(json_value), json_value_col)
         }
 
         let json_key_list: serde_json::Value = serde_json::from_str(r#"["a", "b"]"#).unwrap();
 
-        let json_key_col = Column::Param(SQLParamContainer::new("a"));
+        let json_key_col = Column::Param(SQLParamContainer::str("a"));
 
         //// Test bindings starting now
 
@@ -520,7 +520,7 @@ mod tests {
         );
 
         // matchKey
-        let json_key_list_col = Column::Param(SQLParamContainer::new(json_key_list.clone()));
+        let json_key_list_col = Column::Param(SQLParamContainer::json(json_key_list.clone()));
 
         let (json_col, _, _) = json_test_data(json_col_id);
 
@@ -543,7 +543,7 @@ mod tests {
         );
 
         // matchAllKeys
-        let json_key_list_col = Column::Param(SQLParamContainer::new(json_key_list.clone()));
+        let json_key_list_col = Column::Param(SQLParamContainer::json(json_key_list.clone()));
 
         let (json_col, _, _) = json_test_data(json_col_id);
 

--- a/libs/exo-sql/src/sql/sql_builder.rs
+++ b/libs/exo-sql/src/sql/sql_builder.rs
@@ -7,17 +7,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
-use crate::{Database, SQLParam};
+use crate::Database;
 
-use super::{physical_table::PhysicalTableName, ExpressionBuilder};
+use super::{physical_table::PhysicalTableName, sql_param::SQLParamWithType, ExpressionBuilder};
 
 pub struct SQLBuilder {
     /// The SQL being built with placeholders for each parameter
     sql: String,
     /// The list of parameters
-    params: Vec<Arc<dyn SQLParam>>,
+    params: Vec<SQLParamWithType>,
     /// Indicates if column name should be rendered with the table name i.e. "table"."col"  instead
     /// of "col" (needed for INSERT/UPDATE statements)
     fully_qualify_column_names: bool,
@@ -99,7 +99,7 @@ impl SQLBuilder {
 
     /// Push a parameter, which will be replaced with a placeholder in the SQL string
     /// and the parameter will be added to the list of parameters.
-    pub fn push_param(&mut self, param: Arc<dyn SQLParam>) {
+    pub fn push_param(&mut self, param: SQLParamWithType) {
         self.params.push(param);
         self.push('$');
         self.push_str(&self.params.len().to_string());
@@ -140,7 +140,7 @@ impl SQLBuilder {
 
     /// Get the SQL string and the list of parameters. Calling this method should be the final step
     /// in building an SQL expression, and thus this builder consumes the `self`.
-    pub fn into_sql(self) -> (String, Vec<Arc<dyn SQLParam>>) {
+    pub fn into_sql(self) -> (String, Vec<SQLParamWithType>) {
         (self.sql, self.params)
     }
 

--- a/libs/exo-sql/src/sql/sql_param.rs
+++ b/libs/exo-sql/src/sql/sql_param.rs
@@ -7,9 +7,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::any::Any;
+use std::{any::Any, sync::Arc};
 
-use tokio_postgres::types::ToSql;
+use tokio_postgres::types::{ToSql, Type};
+
+pub type SQLParamWithType = (Arc<dyn SQLParam>, Type);
 
 /// A trait to simplify our use of SQL parameters, specifically to have the [Send] and [Sync] bounds.
 pub trait SQLParam: ToSql + Send + Sync {

--- a/libs/exo-sql/src/sql/sql_param_container.rs
+++ b/libs/exo-sql/src/sql/sql_param_container.rs
@@ -7,22 +7,23 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use chrono::FixedOffset;
+use pg_bigdecimal::{BigDecimal, PgNumeric};
 use std::{
     fmt::{Debug, Display},
     sync::Arc,
 };
 use tokio_postgres::types::{to_sql_checked, ToSql, Type};
 
-use crate::SQLParam;
+use crate::{SQLBytes, SQLParam};
 
-/// Newtype for SQL parameters that can be used in a prepared statement. We would have been fine
-/// with just using `Arc<dyn SQLParam>` but we need to implement `ToSql` for it and since `Arc`
-/// (unlike `Box`) is not a `#[fundamental]` type, we have to wrap it in a newtype.
+use super::{physical_column::to_pg_array_type, sql_param::SQLParamWithType, SQLValue};
+
 #[derive(Clone)]
-pub struct SQLParamContainer(Arc<dyn SQLParam>);
+pub struct SQLParamContainer(SQLParamWithType);
 
 impl SQLParamContainer {
-    pub fn param(&self) -> Arc<dyn SQLParam> {
+    pub fn param(&self) -> SQLParamWithType {
         self.0.clone()
     }
 }
@@ -33,7 +34,7 @@ impl ToSql for SQLParamContainer {
         ty: &Type,
         out: &mut bytes::BytesMut,
     ) -> Result<tokio_postgres::types::IsNull, Box<dyn std::error::Error + Sync + Send>> {
-        self.0.as_ref().to_sql_checked(ty, out)
+        self.0 .0.as_ref().to_sql_checked(ty, out)
     }
 
     fn accepts(_ty: &Type) -> bool {
@@ -44,20 +45,101 @@ impl ToSql for SQLParamContainer {
 }
 
 impl SQLParamContainer {
-    pub fn new<T: SQLParam + 'static>(param: T) -> Self {
-        Self(Arc::new(param))
+    pub(crate) fn new<T: SQLParam + 'static>(param: T, param_type: Type) -> Self {
+        Self((Arc::new(param), param_type))
+    }
+
+    pub fn string(value: String) -> Self {
+        Self::new(value, Type::TEXT)
+    }
+
+    pub fn str(value: &'static str) -> Self {
+        Self::new(value, Type::TEXT)
+    }
+
+    pub fn bool(value: bool) -> Self {
+        Self::new(value, Type::BOOL)
+    }
+
+    pub fn i16(value: i16) -> Self {
+        Self::new(value, Type::INT2)
+    }
+
+    pub fn i32(value: i32) -> Self {
+        Self::new(value, Type::INT4)
+    }
+
+    pub fn i64(value: i64) -> Self {
+        Self::new(value, Type::INT8)
+    }
+
+    pub fn f32(value: f32) -> Self {
+        Self::new(value, Type::FLOAT4)
+    }
+
+    pub fn f64(value: f64) -> Self {
+        Self::new(value, Type::FLOAT8)
+    }
+
+    pub fn f32_array(value: Vec<f32>) -> Self {
+        Self::new(value, Type::FLOAT4_ARRAY)
+    }
+
+    pub fn uuid(value: uuid::Uuid) -> Self {
+        Self::new(value, Type::UUID)
+    }
+
+    pub fn bytes(value: bytes::Bytes) -> Self {
+        Self::new(SQLBytes(value), Type::BYTEA)
+    }
+
+    pub fn bytes_from_vec(value: Vec<u8>) -> Self {
+        Self::new(SQLBytes::new(value), Type::BYTEA)
+    }
+
+    pub fn numeric(decimal: Option<BigDecimal>) -> Self {
+        Self::new(PgNumeric { n: decimal }, Type::NUMERIC)
+    }
+
+    pub fn date(value: chrono::NaiveDate) -> Self {
+        Self::new(value, Type::DATE)
+    }
+
+    pub fn time(value: chrono::NaiveTime) -> Self {
+        Self::new(value, Type::TIME)
+    }
+
+    pub fn timestamp(value: chrono::NaiveDateTime) -> Self {
+        Self::new(value, Type::TIMESTAMP)
+    }
+
+    pub fn timestamp_tz(value: chrono::DateTime<FixedOffset>) -> Self {
+        Self::new(value, Type::TIMESTAMPTZ)
+    }
+
+    pub fn timestamp_utc(value: chrono::DateTime<chrono::Utc>) -> Self {
+        Self::new(value, Type::TIMESTAMPTZ)
+    }
+
+    pub fn json(value: serde_json::Value) -> Self {
+        Self::new(value, Type::JSONB)
+    }
+
+    pub fn from_sql_values(params: Vec<SQLValue>, elem_type: Type) -> Self {
+        let collection_type = to_pg_array_type(&elem_type);
+
+        Self::new(params, collection_type)
+    }
+
+    pub fn from_sql_value(value: SQLValue) -> Self {
+        let type_ = value.type_.clone();
+        Self::new(value, type_)
     }
 }
 
 impl PartialEq for SQLParamContainer {
     fn eq(&self, other: &Self) -> bool {
         self.0.eq(&other.0)
-    }
-}
-
-impl AsRef<dyn SQLParam> for SQLParamContainer {
-    fn as_ref(&self) -> &(dyn SQLParam + 'static) {
-        self.0.as_ref()
     }
 }
 

--- a/libs/exo-sql/src/sql/sql_param_container.rs
+++ b/libs/exo-sql/src/sql/sql_param_container.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use chrono::FixedOffset;
+#[cfg(feature = "bigdecimal")]
 use pg_bigdecimal::{BigDecimal, PgNumeric};
 use std::{
     fmt::{Debug, Display},
@@ -97,6 +98,7 @@ impl SQLParamContainer {
         Self::new(SQLBytes::new(value), Type::BYTEA)
     }
 
+    #[cfg(feature = "bigdecimal")]
     pub fn numeric(decimal: Option<BigDecimal>) -> Self {
         Self::new(PgNumeric { n: decimal }, Type::NUMERIC)
     }

--- a/libs/exo-sql/src/sql/sql_value.rs
+++ b/libs/exo-sql/src/sql/sql_value.rs
@@ -17,7 +17,7 @@ use crate::database_error::DatabaseError;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SQLValue {
     value: Vec<u8>,
-    type_: Type,
+    pub(crate) type_: Type,
 }
 
 impl Display for SQLValue {
@@ -39,6 +39,10 @@ impl ToSql for SQLValue {
             out.extend(self.value.as_slice());
             Ok(tokio_postgres::types::IsNull::No)
         } else {
+            println!(
+                "Type mismatch expected {:?} got {:?} {:?}",
+                ty, self.type_, self
+            );
             Err(DatabaseError::Validation("Type mismatch".into()).into())
         }
     }

--- a/libs/exo-sql/src/sql/test_util.rs
+++ b/libs/exo-sql/src/sql/test_util.rs
@@ -51,10 +51,11 @@ macro_rules! assert_params {
     ($actual_params:expr, $expected_param:expr) => {
         match $actual_params.split_first() {
             Some((actual_head, actual_tail)) => {
-                let actual_boxed_head = actual_head.as_any().downcast_ref::<$crate::sql::SQLParamContainer>();
+                let actual_boxed_head = actual_head.0.as_any().downcast_ref::<$crate::sql::SQLParamContainer>();
                 match actual_boxed_head {
                     Some(actual_boxed_head) => {
-                        let actual_head = actual_boxed_head.as_ref();
+                        let actual_head = actual_boxed_head.param();
+                        let actual_head = actual_head.0.as_ref();
                         assert_eq!(
                             &actual_head,
                             &(&$expected_param as &dyn $crate::sql::SQLParam),
@@ -62,7 +63,7 @@ macro_rules! assert_params {
                         );
                     },
                     None => {
-                        assert_eq!(&actual_head.as_ref(), &(&$expected_param as &dyn $crate::sql::SQLParam), "Parameter mismatch");
+                        assert_eq!(actual_head.0.as_ref(), (&$expected_param as &dyn $crate::sql::SQLParam), "Parameter mismatchx");
                     }
                 }
                 assert_eq!(actual_tail.len(), 0, "Extra actual parameters")
@@ -73,10 +74,11 @@ macro_rules! assert_params {
     ($actual_params:expr, $expected_param:expr, $($rest:expr), *) => {
         match $actual_params.split_first() {
             Some((actual_head, actual_tail)) => {
-                let actual_boxed_head = actual_head.as_any().downcast_ref::<$crate::sql::SQLParamContainer>();
+                let actual_boxed_head = actual_head.0.as_any().downcast_ref::<$crate::sql::SQLParamContainer>();
                 match actual_boxed_head {
                     Some(actual_boxed_head) => {
-                        let actual_head = actual_boxed_head.as_ref();
+                        let actual_head = actual_boxed_head.param();
+                        let actual_head = actual_head.0.as_ref();
                         assert_eq!(
                             &actual_head,
                             &(&$expected_param as &dyn $crate::sql::SQLParam),
@@ -84,7 +86,7 @@ macro_rules! assert_params {
                         );
                     },
                     None => {
-                        assert_eq!(&actual_head.as_ref(), &(&$expected_param as &dyn $crate::sql::SQLParam), "Parameter mismatch");
+                        assert_eq!(&actual_head.0.as_ref(), &(&$expected_param as &dyn $crate::sql::SQLParam), "Parameter mismatch");
                     }
                 }
                 assert_params!(actual_tail, $($rest), *);

--- a/libs/exo-sql/src/sql/update.rs
+++ b/libs/exo-sql/src/sql/update.rs
@@ -116,11 +116,9 @@ impl<'a> TemplateUpdate<'a> {
                         column_id: self.nesting_relation.foreign_column_id,
                         table_alias: None,
                     },
-                    Column::Param(SQLParamContainer::new(transaction_context.resolve_value(
-                        prev_step_id,
-                        row_index,
-                        0,
-                    ))),
+                    Column::Param(SQLParamContainer::from_sql_value(
+                        transaction_context.resolve_value(prev_step_id, row_index, 0),
+                    )),
                 );
 
                 Update {

--- a/libs/exo-sql/src/sql/vector.rs
+++ b/libs/exo-sql/src/sql/vector.rs
@@ -28,6 +28,7 @@ impl<C: ExpressionBuilder> ExpressionBuilder for VectorDistance<C> {
         self.function.build(database, builder);
         builder.push_space();
         self.rhs.build(database, builder);
+        builder.push_str("::vector");
     }
 }
 

--- a/libs/exo-sql/src/transform/pg/delete/cte_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/delete/cte_strategy.rs
@@ -168,7 +168,7 @@ mod tests {
              }| {
                 let predicate = AbstractPredicate::Eq(
                     ColumnPath::Physical(PhysicalColumnPath::leaf(concerts_name_column)),
-                    ColumnPath::Param(SQLParamContainer::new("v1".to_string())),
+                    ColumnPath::Param(SQLParamContainer::string("v1".to_string())),
                 );
 
                 let adelete = AbstractDelete {
@@ -214,7 +214,7 @@ mod tests {
                         vec![concerts_venue_id_column, venues_name_column],
                         &database,
                     )),
-                    ColumnPath::Param(SQLParamContainer::new("v1".to_string())),
+                    ColumnPath::Param(SQLParamContainer::string("v1".to_string())),
                 );
 
                 let adelete = AbstractDelete {

--- a/libs/exo-sql/src/transform/pg/predicate_transformer.rs
+++ b/libs/exo-sql/src/transform/pg/predicate_transformer.rs
@@ -442,7 +442,7 @@ mod tests {
              }| {
                 let abstract_predicate = AbstractPredicate::Eq(
                     ColumnPath::Physical(PhysicalColumnPath::leaf(concerts_name_column)),
-                    ColumnPath::Param(SQLParamContainer::new("v1".to_string())),
+                    ColumnPath::Param(SQLParamContainer::string("v1".to_string())),
                 );
 
                 {
@@ -528,14 +528,14 @@ mod tests {
                 let abstract_predicate = AbstractPredicate::and(
                     AbstractPredicate::Eq(
                         ColumnPath::Physical(PhysicalColumnPath::leaf(concerts_venue_id_column)),
-                        ColumnPath::Param(SQLParamContainer::new(1)),
+                        ColumnPath::Param(SQLParamContainer::i32(1)),
                     ),
                     AbstractPredicate::Eq(
                         ColumnPath::Physical(PhysicalColumnPath::from_columns(
                             vec![concerts_venue_id_column, venues_name_column],
                             &database,
                         )),
-                        ColumnPath::Param(SQLParamContainer::new("v1".to_string())),
+                        ColumnPath::Param(SQLParamContainer::string("v1".to_string())),
                     ),
                 );
 
@@ -594,7 +594,7 @@ mod tests {
                         &database,
                     ));
                     let literal_column =
-                        ColumnPath::Param(SQLParamContainer::new("v1".to_string()));
+                        ColumnPath::Param(SQLParamContainer::string("v1".to_string()));
 
                     let abstract_predicate = if literal_on_the_right {
                         op(physical_column, literal_column)

--- a/libs/exo-sql/src/transform/pg/select/select_transformer.rs
+++ b/libs/exo-sql/src/transform/pg/select/select_transformer.rs
@@ -213,7 +213,7 @@ mod tests {
              }| {
                 let concert_id_path =
                     ColumnPath::Physical(PhysicalColumnPath::leaf(concerts_id_column));
-                let literal = ColumnPath::Param(SQLParamContainer::new(5));
+                let literal = ColumnPath::Param(SQLParamContainer::i32(5));
                 let predicate = AbstractPredicate::Eq(concert_id_path, literal);
 
                 let aselect = AbstractSelect {
@@ -445,7 +445,7 @@ mod tests {
                                                 vec![concerts_venue_id_column, venues_id_column],
                                                 &database,
                                             )),
-                                            ColumnPath::Param(SQLParamContainer::new(1)),
+                                            ColumnPath::Param(SQLParamContainer::i32(1)),
                                         ),
                                         order_by: None,
                                         offset: None,
@@ -493,7 +493,7 @@ mod tests {
                         vec![concerts_venue_id_column, venues_name_column],
                         &database,
                     )),
-                    ColumnPath::Param(SQLParamContainer::new("v1".to_string())),
+                    ColumnPath::Param(SQLParamContainer::string("v1".to_string())),
                 );
                 let aselect = AbstractSelect {
                     table_id: concerts_table,
@@ -569,7 +569,7 @@ mod tests {
                 let concert_name_path =
                     ColumnPath::Physical(PhysicalColumnPath::leaf(concerts_name_column));
 
-                let literal = ColumnPath::Param(SQLParamContainer::new("c1".to_string()));
+                let literal = ColumnPath::Param(SQLParamContainer::string("c1".to_string()));
                 let predicate = AbstractPredicate::Eq(concert_name_path, literal);
 
                 let aselect = AbstractSelect {


### PR DESCRIPTION
Use Exograph's fork of `tokio-postgres` from https://github.com/exograph/rust-postgres, which offers a new `query_with_param_types` method that performs queries in one roundtrip to the database. This requires that we track query parameter types, which is the bulk of the changes in this PR.