### PR TITLE
Fix the `with-interceptor` test

### DIFF
--- a/integration-tests/services/with-interceptor/src/time.ts
+++ b/integration-tests/services/with-interceptor/src/time.ts
@@ -1,4 +1,4 @@
-import { Operation } from '../generated/exograph.d.ts';
+import type { Operation } from '../generated/exograph.d.ts';
 
 export async function time(operation: Operation) {
 	return await operation.proceed();


### PR DESCRIPTION
The new version of Deno is stricter and loading of the incorrect import of the form `import { Operation } from "...exograph.d.ts"` fails during release testing (the new version of the definitions hasn't been published yet). The fix is to add `type` as in `import type { Operation } from "...exograph.d.ts"`