### PR TITLE
Fix aliasing involving a many-to-one relationship

### DIFF
--- a/integration-tests/ownership-access-check/indirect/tests/admin-nested-fields.exotest
+++ b/integration-tests/ownership-access-check/indirect/tests/admin-nested-fields.exotest
@@ -1,0 +1,107 @@
+operation: |
+  query questions {
+    withProject: questions @unordered {
+      id
+      project {
+        id
+        name
+      }
+    }
+
+    withProjectAndOwner: questions @unordered {
+      id
+      project {
+        id
+        name
+        owner {
+          id
+          name
+        }
+      }
+    }
+  }
+auth: |
+  {
+    isAdmin: true
+  }
+response: |
+  {
+    "data": {
+      "withProject": [
+        {
+          "id": $.q1Ids[0],
+          "project": {
+            id: $.p1Id,
+            "name": "P1"
+          }
+        },
+        {
+          "id": $.q1Ids[1],
+          "project": {
+            id: $.p1Id,
+            "name": "P1"
+          }
+        },
+        {
+          "id": $.q2Ids[0],
+          "project": {
+            id: $.p2Id,
+            "name": "P2"
+          }
+        },
+        {
+          "id": $.q2Ids[1],
+          "project": {
+            id: $.p2Id,
+            "name": "P2"
+          }
+        }
+      ],
+      "withProjectAndOwner": [
+        {
+          "id": $.q1Ids[0],
+          "project": {
+            id: $.p1Id,
+            "name": "P1",
+            "owner": {
+              id: $.u1Id,
+              "name": "U1"
+            }
+          }
+        },
+        {
+          "id": $.q1Ids[1],
+          "project": {
+            id: $.p1Id,
+            "name": "P1",
+            "owner": {
+              id: $.u1Id,
+              "name": "U1"
+            }
+          }
+        },
+        {
+          "id": $.q2Ids[0],
+          "project": {
+            id: $.p2Id,
+            "name": "P2",
+            "owner": {
+              id: $.u2Id,
+              "name": "U2"
+            }
+          }
+        },
+        {
+          "id": $.q2Ids[1],
+          "project": {
+            id: $.p2Id,
+            "name": "P2",
+            "owner": {
+              id: $.u2Id,
+              "name": "U2"
+            }
+          }
+        }
+      ]
+    }
+  }

--- a/integration-tests/ownership-access-check/indirect/tests/user-nested-fields.exotest
+++ b/integration-tests/ownership-access-check/indirect/tests/user-nested-fields.exotest
@@ -1,0 +1,71 @@
+operation: |
+  query questions {
+    withProject: questions @unordered {
+      id
+      project {
+        id
+        name
+      }
+    }
+
+    withProjectAndOwner: questions @unordered {
+      id
+      project {
+        id
+        name
+        owner {
+          id
+          name
+        }
+      }
+    }
+  }
+auth: |
+  {
+    sub: $.u1Id
+  }
+response: |
+  {
+    "data": {
+      "withProject": [
+        {
+          "id": $.q1Ids[0],
+          "project": {
+            id: $.p1Id,
+            "name": "P1"
+          }
+        },
+        {
+          "id": $.q1Ids[1],
+          "project": {
+            id: $.p1Id,
+            "name": "P1"
+          }
+        }
+      ],
+      "withProjectAndOwner": [
+        {
+          "id": $.q1Ids[0],
+          "project": {
+            id: $.p1Id,
+            "name": "P1",
+            "owner": {
+              id: $.u1Id,
+              "name": "U1"
+            }
+          }
+        },
+        {
+          "id": $.q1Ids[1],
+          "project": {
+            id: $.p1Id,
+            "name": "P1",
+            "owner": {
+              id: $.u1Id,
+              "name": "U1"
+            }
+          }
+        }
+      ]
+    }
+  }


### PR DESCRIPTION
We were not correctly aliasing the columns of the parent table when a query contained a nested field that was a many-to-one relationship (and the join involved another level for access control)

Fixes #1204