### PR TITLE
Emit errors if transpilation fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,6 +1534,7 @@ dependencies = [
  "core-plugin-shared",
  "serde",
  "thiserror",
+ "url",
 ]
 
 [[package]]

--- a/crates/builder/src/lib.rs
+++ b/crates/builder/src/lib.rs
@@ -409,13 +409,13 @@ fn emit_diagnostics(
             collect_diagnostics(diagnostics, codemap, report_collector);
             emitter.emit(diagnostics);
         }
-        ParserError::ModelBuildingError(ModelBuildingError::ExternalResourceParsing(e)) => {
+        ParserError::ModelBuildingError(ModelBuildingError::TSJSParsingError(error)) => {
             // This is an error in a JavaScript/TypeScript file, so we
             // have emit it directly to stderr (can't use the emitter, which is tied to exo sources)
             emitter.emit(&[Diagnostic {
                 level: Level::Error,
                 code: None,
-                message: e.to_string(),
+                message: error.to_string(),
                 spans: vec![],
             }]);
         }

--- a/crates/core-subsystem/core-model-builder/Cargo.toml
+++ b/crates/core-subsystem/core-model-builder/Cargo.toml
@@ -9,6 +9,7 @@ codemap.workspace = true
 serde.workspace = true
 codemap-diagnostic.workspace = true
 thiserror.workspace = true
+url.workspace = true
 
 core-model = { path = "../core-model" }
 core-plugin-shared = { path = "../core-plugin-shared" }

--- a/crates/core-subsystem/core-model-builder/src/error.rs
+++ b/crates/core-subsystem/core-model-builder/src/error.rs
@@ -22,8 +22,8 @@ pub enum ModelBuildingError {
     #[error("{0}")]
     Generic(String),
 
-    #[error("{0}")]
-    ExternalResourceParsing(String),
+    #[error("Could not parse TypeScript/JavaScript files")]
+    TSJSParsingError(String),
 
     #[error("Unable to serialize model {0}")]
     Serialize(#[source] ModelSerializationError),

--- a/crates/core-subsystem/core-model-builder/src/error.rs
+++ b/crates/core-subsystem/core-model-builder/src/error.rs
@@ -8,8 +8,11 @@
 // by the Apache License, Version 2.0.
 
 use codemap_diagnostic::Diagnostic;
-use core_plugin_shared::error::ModelSerializationError;
+use std::path::Path;
 use thiserror::Error;
+use url::Url;
+
+use core_plugin_shared::error::ModelSerializationError;
 
 #[derive(Error, Debug)]
 pub enum ModelBuildingError {
@@ -30,4 +33,24 @@ pub enum ModelBuildingError {
 
     #[error("Unable to deserialize model {0}")]
     Deserialize(#[source] ModelSerializationError),
+}
+
+impl ModelBuildingError {
+    pub fn tsjs_error(
+        error: String,
+        relative_source_path: &Path,
+        cananical_source_path: &Url,
+    ) -> Self {
+        let relative_source_path_str = relative_source_path.to_str().unwrap();
+        let canonical_source_path_str = cananical_source_path.to_string();
+
+        // Replace cananical path ("file:///<user-directory>/project/src/foo.ts") with relative path ("src/foo.ts")
+        let error = error
+            .lines()
+            .map(|line| line.replace(&canonical_source_path_str, relative_source_path_str))
+            .collect::<Vec<String>>()
+            .join("\n");
+
+        ModelBuildingError::TSJSParsingError(error)
+    }
 }

--- a/crates/deno-subsystem/deno-model-builder/src/system_builder.rs
+++ b/crates/deno-subsystem/deno-model-builder/src/system_builder.rs
@@ -124,6 +124,7 @@ fn process_script(
     let root = Url::from_file_path(std::fs::canonicalize(module_fs_path).unwrap()).unwrap();
     let root_clone = root.clone();
 
+    let module_fs_path = module_fs_path.to_path_buf();
     // TODO: Make the process_script function async. Currently, we can't because `CliOptions` isn't a
     // `Send`. But to make this useful as a callback, we would make this function return a
     // `BoxFuture`, which has the `Send` requirement.
@@ -180,17 +181,17 @@ fn process_script(
             );
 
             let managed_npm = npm_resolver.as_managed().unwrap();
-            let root_path = npm_resolver
+            let npm_cache_folder = npm_resolver
                 .as_managed()
                 .unwrap()
                 .global_cache_root_folder()
                 .join("registry.npmjs.org");
 
-            if !root_path.exists() {
-                std::fs::create_dir_all(&root_path).unwrap();
+            if !npm_cache_folder.exists() {
+                std::fs::create_dir_all(&npm_cache_folder).unwrap();
             }
 
-            let vfs = if let Ok(mut builder) = VfsBuilder::new(root_path.clone()) {
+            let vfs = if let Ok(mut builder) = VfsBuilder::new(npm_cache_folder.clone()) {
                 for package in managed_npm.all_system_packages(&Default::default()) {
                     let folder = managed_npm
                         .resolve_pkg_folder_from_pkg_id(&package.id)
@@ -213,6 +214,7 @@ fn process_script(
 
             Ok::<DenoScriptDefn, ModelBuildingError>(DenoScriptDefn {
                 modules: walk_module_graph(
+                    &module_fs_path,
                     graph,
                     npm_loader,
                     node_resolver.clone(),
@@ -220,7 +222,7 @@ fn process_script(
                     code_translator,
                     parsed_source_cache,
                     module_info_cache,
-                    root_path,
+                    npm_cache_folder,
                 )
                 .await?,
                 npm_snapshot: Some((
@@ -417,6 +419,7 @@ async fn walk_node_resolutions(
 
 #[allow(clippy::too_many_arguments)]
 async fn walk_module_graph(
+    module_fs_path: &Path,
     graph: ModuleGraph,
     npm_loader: NpmModuleLoader,
     node_resolver: Arc<NodeResolver>,
@@ -424,7 +427,7 @@ async fn walk_module_graph(
     code_translator: Arc<NodeCodeTranslator<CliCjsCodeAnalyzer>>,
     parsed_source_cache: Arc<ParsedSourceCache>,
     module_info_cache: Arc<ModuleInfoCache>,
-    root_path: PathBuf,
+    npm_cache_folder: PathBuf,
 ) -> Result<HashMap<Url, ResolvedModule>, ModelBuildingError> {
     let mut modules: HashMap<Url, ResolvedModule> = HashMap::new();
 
@@ -475,7 +478,7 @@ async fn walk_module_graph(
                             &code_translator,
                             &parsed_source_cache,
                             &module_info_cache,
-                            &root_path,
+                            &npm_cache_folder,
                             &mut modules,
                         )
                         .await
@@ -517,22 +520,32 @@ async fn walk_module_graph(
                             maybe_syntax: None,
                         });
 
-                        let parsed = parsed
-                            .map_err(|e| ModelBuildingError::TSJSParsingError(e.to_string()))?;
+                        let parsed = parsed.map_err(|e| {
+                            ModelBuildingError::tsjs_error(e.to_string(), module_fs_path, specifier)
+                        })?;
 
-                        let transpiled = match parsed
-                            .transpile(&Default::default(), &EmitOptions::default())
-                        {
-                            Ok(parsed) => parsed,
-                            Err(e) => {
-                                return Err(ModelBuildingError::TSJSParsingError(e.to_string()));
-                            }
-                        };
+                        let transpiled =
+                            match parsed.transpile(&Default::default(), &EmitOptions::default()) {
+                                Ok(parsed) => parsed,
+                                Err(e) => {
+                                    return Err(ModelBuildingError::tsjs_error(
+                                        e.to_string(),
+                                        module_fs_path,
+                                        specifier,
+                                    ));
+                                }
+                            };
 
                         transpiled
                             .into_source()
                             .into_string()
-                            .map_err(|e| ModelBuildingError::TSJSParsingError(e.to_string()))?
+                            .map_err(|e| {
+                                ModelBuildingError::tsjs_error(
+                                    e.to_string(),
+                                    module_fs_path,
+                                    specifier,
+                                )
+                            })?
                             .text
                     } else {
                         module_source
@@ -553,9 +566,11 @@ async fn walk_module_graph(
                 modules.insert(specifier.clone(), ResolvedModule::Redirect(to.clone()));
             }
             ModuleEntryRef::Err(e) => {
-                return Err(ModelBuildingError::TSJSParsingError(
+                return Err(ModelBuildingError::tsjs_error(
                     e.to_string_with_range(),
-                ))
+                    module_fs_path,
+                    specifier,
+                ));
             }
         };
     }

--- a/error-report-testing/.gitignore
+++ b/error-report-testing/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 error.txt.new
+generated

--- a/error-report-testing/src/index.ts
+++ b/error-report-testing/src/index.ts
@@ -16,7 +16,7 @@ if (!exo_executable) {
       exo_executable = path.resolve(__dirname, "../../target/release/exo");
       break;
     default:
-      console.error(`Unknown mode: ${MODE} for EXECUTABLE_MODE`);
+      console.error(`Unknown mode: ${MODE} for EXECUTABLE_MODE. Expected "debug" or "release"`);
       process.exit(1);
   }
 }

--- a/error-report-testing/src/index.ts
+++ b/error-report-testing/src/index.ts
@@ -104,10 +104,11 @@ function diffFiles(expectedFile: string, actualFile: string): string {
   const diff = spawnSync('diff', ["-b", expectedFile, actualFile], { encoding: 'utf-8', stdio: 'pipe' });
 
   // If the diff command fails, replace Windows-style paths with Unix-style paths in actualFile and try again
-  // This is not foolproof (we may be replacing non-path strings, too, but if the CI passes on other platforms 
-  // AND it passes on Windows after the adjustment, we're good)
+  // This is not foolproof (we may be replacing non-path strings, too), but if the CI passes on other platforms 
+  // AND it passes on Windows after the adjustment, we're good.
   if (diff.stdout && process.platform === 'win32') {
-    spawnSync('sed', ['-i', 's/\\/\//g', actualFile]);
+    // Replace all backslashes with forward slashes
+    spawnSync('sed', ['-i', 's/\\\\/\\//g', actualFile]);
     const adjustedDiff = spawnSync('diff', ["-b", expectedFile, actualFile], { encoding: 'utf-8', stdio: 'pipe' });
     return adjustedDiff.stdout || "";
   }

--- a/error-report-testing/transpilation-errors/error.txt
+++ b/error-report-testing/transpilation-errors/error.txt
@@ -1,4 +1,4 @@
-error: Expected '}', got '<eof>' at file:///Users/ramnivas/exograph-org/exograph/error-report-testing/transpilation-errors/src/todo.ts:2:3
+error: Expected '}', got '<eof>' at src/todo.ts:2:3
 
   	5
    ~

--- a/error-report-testing/transpilation-errors/error.txt
+++ b/error-report-testing/transpilation-errors/error.txt
@@ -1,0 +1,7 @@
+error: Expected '}', got '<eof>' at file:///Users/ramnivas/exograph-org/exograph/error-report-testing/transpilation-errors/src/todo.ts:2:3
+
+  	5
+   ~
+
+Error: Parser error: Could not parse TypeScript/JavaScript files
+

--- a/error-report-testing/transpilation-errors/src/index.exo
+++ b/error-report-testing/transpilation-errors/src/index.exo
@@ -1,0 +1,5 @@
+@deno("todo.ts")
+module TodoService {
+  @access(true)
+  query todoCount(): Int
+}

--- a/error-report-testing/transpilation-errors/src/todo.ts
+++ b/error-report-testing/transpilation-errors/src/todo.ts
@@ -1,0 +1,3 @@
+export function todoCount(): number {
+	5
+// Purposefully not adding `}` to cause a transpilation error


### PR DESCRIPTION
Earlier, we had an `unwrap` that didn't inform user of any transpilation errors.

Fixes #1285