### PR TITLE
ci(integration tests): support postgres in docker

### DIFF
--- a/crates/testing/src/execution/integration_test.rs
+++ b/crates/testing/src/execution/integration_test.rs
@@ -157,11 +157,19 @@ impl IntegrationTest {
 
                 let exo_ir_file = self.exo_ir_file_path(project_dir).display().to_string();
 
+                let separator = match db_instance.url().contains("?") {
+                    true => "&",
+                    false => "?",
+                };
                 let mut env = HashMap::from([
                     (
                         EXO_POSTGRES_URL.to_string(),
                         // set a common timezone for tests for consistency "-c TimeZone=UTC+00"
-                        format!("{}?options=-c%20TimeZone%3DUTC%2B00", db_instance.url()),
+                        format!(
+                            "{}{}options=-c%20TimeZone%3DUTC%2B00",
+                            db_instance.url(),
+                            separator
+                        ),
                     ),
                     (EXO_JWT_SECRET.to_string(), jwtsecret.to_string()),
                     (EXO_CONNECTION_POOL_SIZE.to_string(), "1".to_string()),


### PR DESCRIPTION
fixes:
```console
** Running integration tests
Local PostgreSQL is not available: Failed to find executable: initdb (cannot find binary path)
Launching PostgreSQL in Docker...
```
```
A testfile errored while running.
Subsystem loading error: Configuration error: Invalid 'sslmode' parameter value disable?options=-c TimeZone=UTC+00

Caused by:
    0: Configuration error: Invalid 'sslmode' parameter value disable?options=-c TimeZone=UTC+00
    1: Configuration error: Invalid 'sslmode' parameter value disable?options=-c TimeZone=UTC+00
```