### PR TITLE
Upgrade to Rust 1.82

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.82.0"
 components = ["clippy", "rustfmt"]
 targets = ["wasm32-wasi", "wasm32-unknown-unknown"]
 profile = "minimal"


### PR DESCRIPTION
No new clippy warnings, so needed to change only rust-toolchain.toml