### PR TITLE
Do not run build-binaries workflow on pull requests

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -15,7 +15,6 @@ on:
     branches: ["main"]
     tags:
       - "*"
-  pull_request: # temporary to test cf-worker build without merging
 
 jobs:
   # Build and package all the things


### PR DESCRIPTION
This was a leftover from an earlier commit to test building of Cloudflare Workers