### PR TITLE
Make @readonly work with context-sourced default values

### DIFF
--- a/crates/postgres-subsystem/postgres-model-builder/src/mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/mutation_builder.rs
@@ -285,7 +285,7 @@ pub trait DataParamBuilder<D> {
                     }
                 }
             }
-            PostgresRelation::Scalar { .. } => (!field.readonly).then_some(PostgresField {
+            PostgresRelation::Scalar { .. } => Some(PostgresField {
                 name: field.name.clone(),
                 typ: if optional {
                     to_mutation_type(&field.typ).optional()

--- a/crates/postgres-subsystem/postgres-model/src/types.rs
+++ b/crates/postgres-subsystem/postgres-model/src/types.rs
@@ -261,7 +261,9 @@ impl TypeDefinitionProvider<PostgresSubsystem> for MutationType {
             let fields = self
                 .fields
                 .iter()
-                .map(|field| default_positioned(field.input_value()))
+                .flat_map(|field| {
+                    (!field.readonly).then_some(default_positioned(field.input_value()))
+                })
                 .collect();
             TypeKind::InputObject(InputObjectType { fields })
         };

--- a/integration-tests/readonly/src/index.exo
+++ b/integration-tests/readonly/src/index.exo
@@ -1,3 +1,7 @@
+context AuthContext {
+  @jwt("sub") id: Int
+}
+
 @postgres
 module TodoDatabase {
   @access(true)
@@ -6,5 +10,12 @@ module TodoDatabase {
     title: String
     completed: Boolean
     @readonly createdAt: Instant = now()
+  }
+
+  @access(true)
+  type Document {
+    @pk id: Int = autoIncrement()
+    title: String
+    @readonly ownerId: Int = AuthContext.id
   }
 }

--- a/integration-tests/readonly/tests/create-prevent-user-specified-context-default.exotest
+++ b/integration-tests/readonly/tests/create-prevent-user-specified-context-default.exotest
@@ -1,0 +1,26 @@
+operation: |
+  mutation {
+      createDocument(data: {title: "invalid-createAt", ownerId: 2}) {
+          id
+          title
+          ownerId
+      }
+  }
+auth: |
+  {
+    "sub": 2
+  }
+response: |
+  {
+    "errors": [
+      {
+        "message": "Argument(s) '[\"ownerId\"]' invalid for 'createDocument'",
+        "locations": [
+          {
+            "line": 2,
+            "column": 5
+          }
+        ]
+      }
+    ]
+  }

--- a/integration-tests/readonly/tests/create-readonly-values.exotest
+++ b/integration-tests/readonly/tests/create-readonly-values.exotest
@@ -1,0 +1,59 @@
+deno: |
+  function assertTimestampUpdate(actual, minimum) {
+    const minimum_ms = Date.parse(minimum);
+    const actual_ms = Date.parse(actual);
+
+    if (actual_ms <= minimum_ms) {
+        throw new ExographError(
+          "Update time not correct: expected later than " + minimum_ms + ", got " + actual_ms
+        )
+    }
+
+    const now_ms = Date.now();
+
+    if (Math.abs(actual_ms - now_ms) > 5000) {
+        throw new ExographError(
+          "Time returned is off by more than 5 seconds: expected " + now_ms + ", got " + actual_ms
+        )
+    } 
+
+    return true
+  }  
+operation: |
+  mutation {
+      createTodo(data: {completed: true, title: "new-todo"}) {
+          id
+          title
+          completed
+          createdAt
+      }
+
+      createDocument(data: {title: "new-document"}) {
+          id
+          title
+          ownerId
+      }
+  }
+auth: |
+  {
+    "sub": 10
+  }
+response: |
+  {
+    "data": {
+      "createTodo": {
+        "id": 5,
+        "title": "new-todo",
+        "completed": true,
+        "createdAt": (createTime) => {
+            const now = Date.now() - 5000; // allow 5 seconds of drift between server and client
+            return assertTimestampUpdate(createTime, new Date(now).toISOString())
+        },
+      },
+      "createDocument": {
+        "id": 3,
+        "title": "new-document",
+        "ownerId": 10
+      },      
+    }
+  }

--- a/integration-tests/readonly/tests/init.gql
+++ b/integration-tests/readonly/tests/init.gql
@@ -1,19 +1,33 @@
-operation: |
-    mutation {
-        t1: createTodo(data: {title: "T1", completed: true}) {
-            id @bind(name: "t1id")
-            createdAt @bind(name: "t1CreatedAt")
+stages:
+    - operation: |
+        mutation {
+            t1: createTodo(data: {title: "T1", completed: true}) {
+                id @bind(name: "t1id")
+                createdAt @bind(name: "t1CreatedAt")
+            }
+            t2: createTodo(data: {title: "T2", completed: false}) {
+                id @bind(name: "t2id")
+                createdAt @bind(name: "t2CreatedAt")
+            }
+            t3: createTodo(data: {title: "T3", completed: true}) {
+                id @bind(name: "t3id")
+                createdAt @bind(name: "t3CreatedAt")
+            }
+            t4: createTodo(data: {title: "T4", completed: false}) {
+                id @bind(name: "t4id")
+                createdAt @bind(name: "t4CreatedAt")
+            }
         }
-        t2: createTodo(data: {title: "T2", completed: false}) {
-            id @bind(name: "t2id")
-            createdAt @bind(name: "t2CreatedAt")
+    - operation: |
+        mutation {
+            d1: createDocument(data: {title: "D1"}) {
+                id @bind(name: "d1id")
+            }
+            d2: createDocument(data: {title: "D2"}) {
+                id @bind(name: "d2id")
+            }
         }
-        t3: createTodo(data: {title: "T3", completed: true}) {
-            id @bind(name: "t3id")
-            createdAt @bind(name: "t3CreatedAt")
+      auth: |
+        {
+            "sub": 1
         }
-        t4: createTodo(data: {title: "T4", completed: false}) {
-            id @bind(name: "t4id")
-            createdAt @bind(name: "t4CreatedAt")
-        }
-    }

--- a/integration-tests/readonly/tests/update-prevent-user-specified-context-default.exotest
+++ b/integration-tests/readonly/tests/update-prevent-user-specified-context-default.exotest
@@ -1,0 +1,31 @@
+operation: |
+  mutation($id: Int!) {
+      updateDocument(id: $id, data: {title: "changed", ownerId: 2}) {
+          id
+          title
+          ownerId
+      }
+  }
+variable: |
+  {
+    id: $.t1id
+  }
+auth: |
+  {
+    "sub": 2
+  }
+response: |
+  {
+    "errors": [
+      {
+        "message": "Argument(s) '[\"ownerId\"]' invalid for 'updateDocument'",
+        "locations": [
+          {
+            "line": 2,
+            "column": 5
+          }
+        ]
+      }
+    ]
+  }
+


### PR DESCRIPTION
This allows use cases such as the following, where a field must be assigned the value from a context at the creation time and never be updated:

```exo
context AuthContext {
  @jwt("sub") id: Int
}

@postgres
module DocumentDatabase {
  @access(true)
  type Document {
    @pk id: Int = autoIncrement()
    title: String
    @readonly ownerId: Int = AuthContext.id
  }
}
```