### PR TITLE
Improve query to introspect schemas

### DIFF
--- a/libs/exo-sql/src/schema/database_spec.rs
+++ b/libs/exo-sql/src/schema/database_spec.rs
@@ -198,7 +198,7 @@ impl DatabaseSpec {
         client: &DatabaseClient,
     ) -> Result<WithIssues<DatabaseSpec>, DatabaseError> {
         const SCHEMAS_QUERY: &str =
-            "SELECT DISTINCT table_schema FROM information_schema.tables WHERE table_schema != 'information_schema' AND table_schema != 'pg_catalog'";
+            "SELECT DISTINCT table_schema FROM information_schema.tables WHERE table_schema != 'information_schema' AND table_schema NOT LIKE 'pg_%' AND table_type <> 'SYSTEM VIEW'";
 
         // Query to get a list of all the tables in the database
         const TABLE_NAMES_QUERY: &str =


### PR DESCRIPTION
Earlier, the schema introspection query picked up a few system tables in certain situations (for example, when working with CockroachDB, it picked up `crdb_internal`). In this commit, we check for the `table_type` value to ignore system-defined schemas.