### PR TITLE
Support `contains` function in access expressions

### DIFF
--- a/crates/builder/src/typechecker/selection.rs
+++ b/crates/builder/src/typechecker/selection.rs
@@ -202,7 +202,7 @@ impl TypecheckFunctionCallFrom<FieldSelectionElement<Untyped>> for FieldSelectio
                                     level: Level::Error,
                                     message: format!(
                                         "Parameter type does not match element type: expected `{}`, found `{}`",
-                                        elem_type, param_type, 
+                                        elem_type, param_type,
                                     ),
                                     code: Some("C000".to_string()),
                                     spans: vec![SpanLabel {

--- a/crates/builder/src/typechecker/selection.rs
+++ b/crates/builder/src/typechecker/selection.rs
@@ -415,7 +415,20 @@ impl TypecheckFrom<FieldSelection<Untyped>> for FieldSelection<Typed> {
                                 updated
                             }
                             _ => {
-                                todo!()
+                                *typ = Type::Error;
+
+                                errors.push(Diagnostic {
+                                    level: Level::Error,
+                                    message: "Only `contains` function is supported on arrays"
+                                        .to_string(),
+                                    code: Some("C000".to_string()),
+                                    spans: vec![SpanLabel {
+                                        span: *elem.span(),
+                                        style: SpanStyle::Primary,
+                                        label: Some("unsupported field".to_string()),
+                                    }],
+                                });
+                                false
                             }
                         },
                         _ => {

--- a/crates/builder/src/typechecker/selection.rs
+++ b/crates/builder/src/typechecker/selection.rs
@@ -20,7 +20,7 @@ use crate::ast::ast_types::{AstModelKind, FieldSelection, Untyped};
 
 use super::{Scope, Type, TypecheckFrom};
 
-pub trait TypecheckHofCallFrom<T>
+pub trait TypecheckFunctionCallFrom<T>
 where
     Self: Sized,
 {
@@ -35,7 +35,7 @@ where
     ) -> bool;
 }
 
-impl TypecheckHofCallFrom<FieldSelectionElement<Untyped>> for FieldSelectionElement<Typed> {
+impl TypecheckFunctionCallFrom<FieldSelectionElement<Untyped>> for FieldSelectionElement<Typed> {
     fn shallow(untyped: &FieldSelectionElement<Untyped>) -> Self {
         match untyped {
             FieldSelectionElement::Identifier(value, s, _) => {
@@ -52,6 +52,14 @@ impl TypecheckHofCallFrom<FieldSelectionElement<Untyped>> for FieldSelectionElem
                 name: name.clone(),
                 param_name: elem_name.clone(),
                 expr: Box::new(AstExpr::shallow(expr)),
+                typ: Type::Defer,
+            },
+            FieldSelectionElement::NormalCall {
+                span, name, params, ..
+            } => FieldSelectionElement::NormalCall {
+                span: *span,
+                name: name.clone(),
+                params: params.iter().map(AstExpr::shallow).collect(),
                 typ: Type::Defer,
             },
         }
@@ -141,6 +149,76 @@ impl TypecheckHofCallFrom<FieldSelectionElement<Untyped>> for FieldSelectionElem
                 *typ = expr.typ().clone();
                 updated
             }
+            FieldSelectionElement::NormalCall {
+                name,
+                params,
+                typ,
+                span,
+            } => {
+                let updated = params
+                    .iter_mut()
+                    .map(|p| p.pass(type_env, annotation_env, scope, errors))
+                    .all(|b| b);
+
+                if name.0 != "contains" {
+                    *typ = Type::Error;
+
+                    errors.push(Diagnostic {
+                        level: Level::Error,
+                        message: format!(
+                            "Only `contains` function is supported on arrays, not `{}`",
+                            name.0
+                        ),
+                        code: Some("C000".to_string()),
+                        spans: vec![SpanLabel {
+                            span: *span,
+                            style: SpanStyle::Primary,
+                            label: Some("unknown context".to_string()),
+                        }],
+                    });
+                    false
+                } else {
+                    // Ensure that the params and elem_type are compatible
+                    if params.is_empty() {
+                        *typ = Type::Error;
+                        errors.push(Diagnostic {
+                            level: Level::Error,
+                            message: "Contains function expects one parameter".to_string(),
+                            code: Some("C000".to_string()),
+                            spans: vec![SpanLabel {
+                                span: *span,
+                                style: SpanStyle::Primary,
+                                label: Some("type mismatch".to_string()),
+                            }],
+                        });
+                        return false;
+                    }
+                    if params.len() == 1 {
+                        let param_type = params[0].typ();
+                        if let Some(elem_type) = elem_type {
+                            if elem_type != &param_type {
+                                *typ = Type::Error;
+                                errors.push(Diagnostic {
+                                    level: Level::Error,
+                                    message: format!(
+                                        "Parameter type does not match element type: expected `{}`, found `{}`",
+                                        elem_type, param_type, 
+                                    ),
+                                    code: Some("C000".to_string()),
+                                    spans: vec![SpanLabel {
+                                        span: params[0].span(),
+                                        style: SpanStyle::Primary,
+                                        label: Some("type mismatch".to_string()),
+                                    }],
+                                });
+                                return false;
+                            }
+                        }
+                    }
+                    *typ = typ.clone();
+                    updated
+                }
+            }
         }
     }
 }
@@ -174,7 +252,8 @@ impl TypecheckFrom<FieldSelection<Untyped>> for FieldSelection<Typed> {
                     FieldSelectionElement::Identifier(_, _, resolved_typ) => {
                         *typ = resolved_typ.clone();
                     }
-                    FieldSelectionElement::HofCall { name, span, .. } => {
+                    FieldSelectionElement::HofCall { name, span, .. }
+                    | FieldSelectionElement::NormalCall { name, span, .. } => {
                         *typ = Type::Error;
                         errors.push(Diagnostic {
                             level: Level::Error,
@@ -218,6 +297,27 @@ impl TypecheckFrom<FieldSelection<Untyped>> for FieldSelection<Typed> {
                             let elem = match elem {
                                 FieldSelectionElement::Identifier(value, s, _) => (value, *s),
                                 FieldSelectionElement::HofCall { span, name, .. } => {
+                                    *typ = Type::Error;
+                                    errors.push(Diagnostic {
+                                        level: Level::Error,
+                                        message: format!(
+                                            "Function call {} not supported on type {}",
+                                            name.0, c.name
+                                        ),
+                                        code: Some("C000".to_string()),
+                                        spans: vec![SpanLabel {
+                                            span: *span,
+                                            style: SpanStyle::Primary,
+                                            label: Some(
+                                                "unsupported function call target type".to_string(),
+                                            ),
+                                        }],
+                                    });
+                                    return false;
+                                }
+                                FieldSelectionElement::NormalCall {
+                                    span, name, typ, ..
+                                } => {
                                     *typ = Type::Error;
                                     errors.push(Diagnostic {
                                         level: Level::Error,
@@ -290,6 +390,33 @@ impl TypecheckFrom<FieldSelection<Untyped>> for FieldSelection<Typed> {
                                 *typ = hof_call.typ().clone();
                                 updated
                             }
+                            normal_call @ FieldSelectionElement::NormalCall { .. } => {
+                                let updated = normal_call.pass(
+                                    type_env,
+                                    annotation_env,
+                                    scope,
+                                    Some(&elem_type),
+                                    errors,
+                                );
+                                *typ = normal_call.typ().clone();
+                                updated
+                            }
+                        },
+                        Type::Array(elem_type) => match elem {
+                            normal_call @ FieldSelectionElement::NormalCall { .. } => {
+                                let updated = normal_call.pass(
+                                    type_env,
+                                    annotation_env,
+                                    scope,
+                                    Some(&elem_type),
+                                    errors,
+                                );
+                                *typ = normal_call.typ().clone();
+                                updated
+                            }
+                            _ => {
+                                todo!()
+                            }
                         },
                         _ => {
                             *typ = Type::Error;
@@ -297,13 +424,14 @@ impl TypecheckFrom<FieldSelection<Untyped>> for FieldSelection<Typed> {
                             let field_name = match elem {
                                 FieldSelectionElement::Identifier(value, _, _) => value,
                                 FieldSelectionElement::HofCall { name, .. } => &name.0,
+                                FieldSelectionElement::NormalCall { name, .. } => &name.0,
                             };
 
                             if !prefix.typ().is_error() {
                                 errors.push(Diagnostic {
                                     level: Level::Error,
                                     message: format!(
-                                        "Cannot read field {} from a non-composite type {}",
+                                        "Cannot read field `{}` from a non-composite type `{}`",
                                         field_name,
                                         prefix.typ().deref(type_env)
                                     ),

--- a/crates/core-subsystem/core-model-builder/src/builder/system_builder.rs
+++ b/crates/core-subsystem/core-model-builder/src/builder/system_builder.rs
@@ -7,7 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use core_model::function_defn::FunctionDefinition;
 use core_model::primitive_type::PrimitiveType;
+use core_model::types::FieldType;
 use core_model::{context_type::ContextType, mapped_arena::MappedArena};
 
 use crate::error::ModelBuildingError;
@@ -25,6 +27,7 @@ pub struct SystemContextBuilding {
 pub struct BaseModelSystem {
     pub primitive_types: MappedArena<PrimitiveType>,
     pub contexts: MappedArena<ContextType>,
+    pub function_definitions: MappedArena<FunctionDefinition>,
 }
 
 pub fn build(
@@ -41,8 +44,20 @@ pub fn build(
 
     context_builder::build(&resolved.contexts, &mut building);
 
+    let mut function_definitions = MappedArena::default();
+
+    vec![FunctionDefinition {
+        name: "contains".to_string(),
+        return_type: FieldType::Plain(PrimitiveType::Boolean),
+    }]
+    .into_iter()
+    .for_each(|defn| {
+        function_definitions.add(&defn.name.clone(), defn);
+    });
+
     Ok(BaseModelSystem {
         primitive_types: building.primitive_types,
         contexts: building.contexts,
+        function_definitions,
     })
 }

--- a/crates/core-subsystem/core-model/src/context_type.rs
+++ b/crates/core-subsystem/core-model/src/context_type.rs
@@ -30,7 +30,11 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{mapped_arena::MappedArena, primitive_type::PrimitiveType, types::FieldType};
+use crate::{
+    mapped_arena::MappedArena,
+    primitive_type::{PrimitiveType, PrimitiveValue},
+    types::FieldType,
+};
 
 /// A context type to represent objects such as `AuthContext` and `IPContext`
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -80,33 +84,14 @@ pub struct ContextSelection {
     pub context_name: String,
     /// The path to the value within the context such as `role`. Since the path is always non-empty,
     /// it is represented with a tuple of the first element and the rest of the elements.
-    pub path: (String, Vec<String>),
+    pub path: (String, Vec<ContextSelectionElement>),
 }
 
-pub fn get_context<'a>(
-    path_elements: &[String],
-    contexts: &'a MappedArena<ContextType>,
-) -> (ContextSelection, &'a ContextFieldType) {
-    if path_elements.len() == 2 {
-        let context_type = contexts
-            .iter()
-            .find(|t| t.1.name == path_elements[0])
-            .unwrap()
-            .1;
-        let field = context_type
-            .fields
-            .iter()
-            .find(|field| field.name == path_elements[1])
-            .unwrap();
-
-        (
-            ContextSelection {
-                context_name: path_elements[0].clone(),
-                path: (path_elements[1].clone(), vec![]),
-            },
-            &field.typ,
-        )
-    } else {
-        todo!() // Nested selection such as AuthContext.user.id
-    }
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum ContextSelectionElement {
+    Identifier(String),
+    NormalCall {
+        function_name: String,
+        args: Vec<PrimitiveValue>,
+    },
 }

--- a/crates/core-subsystem/core-model/src/function_defn.rs
+++ b/crates/core-subsystem/core-model/src/function_defn.rs
@@ -1,0 +1,8 @@
+use crate::{primitive_type::PrimitiveType, types::FieldType};
+
+#[derive(Debug, Clone)]
+pub struct FunctionDefinition {
+    pub name: String,
+    // pub parameters: Vec<Parameter>,
+    pub return_type: FieldType<PrimitiveType>,
+}

--- a/crates/core-subsystem/core-model/src/lib.rs
+++ b/crates/core-subsystem/core-model/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod access;
 pub mod context_type;
+pub mod function_defn;
 pub mod mapped_arena;
 pub mod primitive_type;
 

--- a/crates/core-subsystem/core-model/src/primitive_type.rs
+++ b/crates/core-subsystem/core-model/src/primitive_type.rs
@@ -86,3 +86,11 @@ pub fn vector_introspection_type(optional: bool) -> Type {
         nullable: optional,
     }
 }
+
+// TODO: We should refactor `PrimitiveValue` along with `Val` to be a single enum
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum PrimitiveValue {
+    Int(i64),
+    String(String),
+    Boolean(bool),
+}

--- a/crates/core-subsystem/core-resolver/src/context/error.rs
+++ b/crates/core-subsystem/core-resolver/src/context/error.rs
@@ -32,6 +32,9 @@ pub enum ContextExtractionError {
     #[error("Field not found: `{0}`")]
     FieldNotFound(String),
 
+    #[error("Unexpected function call in context selection: `{0}`")]
+    UnexpectedFunctionCallInContextSelection(String),
+
     #[error("{0}")]
     Generic(String),
 }

--- a/crates/core-subsystem/core-resolver/src/value/val.rs
+++ b/crates/core-subsystem/core-resolver/src/value/val.rs
@@ -29,6 +29,9 @@ pub enum Val {
     Null,
 }
 
+pub const TRUE: Val = Val::Bool(true);
+pub const FALSE: Val = Val::Bool(false);
+
 impl Val {
     pub fn into_json(self) -> Result<serde_json::Value, serde_json::Error> {
         self.try_into()

--- a/crates/postgres-subsystem/postgres-model-builder/src/access_utils.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/access_utils.rs
@@ -748,8 +748,8 @@ fn compute_column_selection<'a>(
                     }
                 }
             } else {
-                let (context_selection, context_field_type) =
-                    selection.get_context(resolved_env.contexts, resolved_env.function_definitions);
+                let (context_selection, context_field_type) = selection
+                    .get_context(resolved_env.contexts, resolved_env.function_definitions)?;
                 Ok(DatabasePathSelection::Context(
                     context_selection,
                     context_field_type,
@@ -896,7 +896,7 @@ fn compute_json_selection<'a>(
                 }
                 None => {
                     let (context_selection, context_field_type) = selection
-                        .get_context(resolved_env.contexts, resolved_env.function_definitions);
+                        .get_context(resolved_env.contexts, resolved_env.function_definitions)?;
                     Ok(JsonPathSelection::Context(
                         context_selection,
                         context_field_type,

--- a/crates/postgres-subsystem/postgres-model-builder/src/system_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/system_builder.rs
@@ -52,6 +52,7 @@ pub fn build(
         let resolved_env = ResolvedTypeEnv {
             contexts: &base_system.contexts,
             resolved_types,
+            function_definitions: &base_system.function_definitions,
         };
 
         build_shallow(&resolved_env, &mut building);

--- a/crates/postgres-subsystem/postgres-model-builder/src/type_builder.rs
+++ b/crates/postgres-subsystem/postgres-model-builder/src/type_builder.rs
@@ -403,7 +403,7 @@ fn expand_dynamic_default_values(
                             let (context_selection, context_type) = selection.get_context(
                                 resolved_env.contexts,
                                 resolved_env.function_definitions,
-                            );
+                            )?;
 
                             match entity_field.relation {
                                 PostgresRelation::Scalar { .. } => {

--- a/crates/subsystem-util/subsystem-model-builder-util/src/builder/access_utils.rs
+++ b/crates/subsystem-util/subsystem-model-builder-util/src/builder/access_utils.rs
@@ -12,7 +12,7 @@ use core_model::{
         AccessLogicalExpression, AccessPredicateExpression, AccessRelationalOp,
         CommonAccessPrimitiveExpression,
     },
-    context_type::{get_context, ContextFieldType, ContextSelection},
+    context_type::{ContextFieldType, ContextSelection},
     primitive_type::PrimitiveType,
 };
 use core_model_builder::{
@@ -136,8 +136,7 @@ fn compute_selection<'a>(
     selection: &FieldSelection<Typed>,
     resolved_env: &'a ResolvedTypeEnv<'a>,
 ) -> PathSelection<'a> {
-    let path_elements = selection.context_path();
-
-    let (context_selection, column_type) = get_context(&path_elements, resolved_env.contexts);
+    let (context_selection, column_type) =
+        selection.get_context(resolved_env.contexts, resolved_env.function_definitions);
     PathSelection::Context(context_selection, column_type)
 }

--- a/crates/subsystem-util/subsystem-model-builder-util/src/builder/system_builder.rs
+++ b/crates/subsystem-util/subsystem-model-builder-util/src/builder/system_builder.rs
@@ -97,6 +97,7 @@ pub async fn build_with_selection(
         contexts: &base_system.contexts,
         resolved_types: resolved_system.module_types,
         resolved_modules: resolved_system.modules,
+        function_definitions: &base_system.function_definitions,
     };
 
     build_shallow_module(&resolved_env, &mut building);

--- a/crates/subsystem-util/subsystem-model-builder-util/src/builder/type_builder.rs
+++ b/crates/subsystem-util/subsystem-model-builder-util/src/builder/type_builder.rs
@@ -7,7 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use core_model::{context_type::ContextType, mapped_arena::MappedArena, types::FieldType};
+use core_model::{
+    context_type::ContextType, function_defn::FunctionDefinition, mapped_arena::MappedArena,
+    types::FieldType,
+};
 use core_model_builder::{ast::ast_types::AstExpr, error::ModelBuildingError, typechecker::Typed};
 use subsystem_model_util::{
     access::Access,
@@ -28,6 +31,7 @@ use super::{
 #[derive(Debug, Clone)]
 pub struct ResolvedTypeEnv<'a> {
     pub contexts: &'a MappedArena<ContextType>,
+    pub function_definitions: &'a MappedArena<FunctionDefinition>,
     pub resolved_types: MappedArena<ResolvedType>,
     pub resolved_modules: MappedArena<ResolvedModule>,
 }

--- a/error-report-testing/contains/contains-no-param/error.txt
+++ b/error-report-testing/contains/contains-no-param/error.txt
@@ -1,0 +1,8 @@
+error[C000]: Contains function expects one parameter
+ --> src/index.exo:7:29
+  |
+7 |   @access(AuthContext.roles.contains())
+  |                             ^^^^^^^^^^ type mismatch
+
+Error: Parser error: Could not process input exo files
+

--- a/error-report-testing/contains/contains-no-param/src/index.exo
+++ b/error-report-testing/contains/contains-no-param/src/index.exo
@@ -1,0 +1,13 @@
+context AuthContext {
+  @jwt roles: Array<String>
+}
+
+@postgres
+module TodoDatabase {
+  @access(AuthContext.roles.contains())
+  type Todo {
+    @pk id: Int = autoIncrement()
+    title: String
+    completed: Boolean
+  }
+}

--- a/error-report-testing/contains/contains-type-mismatch/error.txt
+++ b/error-report-testing/contains/contains-type-mismatch/error.txt
@@ -1,0 +1,8 @@
+error[C000]: Parameter type does not match element type: expected `String`, found `Int`
+ --> src/index.exo:7:38
+  |
+7 |   @access(AuthContext.roles.contains(1))
+  |                                      ^ type mismatch
+
+Error: Parser error: Could not process input exo files
+

--- a/error-report-testing/contains/contains-type-mismatch/src/index.exo
+++ b/error-report-testing/contains/contains-type-mismatch/src/index.exo
@@ -1,0 +1,13 @@
+context AuthContext {
+  @jwt roles: Array<String>
+}
+
+@postgres
+module TodoDatabase {
+  @access(AuthContext.roles.contains(1))
+  type Todo {
+    @pk id: Int = autoIncrement()
+    title: String
+    completed: Boolean
+  }
+}

--- a/integration-tests/access-expressions/src/access-expressions.ts
+++ b/integration-tests/access-expressions/src/access-expressions.ts
@@ -14,3 +14,7 @@ export async function setUnauthenticatedSecret(secret: string): Promise<string> 
 	return secret.toUpperCase();
 }
 
+export async function getAdminSecret(): Promise<string> {
+	return 'admin-secret';
+}
+

--- a/integration-tests/access-expressions/src/index.exo
+++ b/integration-tests/access-expressions/src/index.exo
@@ -19,6 +19,13 @@ module DocumentModule {
     @pk id: Int = autoIncrement()
     content: String
   }
+
+  // Same as AdminDoc, but with a contains clause
+  @access(AuthContext.roles.contains("ADMIN")) 
+  type AdminDocWithContains {
+    @pk id: Int = autoIncrement()
+    content: String
+  }
   
   // An example of nested access control (users can see there own membership)
   @access(query="ADMIN" in AuthContext.roles || self.user.id == AuthContext.id, mutation="ADMIN" in AuthContext.roles)
@@ -81,4 +88,7 @@ module AccessExpressions {
 
   @access(AuthContext.id == null)
   mutation setUnauthenticatedSecret(secret: String): String
+
+  @access(AuthContext.roles.contains("ADMIN")) 
+  query getAdminSecret(): String
 }

--- a/integration-tests/access-expressions/tests/adminDocsContains-admin-auth.exotest
+++ b/integration-tests/access-expressions/tests/adminDocsContains-admin-auth.exotest
@@ -1,0 +1,35 @@
+operation: |
+    query {
+      adminDocWithContainss @unordered {
+        id
+        content
+      }
+    }
+auth: |
+    {
+        "sub": 2,
+        "roles": ["ADMIN"]
+    }   
+response: |
+    {
+      "data": {
+        "adminDocWithContainss": [
+          {
+            "id": 1,
+            "content": "adminDocWithContains1"
+          },
+          {
+            "id": 2,
+            "content": "adminDocWithContains2"
+          },
+          {
+            "id": 3,
+            "content": "adminDocWithContains3"
+          },
+          {
+            "id": 4,
+            "content": "adminDocWithContains4"
+          }
+        ]
+      }
+    }

--- a/integration-tests/access-expressions/tests/adminDocsContains-no-auth.exotest
+++ b/integration-tests/access-expressions/tests/adminDocsContains-no-auth.exotest
@@ -1,0 +1,15 @@
+operation: |
+    query {
+      adminDocWithContainss {
+        id
+        content
+      }
+    }
+response: |
+    {
+      "errors": [
+        {
+          "message": "Not authorized"
+        }
+      ]
+    }

--- a/integration-tests/access-expressions/tests/adminDocsContains-user-auth.exotest
+++ b/integration-tests/access-expressions/tests/adminDocsContains-user-auth.exotest
@@ -1,0 +1,20 @@
+operation: |
+    query {
+      adminDocWithContainss {
+        id
+        content
+      }
+    }
+auth: |
+    {
+        "sub": 2,
+        "roles": ["USER"]
+    }   
+response: |
+    {
+      "errors": [
+        {
+          "message": "Not authorized"
+        }
+      ]
+    }

--- a/integration-tests/access-expressions/tests/deno-contains.exotest
+++ b/integration-tests/access-expressions/tests/deno-contains.exotest
@@ -1,0 +1,49 @@
+stages:
+  # Admin user queries what they can see
+  - operation: |
+      query {
+        getAdminSecret
+      }
+    auth: |
+      {
+        "sub": 2,
+        "roles": ["ADMIN"]
+      }   
+    response: |
+      {
+        "data": {
+          "getAdminSecret": "admin-secret"
+        }
+      }
+  # Non-admin user queries what they can't see
+  - operation: |
+      query {
+        getAdminSecret
+      }
+    auth: |
+      {
+        "sub": 2,
+        "roles": ["USER"]
+      }   
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Not authorized"
+          }
+        ]
+      }
+
+  # Unauthenticated user queries what they can't see
+  - operation: |
+      query {
+        getAdminSecret
+      }
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Not authorized"
+          }
+        ]
+      }

--- a/integration-tests/access-expressions/tests/init-docs.gql
+++ b/integration-tests/access-expressions/tests/init-docs.gql
@@ -25,6 +25,18 @@ stages:
             adminDoc4: createAdminDoc(data: {content: "adminDoc4"}) {
                 id
             }
+            adminDocWithContains1: createAdminDocWithContains(data: {content: "adminDocWithContains1"}) {
+                id
+            }
+            adminDocWithContains2: createAdminDocWithContains(data: {content: "adminDocWithContains2"}) {
+                id
+            }
+            adminDocWithContains3: createAdminDocWithContains(data: {content: "adminDocWithContains3"}) {
+                id
+            }
+            adminDocWithContains4: createAdminDocWithContains(data: {content: "adminDocWithContains4"}) {
+                id
+            }
             externalDoc1: createExternalDoc(data: {content: "externalDoc1", externalId: 1}) {
                 id
             }


### PR DESCRIPTION
This allows expressing the dual of the `in` operator in access expressions. For example, you can express the following rule:

```exo
@access(AuthContext.roles.contains("admin"))
```

This has the same effect as:
```exo
@access("admin" in AuthContext.roles)
```

But a few developers find the `contains` function more intuitive.

Currently, contains supports expression only on context fields. We can expand this to support other expressions in the future.

Fixes #1244