### PR TITLE
Speed up yolo mode by skipping certificate loading

### DIFF
--- a/libs/exo-sql/src/sql/connect/ssl_config.rs
+++ b/libs/exo-sql/src/sql/connect/ssl_config.rs
@@ -132,11 +132,11 @@ impl SslConfig {
                         .collect::<Result<Vec<_>, _>>()?;
                 }
                 None => {
-                    // If all host addresses are Unix sockets, we don't need to load native certs.
+                    // We need to load certificates only if at least one TCP host is present.
                     let needs_certs = config
                         .get_hosts()
                         .iter()
-                        .all(|host| !matches!(host, tokio_postgres::config::Host::Unix(_)));
+                        .any(|host| matches!(host, tokio_postgres::config::Host::Tcp(_)));
 
                     if needs_certs {
                         root_store.add_parsable_certificates(load_native_certs()?);

--- a/libs/exo-sql/src/sql/connect/ssl_config.rs
+++ b/libs/exo-sql/src/sql/connect/ssl_config.rs
@@ -132,7 +132,15 @@ impl SslConfig {
                         .collect::<Result<Vec<_>, _>>()?;
                 }
                 None => {
-                    root_store.add_parsable_certificates(load_native_certs()?);
+                    // If all host addresses are Unix sockets, we don't need to load native certs.
+                    let needs_certs = config
+                        .get_hosts()
+                        .iter()
+                        .all(|host| !matches!(host, tokio_postgres::config::Host::Unix(_)));
+
+                    if needs_certs {
+                        root_store.add_parsable_certificates(load_native_certs()?);
+                    }
                 }
             }
 

--- a/libs/exo-sql/src/testing/error.rs
+++ b/libs/exo-sql/src/testing/error.rs
@@ -15,12 +15,13 @@ use thiserror::Error;
 pub enum EphemeralDatabaseSetupError {
     #[error("Failed to start postgres")]
     PostgresFailedToStart(#[from] io::Error),
+
     #[error("Failed to find executable: {0} ({1})")]
     ExecutableNotFound(&'static str, which::Error),
 
     #[error("Failed to start Docker (it may not be installed) {0}")]
     Docker(#[source] io::Error),
 
-    #[error("Failed to start postgres {0}")]
+    #[error("{0}")]
     Generic(String),
 }


### PR DESCRIPTION
Loading native certificates takes about 100ms on my machine. Since in yolo mode uses Postgres through either a Unix socket or Docker, we don't need to load any certificates.

In this PR, we check if all hosts are in Unix sockets and if so, skip loading the native certs. Similarly, with Docker, we can set the `sslmode` to `disable` (we already do not load native certs if SSL is disabled).