### PR TITLE
Support null literals in access expressions

### DIFF
--- a/crates/builder/grammar/grammar.js
+++ b/crates/builder/grammar/grammar.js
@@ -132,7 +132,8 @@ module.exports = grammar({
       $.selection,
       $.literal_number,
       $.literal_str,
-      $.literal_boolean
+      $.literal_boolean,
+      $.literal_null
     ),
     parenthetical: $ => seq("(", field("expression", $.expression), ")"),
     selection: $ => choice(
@@ -213,6 +214,7 @@ module.exports = grammar({
     literal_str: $ => seq("\"", field("value", $.str), "\""),
     literal_boolean: $ => choice("true", "false"),
     literal_number: $ => field("value", $.number),
+    literal_null: $ => "null",
     comment: $ => token(choice(
       seq('//', /.*/),
       seq(

--- a/crates/builder/src/builder/interceptor_weaver.rs
+++ b/crates/builder/src/builder/interceptor_weaver.rs
@@ -89,6 +89,7 @@ fn matches(expr: &AstExpr<Typed>, operation_name: &str, operation_kind: Operatio
         AstExpr::StringList(_, _) => {
             panic!("List not supported in interceptor expression")
         }
+        AstExpr::NullLiteral(_) => panic!("NullLiteral not supported in interceptor expression"),
     }
 }
 

--- a/crates/builder/src/parser/converter.rs
+++ b/crates/builder/src/parser/converter.rs
@@ -531,6 +531,7 @@ fn convert_expression(node: Node, source: &[u8], source_span: Span) -> AstExpr<U
             let value = first_child.child(0).unwrap().utf8_text(source).unwrap();
             AstExpr::BooleanLiteral(value == "true", source_span)
         }
+        "literal_null" => AstExpr::NullLiteral(span_from_node(source_span, first_child)),
         "logical_op" => AstExpr::LogicalOp(convert_logical_op(first_child, source, source_span)),
         "relational_op" => {
             AstExpr::RelationalOp(convert_relational_op(first_child, source, source_span))

--- a/crates/builder/src/typechecker/expression.rs
+++ b/crates/builder/src/typechecker/expression.rs
@@ -31,6 +31,7 @@ impl TypecheckFrom<AstExpr<Untyped>> for AstExpr<Typed> {
             AstExpr::BooleanLiteral(v, s) => AstExpr::BooleanLiteral(*v, *s),
             AstExpr::NumberLiteral(v, s) => AstExpr::NumberLiteral(*v, *s),
             AstExpr::StringList(v, s) => AstExpr::StringList(v.clone(), s.clone()),
+            AstExpr::NullLiteral(s) => AstExpr::NullLiteral(*s),
         }
     }
 
@@ -50,7 +51,8 @@ impl TypecheckFrom<AstExpr<Untyped>> for AstExpr<Typed> {
             AstExpr::StringList(_, _)
             | AstExpr::StringLiteral(_, _)
             | AstExpr::BooleanLiteral(_, _)
-            | AstExpr::NumberLiteral(_, _) => false,
+            | AstExpr::NumberLiteral(_, _)
+            | AstExpr::NullLiteral(_) => false,
         }
     }
 }

--- a/crates/core-subsystem/core-model-builder/src/ast/ast_types.rs
+++ b/crates/core-subsystem/core-model-builder/src/ast/ast_types.rs
@@ -283,6 +283,12 @@ pub enum AstExpr<T: NodeTypedness> {
         #[serde(skip_deserializing)]
         Vec<Span>,
     ),
+    NullLiteral(
+        #[serde(skip_serializing)]
+        #[serde(skip_deserializing)]
+        #[serde(default = "default_span")]
+        Span,
+    ),
 }
 
 impl<T: NodeTypedness> AstExpr<T> {
@@ -298,6 +304,7 @@ impl<T: NodeTypedness> AstExpr<T> {
             AstExpr::RelationalOp(r) => r.span(),
             AstExpr::BooleanLiteral(_, s) => *s,
             AstExpr::NumberLiteral(_, s) => *s,
+            AstExpr::NullLiteral(s) => *s,
             AstExpr::StringList(_, s) => {
                 let mut span = s[0].to_owned();
                 for s in s.iter().skip(1) {

--- a/crates/core-subsystem/core-model-builder/src/typechecker/expression.rs
+++ b/crates/core-subsystem/core-model-builder/src/typechecker/expression.rs
@@ -25,6 +25,7 @@ impl AstExpr<Typed> {
             AstExpr::StringList(_, _) => {
                 Type::Array(Box::new(Type::Primitive(PrimitiveType::String)))
             }
+            AstExpr::NullLiteral(_) => Type::Null,
         }
     }
 

--- a/crates/core-subsystem/core-model-builder/src/typechecker/typ.rs
+++ b/crates/core-subsystem/core-model-builder/src/typechecker/typ.rs
@@ -23,6 +23,7 @@ pub enum Type {
     Set(Box<Type>),
     Array(Box<Type>),
     Reference(SerializableSlabIndex<Type>),
+    Null,
     Defer,
     Error,
 }
@@ -53,6 +54,7 @@ impl Display for Type {
                 f.write_str("ref#")?;
                 r.arr_idx().fmt(f)
             }
+            Type::Null => f.write_str("null"),
             _ => Result::Err(std::fmt::Error),
         }
     }

--- a/crates/core-subsystem/core-model/src/access.rs
+++ b/crates/core-subsystem/core-model/src/access.rs
@@ -129,6 +129,7 @@ pub enum CommonAccessPrimitiveExpression {
     StringLiteral(String),              // for example, "ADMIN"
     BooleanLiteral(bool),               // for example, true
     NumberLiteral(i64),                 // for example, integer (-13, 0, 300, etc.)
+    NullLiteral,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/core-subsystem/core-resolver/src/access_solver.rs
+++ b/crates/core-subsystem/core-resolver/src/access_solver.rs
@@ -149,6 +149,7 @@ pub async fn reduce_common_primitive_expression<'a>(
         CommonAccessPrimitiveExpression::StringLiteral(value) => Some(Val::String(value.clone())),
         CommonAccessPrimitiveExpression::BooleanLiteral(value) => Some(Val::Bool(*value)),
         CommonAccessPrimitiveExpression::NumberLiteral(value) => Some(Val::Number((*value).into())),
+        CommonAccessPrimitiveExpression::NullLiteral => Some(Val::Null),
     })
 }
 

--- a/crates/core-subsystem/core-resolver/src/context_extractor.rs
+++ b/crates/core-subsystem/core-resolver/src/context_extractor.rs
@@ -15,6 +15,7 @@ use core_model::{
         ContextContainer, ContextField, ContextFieldType, ContextSelection, ContextType,
     },
     primitive_type::PrimitiveType,
+    types::FieldType,
 };
 use futures::StreamExt;
 
@@ -118,7 +119,13 @@ async fn extract_context_field<'a>(
         )
         .await?;
 
-    Ok(raw_val)
+    // If the field type is optional, we return Val::Null for an empty value.
+    let option_sensitive_value = match typ {
+        FieldType::Optional(_) => Some(raw_val.unwrap_or(&Val::Null)),
+        _ => raw_val,
+    };
+
+    Ok(option_sensitive_value)
 }
 
 fn coerce(value: Val, typ: &ContextFieldType) -> Result<Val, ContextExtractionError> {

--- a/crates/postgres-subsystem/postgres-model-builder/src/access_utils.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/access_utils.rs
@@ -173,6 +173,9 @@ pub fn compute_input_predicate_expression(
         AstExpr::StringList(_, _) => Err(ModelBuildingError::Generic(
             "Top-level expression cannot be a list literal".to_string(),
         )),
+        AstExpr::NullLiteral(_) => Err(ModelBuildingError::Generic(
+            "Top-level expression cannot be a null literal".to_string(),
+        )),
     }
 }
 
@@ -497,6 +500,9 @@ fn compute_primitive_db_expr(
         AstExpr::NumberLiteral(value, _) => Ok(DatabaseAccessPrimitiveExpression::Common(
             CommonAccessPrimitiveExpression::NumberLiteral(*value),
         )),
+        AstExpr::NullLiteral(_) => Ok(DatabaseAccessPrimitiveExpression::Common(
+            CommonAccessPrimitiveExpression::NullLiteral,
+        )),
         AstExpr::StringList(_, _) => Err(ModelBuildingError::Generic(
             "Access expressions do not support lists yet".to_string(),
         )),
@@ -539,6 +545,9 @@ fn compute_primitive_json_expr(
         )),
         AstExpr::NumberLiteral(value, _) => Ok(InputAccessPrimitiveExpression::Common(
             CommonAccessPrimitiveExpression::NumberLiteral(*value),
+        )),
+        AstExpr::NullLiteral(_) => Ok(InputAccessPrimitiveExpression::Common(
+            CommonAccessPrimitiveExpression::NullLiteral,
         )),
         AstExpr::StringList(_, _) => Err(ModelBuildingError::Generic(
             "Access expressions do not support lists yet".to_string(),

--- a/crates/postgres-subsystem/postgres-resolver/src/access_solver.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/access_solver.rs
@@ -206,6 +206,7 @@ impl<'a> AccessSolver<'a, DatabaseAccessPrimitiveExpression, AbstractPredicateWr
                 AbstractPredicate::In,
                 |left_value, right_value| match right_value {
                     Val::List(values) => values.contains(&left_value).into(),
+                    Val::Null => false.into(),
                     _ => unreachable!("The right side operand of `in` operator must be an array"), // This never happens see relational_op::in_relation_match
                 },
             ),

--- a/crates/subsystem-util/subsystem-model-builder-util/src/builder/access_utils.rs
+++ b/crates/subsystem-util/subsystem-model-builder-util/src/builder/access_utils.rs
@@ -123,6 +123,9 @@ fn compute_primitive_expr(
         AstExpr::NumberLiteral(value, _) => ModuleAccessPrimitiveExpression::Common(
             CommonAccessPrimitiveExpression::NumberLiteral(*value),
         ),
+        AstExpr::NullLiteral(_) => {
+            ModuleAccessPrimitiveExpression::Common(CommonAccessPrimitiveExpression::NullLiteral)
+        }
         AstExpr::StringList(_, _) => panic!("Module access expressions do not support lists yet"),
         AstExpr::LogicalOp(_) => unreachable!(), // Parser has already ensures that the two sides are primitive expressions
         AstExpr::RelationalOp(_) => unreachable!(), // Parser has already ensures that the two sides are primitive expressions

--- a/integration-tests/access-expressions/src/access-expressions.ts
+++ b/integration-tests/access-expressions/src/access-expressions.ts
@@ -1,0 +1,16 @@
+export async function getAuthenticatedSecret(): Promise<string> {
+	return 'authenticated-secret';
+}
+
+export async function setAuthenticatedSecret(secret: string): Promise<string> {
+	return secret.toUpperCase();
+}
+
+export async function getUnauthenticatedSecret(): Promise<string> {
+	return 'unauthenticated-secret';
+}
+
+export async function setUnauthenticatedSecret(secret: string): Promise<string> {
+	return secret.toUpperCase();
+}
+

--- a/integration-tests/access-expressions/src/index.exo
+++ b/integration-tests/access-expressions/src/index.exo
@@ -1,5 +1,5 @@
 context AuthContext {
-  @jwt("sub") id: Int 
+  @jwt("sub") id: Int?
   @jwt("roles") roles: Array<String> 
   @jwt("externalId") externalId: Int
 }
@@ -51,4 +51,34 @@ module DocumentModule {
     externalId: Int?
     content: String
   }
+
+  // Only authenticated users can see the docs
+  @access(query=AuthContext.id != null || "ADMIN" in AuthContext.roles, mutation="ADMIN" in AuthContext.roles)
+  type AuthenticatedDoc {
+    @pk id: Int = autoIncrement()
+    content: String
+  }
+
+  // Only un-authenticated users can see the docs (this is a contrived example)
+  @access(query=AuthContext.id == null || "ADMIN" in AuthContext.roles, mutation="ADMIN" in AuthContext.roles)
+  type UnauthenticatedDoc {
+    @pk id: Int = autoIncrement()
+    content: String
+  }
+}
+
+@deno("access-expressions.ts")
+module AccessExpressions {
+  @access(AuthContext.id != null)
+  query getAuthenticatedSecret(): String
+
+  @access(AuthContext.id != null)
+  mutation setAuthenticatedSecret(secret: String): String
+
+  // This is a contrived example, but it shows `== null` in the access expression
+  @access(AuthContext.id == null)
+  query getUnauthenticatedSecret(): String
+
+  @access(AuthContext.id == null)
+  mutation setUnauthenticatedSecret(secret: String): String
 }

--- a/integration-tests/access-expressions/tests/authDocs.exotest
+++ b/integration-tests/access-expressions/tests/authDocs.exotest
@@ -1,0 +1,71 @@
+stages:
+  # Authenticated user with no roles
+  - operation: |
+      query {
+        authenticatedDocs {
+          id
+          content
+        }
+      }
+    auth: |
+      {
+        "sub": 2,
+      }   
+    response: |
+      {
+        "data": {
+          "authenticatedDocs": [
+            {
+              "id": $.authenticatedDoc1Id,
+              "content": "authenticatedDoc1"
+            },
+            {
+              "id": $.authenticatedDoc2Id,
+              "content": "authenticatedDoc2"
+            }
+          ]
+        }
+      }
+  # Authenticated user with ADMIN role
+  - operation: |
+      query {
+        authenticatedDocs {
+          id
+          content
+        }
+      }
+    auth: |
+      {
+        "roles": ["ADMIN"],
+      }   
+    response: |
+      {
+        "data": {
+          "authenticatedDocs": [
+            {
+              "id": $.authenticatedDoc1Id,
+              "content": "authenticatedDoc1"
+            },
+            {
+              "id": $.authenticatedDoc2Id,
+              "content": "authenticatedDoc2"
+            }
+          ]
+        }
+      }
+  # Unauthenticated user
+  - operation: |
+      query {
+        authenticatedDocs {
+          id
+          content
+        }
+      }  
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Not authorized"
+          }
+        ]
+      }

--- a/integration-tests/access-expressions/tests/init-docs.gql
+++ b/integration-tests/access-expressions/tests/init-docs.gql
@@ -34,6 +34,18 @@ stages:
             users: createUsers(data: [{name: "u1"}, {name: "u2"}, {name: "a1"}, {name: "a2"}]) {
                 id @bind(name: "userIds")
             }
+            authenticatedDoc1: createAuthenticatedDoc(data: {content: "authenticatedDoc1"}) {
+                id @bind(name: "authenticatedDoc1Id")
+            }
+            authenticatedDoc2: createAuthenticatedDoc(data: {content: "authenticatedDoc2"}) {
+                id @bind(name: "authenticatedDoc2Id")
+            }
+            unauthenticatedDoc1: createUnauthenticatedDoc(data: {content: "unauthenticatedDoc1"}) {
+                id @bind(name: "unauthenticatedDoc1Id")
+            }
+            unauthenticatedDoc2: createUnauthenticatedDoc(data: {content: "unauthenticatedDoc2"}) {
+                id @bind(name: "unauthenticatedDoc2Id")
+            }
         }  
       auth: |
         {

--- a/integration-tests/access-expressions/tests/null-context.exotest
+++ b/integration-tests/access-expressions/tests/null-context.exotest
@@ -1,0 +1,118 @@
+stages:
+  # Authenticated user queries what they can see
+  - operation: |
+      query {
+        getAuthenticatedSecret
+      }
+    auth: |
+      {
+        "sub": 2,
+      }   
+    response: |
+      {
+        "data": {
+          "getAuthenticatedSecret": "authenticated-secret"
+        }
+      }
+  # Authenticated user queries what they can't see
+  - operation: |
+      query {
+        getUnauthenticatedSecret
+      }
+    auth: |
+      {
+        "sub": 2,
+      }   
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Not authorized"
+          }
+        ]
+      }
+
+  # Unauthenticated user queries what they can see
+  - operation: |
+      query {
+        getUnauthenticatedSecret
+      }
+    response: |
+      {
+        "data": {
+          "getUnauthenticatedSecret": "unauthenticated-secret"
+        }
+      }
+  # Unauthenticated user queries what they can't see
+  - operation: |
+      query {
+        getAuthenticatedSecret
+      }
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Not authorized"
+          }
+        ]
+      }
+
+
+  # Authenticated user mutates what they can 
+  - operation: |
+      mutation {
+        setAuthenticatedSecret(secret: "new")
+      }
+    auth: |
+      {
+        "sub": 2,
+      }
+    response: |
+      {
+        "data": {
+          "setAuthenticatedSecret": "NEW"
+        }
+      }
+  # Authenticated user mutates what they can't
+  - operation: |
+      mutation {
+        setUnauthenticatedSecret(secret: "new")
+      }
+    auth: |
+      {
+        "sub": 2,
+      }
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Not authorized"
+          }
+        ]
+      }
+
+  # Unauthenticated user mutates what they can 
+  - operation: |
+      mutation {
+        setUnauthenticatedSecret(secret: "new")
+      }
+    response: |
+      {
+        "data": {
+          "setUnauthenticatedSecret": "NEW"
+        }
+      }
+  # Unauthenticated user mutates what they can't
+  - operation: |
+      mutation {
+        setAuthenticatedSecret(secret: "new")
+      }
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Not authorized"
+          }
+        ]
+      }
+

--- a/integration-tests/access-expressions/tests/unauthDocs.exotest
+++ b/integration-tests/access-expressions/tests/unauthDocs.exotest
@@ -1,0 +1,71 @@
+stages:
+  # Authenticated user with no roles
+  - operation: |
+      query {
+        unauthenticatedDocs {
+          id
+          content
+        }
+      }
+    auth: |
+      {
+        "sub": 2,
+      }   
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Not authorized"
+          }
+        ]
+      }
+  # Authenticated user with ADMIN role
+  - operation: |
+      query {
+        unauthenticatedDocs {
+          id
+          content
+        }
+      }
+    auth: |
+      {
+        "roles": ["ADMIN"],
+      }   
+    response: |
+      {
+        "data": {
+          "unauthenticatedDocs": [
+            {
+              "id": $.unauthenticatedDoc1Id,
+              "content": "unauthenticatedDoc1"
+            },
+            {
+              "id": $.unauthenticatedDoc2Id,
+              "content": "unauthenticatedDoc2"
+            }
+          ]
+        }
+      }
+  # Unauthenticated user
+  - operation: |
+      query {
+        unauthenticatedDocs {
+          id
+          content
+        }
+      }  
+    response: |
+      {
+        "data": {
+          "unauthenticatedDocs": [
+            {
+              "id": $.unauthenticatedDoc1Id,
+              "content": "unauthenticatedDoc1"
+            },
+            {
+              "id": $.unauthenticatedDoc2Id,
+              "content": "unauthenticatedDoc2"
+            }
+          ]
+        }
+      }


### PR DESCRIPTION
This allows easy checks for common conditions like `AuthContext.id != null` to check for authenticated users.