### PR TITLE
Add --use-ir flag to schema create, migrate, verify commands

### DIFF
--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -73,7 +73,7 @@ impl CommandDefinition for DevCommandDefinition {
             let db_client = open_database(None).await?;
 
             loop {
-                let postgres_subsystem = util::create_postgres_system(&model, None).await?;
+                let postgres_subsystem = util::create_postgres_system(&model, None, false).await?;
                 let verification_result = Migration::verify(&db_client, &postgres_subsystem).await;
 
                 match verification_result {

--- a/crates/cli/src/commands/schema/create.rs
+++ b/crates/cli/src/commands/schema/create.rs
@@ -16,13 +16,11 @@ use std::{io::Write, path::PathBuf};
 use exo_sql::schema::database_spec::DatabaseSpec;
 
 use crate::{
-    commands::command::{
-        default_model_file, ensure_exo_project_dir, get, output_arg, CommandDefinition,
-    },
+    commands::command::{default_model_file, get, output_arg, CommandDefinition},
     util::open_file_for_output,
 };
 
-use super::util;
+use super::util::{self, use_ir_arg};
 
 pub(super) struct CreateCommandDefinition {}
 
@@ -32,16 +30,17 @@ impl CommandDefinition for CreateCommandDefinition {
         Command::new("create")
             .about("Create a database schema from a Exograph model")
             .arg(output_arg())
+            .arg(use_ir_arg())
     }
 
     /// Create a database schema from a exograph model
     async fn execute(&self, matches: &clap::ArgMatches) -> Result<()> {
-        ensure_exo_project_dir(&PathBuf::from("."))?;
+        let use_ir: bool = matches.get_flag("use-ir");
 
         let model: PathBuf = default_model_file();
         let output: Option<PathBuf> = get(matches, "output");
 
-        let postgres_subsystem = util::create_postgres_system(model, None).await?;
+        let postgres_subsystem = util::create_postgres_system(&model, None, use_ir).await?;
 
         let mut buffer: Box<dyn Write> = open_file_for_output(output.as_deref())?;
 

--- a/crates/cli/src/commands/schema/util.rs
+++ b/crates/cli/src/commands/schema/util.rs
@@ -7,9 +7,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::path::Path;
+use std::fs::File;
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+
+use anyhow::anyhow;
 
 use builder::error::ParserError;
+use clap::Arg;
 use core_plugin_shared::{
     serializable_system::SerializableSystem, system_serializer::SystemSerializer,
 };
@@ -17,18 +22,10 @@ use exo_sql::{database_error::DatabaseError, DatabaseClientManager};
 use postgres_model::subsystem::PostgresSubsystem;
 
 use crate::commands::build::build_system_with_static_builders;
+use crate::commands::command::ensure_exo_project_dir;
 use common::env_const::{
     DATABASE_URL, EXO_CHECK_CONNECTION_ON_STARTUP, EXO_CONNECTION_POOL_SIZE, EXO_POSTGRES_URL,
 };
-
-pub(crate) async fn create_postgres_system(
-    model_file: impl AsRef<Path>,
-    trusted_documents_dir: Option<&Path>,
-) -> Result<PostgresSubsystem, ParserError> {
-    deserialize_postgres_subsystem(
-        build_system_with_static_builders(model_file.as_ref(), trusted_documents_dir).await?,
-    )
-}
 
 fn deserialize_postgres_subsystem(
     system: SerializableSystem,
@@ -67,4 +64,41 @@ pub(crate) async fn database_manager_from_env() -> Result<DatabaseClientManager,
         .unwrap_or(true);
 
     DatabaseClientManager::from_url(&url, check_connection, pool_size).await
+}
+
+pub(crate) async fn create_postgres_system(
+    model_file: impl AsRef<Path>,
+    trusted_documents_dir: Option<&Path>,
+    use_ir: bool,
+) -> Result<PostgresSubsystem, anyhow::Error> {
+    let serialized_system = if use_ir {
+        let exo_ir_file = PathBuf::from("target/index.exo_ir");
+        if !Path::new(&exo_ir_file).exists() {
+            return Err(anyhow!("IR file not found"));
+        }
+
+        match File::open(exo_ir_file) {
+            Ok(file) => {
+                let exo_ir_file_buffer = BufReader::new(file);
+
+                SerializableSystem::deserialize_reader(exo_ir_file_buffer)
+                    .map_err(|e| anyhow!("Error deserializing system: {:?}", e))
+            }
+            Err(e) => Err(anyhow!("Error opening IR file: {}", e)),
+        }?
+    } else {
+        ensure_exo_project_dir(&PathBuf::from("."))?;
+        build_system_with_static_builders(model_file.as_ref(), trusted_documents_dir).await?
+    };
+
+    deserialize_postgres_subsystem(serialized_system)
+        .map_err(|e| anyhow!("Error while deserializing database subsystem: {}", e))
+}
+
+pub(super) fn use_ir_arg() -> Arg {
+    Arg::new("use-ir")
+        .help("Use the IR file instead of the model file")
+        .long("use-ir")
+        .required(false)
+        .num_args(0)
 }

--- a/crates/cli/src/commands/yolo.rs
+++ b/crates/cli/src/commands/yolo.rs
@@ -142,8 +142,8 @@ async fn run_server(
     let db_client = open_database(None).await?;
 
     // generate migrations for current database
-    let postgres_subystem = util::create_postgres_system(model, None).await?;
-    let migrations = Migration::from_db_and_model(&db_client, &postgres_subystem).await?;
+    let postgres_subsystem = util::create_postgres_system(model, None, false).await?;
+    let migrations = Migration::from_db_and_model(&db_client, &postgres_subsystem).await?;
 
     // execute migration
     println!("Applying migrations...");


### PR DESCRIPTION
In certain production environments, pushing sources to the server is difficult, yet we would like to be able to run migrations. This PR removes the need to have sources available when running these commands. Instead, passing the `user-ir` flag makes these commands read information from the IR file.