### PR TITLE
Drop the `playground_request` arg from Router.route

### DIFF
--- a/crates/common/src/env_const.rs
+++ b/crates/common/src/env_const.rs
@@ -1,6 +1,5 @@
 use exo_env::Environment;
 
-#[cfg(not(target_family = "wasm"))]
 use super::EnvError;
 
 pub const EXO_INTROSPECTION: &str = "EXO_INTROSPECTION";
@@ -34,7 +33,6 @@ pub enum DeploymentMode {
     Prod,
 }
 
-#[cfg(not(target_family = "wasm"))]
 pub fn get_deployment_mode(env: &dyn Environment) -> Result<DeploymentMode, EnvError> {
     let deployment_mode = env.get(_EXO_DEPLOYMENT_MODE);
 
@@ -60,7 +58,6 @@ pub fn get_deployment_mode(env: &dyn Environment) -> Result<DeploymentMode, EnvE
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
 pub fn is_production(env: &dyn Environment) -> bool {
     matches!(get_deployment_mode(env), Ok(DeploymentMode::Prod) | Err(_))
 }

--- a/crates/common/src/router.rs
+++ b/crates/common/src/router.rs
@@ -13,11 +13,7 @@ use http::StatusCode;
 
 #[async_trait]
 pub trait Router: Sync {
-    async fn route(
-        &self,
-        request: &mut (dyn RequestPayload + Send),
-        playground_request: bool,
-    ) -> Option<ResponsePayload>;
+    async fn route(&self, request: &mut (dyn RequestPayload + Send)) -> Option<ResponsePayload>;
 }
 
 pub struct CompositeRouter {
@@ -32,13 +28,9 @@ impl CompositeRouter {
 
 #[async_trait::async_trait]
 impl Router for CompositeRouter {
-    async fn route(
-        &self,
-        request: &mut (dyn RequestPayload + Send),
-        playground_request: bool,
-    ) -> Option<ResponsePayload> {
+    async fn route(&self, request: &mut (dyn RequestPayload + Send)) -> Option<ResponsePayload> {
         for router in self.routers.iter() {
-            if let Some(response) = router.route(request, playground_request).await {
+            if let Some(response) = router.route(request).await {
                 return Some(response);
             }
         }

--- a/crates/playground-router/src/playground_router.rs
+++ b/crates/playground-router/src/playground_router.rs
@@ -50,11 +50,7 @@ impl PlaygroundRouter {
 
 #[async_trait]
 impl Router for PlaygroundRouter {
-    async fn route(
-        &self,
-        request: &mut (dyn RequestPayload + Send),
-        _playground_request: bool,
-    ) -> Option<ResponsePayload> {
+    async fn route(&self, request: &mut (dyn RequestPayload + Send)) -> Option<ResponsePayload> {
         if !self.suitable(request.get_head()) {
             return None;
         }

--- a/crates/resolver/src/root_resolver.rs
+++ b/crates/resolver/src/root_resolver.rs
@@ -104,11 +104,7 @@ impl Router for GraphQLRouter {
         name = "resolver::resolve"
         skip(self, request)
     )]
-    async fn route(
-        &self,
-        request: &mut (dyn RequestPayload + Send),
-        playground_request: bool,
-    ) -> Option<ResponsePayload> {
+    async fn route(&self, request: &mut (dyn RequestPayload + Send)) -> Option<ResponsePayload> {
         if !self.suitable(request.get_head()) {
             return None;
         }
@@ -118,6 +114,11 @@ impl Router for GraphQLRouter {
         #[cfg(target_family = "wasm")]
         let is_production = !playground_request;
 
+        let playground_request = request
+            .get_head()
+            .get_header("_exo_playground")
+            .map(|value| value == "true")
+            .unwrap_or(false);
         let response = resolve_in_memory(
             request,
             &self.system_resolver,

--- a/crates/resolver/src/root_resolver.rs
+++ b/crates/resolver/src/root_resolver.rs
@@ -15,7 +15,6 @@ use common::env_const::get_graphql_http_path;
 
 use crate::system_loader::{StaticLoaders, SystemLoadingError};
 
-#[cfg(not(target_family = "wasm"))]
 use common::env_const::is_production;
 use common::http::{Headers, RequestHead, RequestPayload, ResponseBody, ResponsePayload};
 use common::router::Router;
@@ -109,26 +108,24 @@ impl Router for GraphQLRouter {
             return None;
         }
 
-        #[cfg(not(target_family = "wasm"))]
-        let is_production = is_production(self.env.as_ref());
-        #[cfg(target_family = "wasm")]
-        let is_production = !playground_request;
-
         let playground_request = request
             .get_head()
             .get_header("_exo_playground")
             .map(|value| value == "true")
             .unwrap_or(false);
-        let response = resolve_in_memory(
-            request,
-            &self.system_resolver,
-            if playground_request && !is_production {
-                TrustedDocumentEnforcement::DoNotEnforce
-            } else {
-                TrustedDocumentEnforcement::Enforce
-            },
-        )
-        .await;
+
+        let is_production = is_production(self.env.as_ref());
+
+        // If the server is in production mode, enforce trusted documents regardless of
+        // the `_exo_playground` header
+        let trusted_document_enforcement = if is_production || !playground_request {
+            TrustedDocumentEnforcement::Enforce
+        } else {
+            TrustedDocumentEnforcement::DoNotEnforce
+        };
+
+        let response =
+            resolve_in_memory(request, &self.system_resolver, trusted_document_enforcement).await;
 
         if let Err(SystemResolutionError::RequestError(e)) = response {
             tracing::error!("Error while resolving request: {:?}", e);

--- a/crates/router/src/system_router.rs
+++ b/crates/router/src/system_router.rs
@@ -71,11 +71,7 @@ impl SystemRouter {
 
 #[async_trait::async_trait]
 impl Router for SystemRouter {
-    async fn route(
-        &self,
-        request: &mut (dyn RequestPayload + Send),
-        playground_request: bool,
-    ) -> Option<ResponsePayload> {
-        self.underlying.route(request, playground_request).await
+    async fn route(&self, request: &mut (dyn RequestPayload + Send)) -> Option<ResponsePayload> {
+        self.underlying.route(request).await
     }
 }

--- a/crates/server-actix/src/lib.rs
+++ b/crates/server-actix/src/lib.rs
@@ -97,18 +97,12 @@ async fn resolve_locally(
     query: Value,
     system_router: web::Data<SystemRouter>,
 ) -> HttpResponse {
-    let playground_request = req
-        .headers()
-        .get("_exo_playground")
-        .map(|value| value == "true")
-        .unwrap_or(false);
-
     let mut request = ActixRequestPayload {
         head: ActixRequestHead::from_request(req, query),
         body: body.map(|b| b.into_inner()).unwrap_or(Value::Null),
     };
 
-    let response = system_router.route(&mut request, playground_request).await;
+    let response = system_router.route(&mut request).await;
 
     match response {
         Some(ResponsePayload {

--- a/crates/server-aws-lambda/src/lib.rs
+++ b/crates/server-aws-lambda/src/lib.rs
@@ -52,7 +52,7 @@ pub async fn resolve(
         body,
     };
 
-    let response_payload = system_router.route(&mut request_payload, false).await;
+    let response_payload = system_router.route(&mut request_payloads).await;
 
     match response_payload {
         Some(ResponsePayload {

--- a/crates/server-aws-lambda/src/lib.rs
+++ b/crates/server-aws-lambda/src/lib.rs
@@ -52,7 +52,7 @@ pub async fn resolve(
         body,
     };
 
-    let response_payload = system_router.route(&mut request_payloads).await;
+    let response_payload = system_router.route(&mut request_payload).await;
 
     match response_payload {
         Some(ResponsePayload {

--- a/crates/server-cf-worker/src/resolve.rs
+++ b/crates/server-cf-worker/src/resolve.rs
@@ -106,7 +106,7 @@ pub async fn resolve(raw_request: web_sys::Request) -> Result<web_sys::Response,
     };
 
     let system_router = crate::init::get_system_router()?;
-    let response_payload = system_router.route(&mut request, true).await;
+    let response_payload = system_router.route(&mut request).await;
 
     let response = match response_payload {
         Some(ResponsePayload {

--- a/crates/testing/src/execution/integration_test.rs
+++ b/crates/testing/src/execution/integration_test.rs
@@ -474,7 +474,7 @@ pub async fn run_query(
     cookies: &mut HashMap<String, String>,
 ) -> Value {
     let mut request = request;
-    let res = router.route(&mut request, true).await.unwrap();
+    let res = router.route(&mut request).await.unwrap();
 
     res.headers.into_iter().for_each(|(k, v)| {
         if k.to_ascii_lowercase() == "set-cookie" {


### PR DESCRIPTION
Instead let the router what actually needs it get it from the request argument. This remove the burden from all routers to pass the argument along.