### PR TITLE
Remove the oidc feature (enable it unconditionally)

### DIFF
--- a/crates/core-subsystem/core-resolver/Cargo.toml
+++ b/crates/core-subsystem/core-resolver/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 [features]
 default = []
 test-context = []
-oidc = ["reqwest", "oidc-jwt-validator"]
 
 [dependencies]
 async-graphql-parser.workspace = true
@@ -19,8 +18,8 @@ bytes.workspace = true
 futures.workspace = true
 serde_json = { workspace = true, features = ["preserve_order"] }
 jsonwebtoken = { workspace = true }
-reqwest = { workspace = true, optional = true }
-oidc-jwt-validator = { git = "https://github.com/exograph/oidc_jwt_validator", branch = "exograph", optional = true }
+reqwest = { workspace = true }
+oidc-jwt-validator = { git = "https://github.com/exograph/oidc_jwt_validator", branch = "exograph" }
 serde.workspace = true
 thiserror.workspace = true
 async-stream.workspace = true

--- a/crates/core-subsystem/core-resolver/src/context/provider/jwt/mod.rs
+++ b/crates/core-subsystem/core-resolver/src/context/provider/jwt/mod.rs
@@ -9,7 +9,6 @@
 
 mod authenticator;
 mod extractor;
-#[cfg(feature = "oidc")]
 mod oidc;
 
 pub use authenticator::JwtAuthenticator;

--- a/crates/graphql-router/Cargo.toml
+++ b/crates/graphql-router/Cargo.toml
@@ -4,9 +4,6 @@ version.workspace = true
 edition.workspace = true
 publish = false
 
-[features]
-oidc = ["core-resolver/oidc"]
-
 [dependencies]
 async-recursion.workspace = true
 async-graphql-parser.workspace = true

--- a/crates/server-cf-worker/Cargo.toml
+++ b/crates/server-cf-worker/Cargo.toml
@@ -43,6 +43,4 @@ exo-env = { path = "../../libs/exo-env" }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 
 [features]
-default = ["oidc"]
 panic_hook = ["console_error_panic_hook"]
-oidc = ["core-resolver/oidc"]

--- a/crates/server-common/Cargo.toml
+++ b/crates/server-common/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 common = { path = "../common", features = ["opentelemetry"] }
-graphql-router = { path = "../graphql-router", features = ["oidc"] }
+graphql-router = { path = "../graphql-router" }
 router = { path = "../router" }
 core-resolver = { path = "../core-subsystem/core-resolver" }
 core-plugin-interface = { path = "../core-subsystem/core-plugin-interface" }

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -46,7 +46,7 @@ exo-deno = { path = "../../libs/exo-deno", features = ["typescript-loader"] }
 exo-env = { path = "../../libs/exo-env" }
 
 core-resolver = { path = "../core-subsystem/core-resolver" }
-graphql-router = { path = "../graphql-router", features = ["oidc"] }
+graphql-router = { path = "../graphql-router" }
 router = { path = "../router" }
 
 core-plugin-interface = { path = "../core-subsystem/core-plugin-interface" }


### PR DESCRIPTION
We no longer need to gate it through a feature since we use our fork for `oidc_jwt_validator`, which supports the wasm32 target.