### PR TITLE
Fix query processing for Actix

### DIFF
--- a/crates/core-subsystem/core-resolver/src/http.rs
+++ b/crates/core-subsystem/core-resolver/src/http.rs
@@ -42,7 +42,7 @@ pub trait RequestHead {
     fn get_ip(&self) -> Option<std::net::IpAddr>;
 
     fn get_path(&self) -> &str;
-    fn get_query(&self) -> Option<serde_json::Value>;
+    fn get_query(&self) -> serde_json::Value;
 
     fn get_method(&self) -> &http::Method;
 }

--- a/crates/postgres-subsystem/postgres-resolver/src/access_solver.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/access_solver.rs
@@ -412,8 +412,8 @@ mod tests {
             ""
         }
 
-        fn get_query(&self) -> Option<serde_json::Value> {
-            None
+        fn get_query(&self) -> serde_json::Value {
+            Default::default()
         }
     }
 

--- a/crates/server-actix/src/lib.rs
+++ b/crates/server-actix/src/lib.rs
@@ -73,7 +73,7 @@ pub fn configure_playground(cfg: &mut ServiceConfig) {
 async fn resolve(
     http_request: HttpRequest,
     body: web::Json<Value>,
-    query: web::Query<Option<Value>>,
+    query: web::Query<Value>,
     endpoint_url: web::Data<Option<Url>>,
     system_resolver: web::Data<SystemResolver>,
 ) -> impl Responder {
@@ -110,7 +110,7 @@ impl RequestPayload for ActixRequestPayload {
 async fn resolve_locally(
     req: HttpRequest,
     body: web::Json<Value>,
-    query: Option<Value>,
+    query: Value,
     system_resolver: web::Data<SystemResolver>,
 ) -> HttpResponse {
     let playground_request = req

--- a/crates/server-actix/src/request.rs
+++ b/crates/server-actix/src/request.rs
@@ -19,11 +19,11 @@ pub struct ActixRequestHead {
     connection_info: ConnectionInfo,
     method: actix_web::http::Method,
     path: String,
-    query: Option<serde_json::Value>,
+    query: serde_json::Value,
 }
 
 impl ActixRequestHead {
-    pub fn from_request(req: HttpRequest, query: Option<serde_json::Value>) -> ActixRequestHead {
+    pub fn from_request(req: HttpRequest, query: serde_json::Value) -> ActixRequestHead {
         ActixRequestHead {
             headers: req.headers().clone(),
             connection_info: req.connection_info().clone(),
@@ -56,7 +56,7 @@ impl RequestHead for ActixRequestHead {
         &self.path
     }
 
-    fn get_query(&self) -> Option<serde_json::Value> {
+    fn get_query(&self) -> serde_json::Value {
         self.query.clone()
     }
 }

--- a/crates/server-aws-lambda/src/request.rs
+++ b/crates/server-aws-lambda/src/request.rs
@@ -19,7 +19,7 @@ pub struct LambdaRequest<'a> {
     event: &'a LambdaEvent<Value>,
     path: &'a str,
     method: http::Method,
-    query: Option<serde_json::Value>,
+    query: serde_json::Value,
 }
 
 impl<'a> LambdaRequest<'a> {
@@ -41,7 +41,11 @@ impl<'a> LambdaRequest<'a> {
         };
 
         let path = event.payload["path"].as_str().unwrap();
-        let query = event.payload.get("queryStringParameters").cloned();
+        let query = event
+            .payload
+            .get("queryStringParameters")
+            .cloned()
+            .unwrap_or_default();
 
         LambdaRequest {
             event,
@@ -107,7 +111,7 @@ impl RequestHead for LambdaRequest<'_> {
         self.path
     }
 
-    fn get_query(&self) -> Option<serde_json::Value> {
+    fn get_query(&self) -> serde_json::Value {
         self.query.clone()
     }
 }

--- a/crates/testing/src/execution/integration_test.rs
+++ b/crates/testing/src/execution/integration_test.rs
@@ -250,7 +250,7 @@ pub struct MemoryRequestHead {
     cookies: HashMap<String, String>,
     method: http::Method,
     path: String,
-    query: Option<Value>,
+    query: Value,
 }
 
 impl MemoryRequestHead {
@@ -258,7 +258,7 @@ impl MemoryRequestHead {
         cookies: HashMap<String, String>,
         method: http::Method,
         path: String,
-        query: Option<Value>,
+        query: Value,
     ) -> Self {
         Self {
             headers: HashMap::new(),
@@ -305,7 +305,7 @@ impl RequestHead for MemoryRequestHead {
         &self.path
     }
 
-    fn get_query(&self) -> Option<serde_json::Value> {
+    fn get_query(&self) -> Value {
         self.query.clone()
     }
 }
@@ -374,7 +374,7 @@ async fn run_operation(
         ctx.cookies.clone(),
         http::Method::POST,
         "/graphql".to_string(),
-        None,
+        Default::default(),
     );
 
     // add JWT token if specified in testfile

--- a/crates/testing/src/execution/introspection_tests.rs
+++ b/crates/testing/src/execution/introspection_tests.rs
@@ -128,7 +128,7 @@ async fn check_introspection(server: &SystemResolver) -> Result<Result<()>> {
         HashMap::new(),
         http::Method::POST,
         "/graphql".to_string(),
-        None,
+        Default::default(),
     );
     let operations_payload = OperationsPayload {
         operation_name: None,


### PR DESCRIPTION
For an empty query, Actix extracts the default value for `serde_json::Value``. We had assumed that to be an `Option`.