### PR TITLE
Treat `Set` correctly when enforcing input/output type disjoinment

### DIFF
--- a/crates/core-subsystem/core-resolver/src/introspection/definition/schema.rs
+++ b/crates/core-subsystem/core-resolver/src/introspection/definition/schema.rs
@@ -141,18 +141,26 @@ impl Schema {
             .map(|td| td.name.node.as_str().to_string())
             .collect();
 
+        fn remove_scalars(
+            field_definitions: &Vec<Positioned<FieldDefinition>>,
+            unused_scalars_names: &mut HashSet<String>,
+        ) {
+            for field in field_definitions {
+                unused_scalars_names.remove(underlying_type(&field.node.ty.node).as_str());
+                for arg in &field.node.arguments {
+                    unused_scalars_names.remove(underlying_type(&arg.node.ty.node).as_str());
+                }
+            }
+        }
+
         // Next, remove scalars that are used
         for td in &type_definitions {
             match &td.kind {
                 TypeKind::Object(object_type) => {
-                    for field in &object_type.fields {
-                        unused_scalars_names.remove(underlying_type(&field.node.ty.node).as_str());
-                    }
+                    remove_scalars(&object_type.fields, &mut unused_scalars_names);
                 }
                 TypeKind::Interface(interface_type) => {
-                    for field in &interface_type.fields {
-                        unused_scalars_names.remove(underlying_type(&field.node.ty.node).as_str());
-                    }
+                    remove_scalars(&interface_type.fields, &mut unused_scalars_names);
                 }
                 TypeKind::InputObject(input_object_type) => {
                     for field in &input_object_type.fields {

--- a/integration-tests/services/set-arg-return-value/src/chat.ts
+++ b/integration-tests/services/set-arg-return-value/src/chat.ts
@@ -1,0 +1,20 @@
+import type { Message, Question } from '../generated/ChatService.d.ts';
+
+export function chat(messages: Message[]): string {
+	return messages.map((message) => {
+		return message.text.toUpperCase();
+	}).join(' ');
+}
+
+export function generateQuestions(_projectId: string): Question[] {
+	return ["What is your name?", "How can I help you?"].map((text) => {
+		return {
+			content: text
+		};
+	});
+}
+
+export function initialQuestion(_projectId: string): Question {
+	return { content: "What's up?" };
+}
+

--- a/integration-tests/services/set-arg-return-value/src/index.exo
+++ b/integration-tests/services/set-arg-return-value/src/index.exo
@@ -1,0 +1,24 @@
+// Exograph should enforce disjoinment only of the underlying types 
+// (Message and Quesion in this case) and not the container types (Set). 
+// See https://github.com/exograph/exograph/issues/1183
+@deno("chat.ts")
+module ChatService {
+  @access(true)
+  type Message {
+    text: String
+  }
+
+  @access(true)
+  type Question {
+    content: String
+  }
+
+  @access(true)
+  query chat(messages: Set<Message>): String
+
+  @access(true)
+  query generateQuestions(projectId: Uuid): Set<Question>
+
+  @access(true)
+  query initialQuestion(projectId: Uuid): Question
+}

--- a/integration-tests/services/set-arg-return-value/tests/basic.exotest
+++ b/integration-tests/services/set-arg-return-value/tests/basic.exotest
@@ -1,0 +1,29 @@
+operation: |
+  query {
+      chat(messages: [{text: "Hello"}, {text: "How are you?"}])
+
+      initialQuestion(projectId: "00000000-0000-0000-0000-000000000000") {
+        content
+      }
+
+      generateQuestions(projectId: "00000000-0000-0000-0000-000000000000") {
+        content
+      }
+  }
+response: |
+  {
+    "data": {
+      "chat": "HELLO HOW ARE YOU?",
+      "initialQuestion": {
+        "content": "What's up?"
+      },
+      "generateQuestions": [
+        {
+          "content": "What is your name?"
+        },
+        {
+          "content": "How can I help you?"
+        }
+      ]
+    }
+  }


### PR DESCRIPTION
We considered the raw `Set` type to be a top-level type. This prevented declaring a `Set` of different underlying types as input and output types in Deno modules. This commit considers the underlying types of the `Set` type when enforcing the disjoining of input and output types.

Also, fix the computation of unused types to consider operation arguments (in addition to return types).

Fixes #1183