### PR TITLE
Fix tracing output not being shown in console

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,6 +1433,7 @@ dependencies = [
  "tokio-postgres",
  "tonic",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
@@ -9797,6 +9798,24 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,10 +1422,9 @@ dependencies = [
  "http 1.1.0",
  "jsonwebtoken",
  "oidc-jwt-validator",
- "opentelemetry 0.27.0",
- "opentelemetry-appender-tracing",
+ "opentelemetry",
  "opentelemetry-otlp",
- "opentelemetry_sdk 0.27.0",
+ "opentelemetry_sdk",
  "reqwest",
  "serde",
  "serde_json",
@@ -1434,7 +1433,6 @@ dependencies = [
  "tokio-postgres",
  "tonic",
  "tracing",
- "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
@@ -6215,20 +6213,6 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570074cc999d1a58184080966e5bd3bf3a9a4af650c3b05047c2621e7405cd17"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f3cebff57f7dbd1255b44d8bddc2cebeb0ea677dbaa2e25a3070a91b318f660"
@@ -6242,18 +6226,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-appender-tracing"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5feffc321035ad94088a7e5333abb4d84a8726e54a802e736ce9dd7237e85b"
-dependencies = [
- "opentelemetry 0.27.0",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "opentelemetry-http"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6262,7 +6234,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "http 1.1.0",
- "opentelemetry 0.27.0",
+ "opentelemetry",
  "reqwest",
 ]
 
@@ -6275,10 +6247,10 @@ dependencies = [
  "async-trait",
  "futures-core",
  "http 1.1.0",
- "opentelemetry 0.27.0",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.27.0",
+ "opentelemetry_sdk",
  "prost 0.13.3",
  "reqwest",
  "thiserror",
@@ -6293,28 +6265,10 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
 dependencies = [
- "opentelemetry 0.27.0",
- "opentelemetry_sdk 0.27.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost 0.13.3",
  "tonic",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c627d9f4c9cdc1f21a29ee4bfbd6028fcb8bcf2a857b43f3abdf72c9c862f3"
-dependencies = [
- "async-trait",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "glob",
- "once_cell",
- "opentelemetry 0.26.0",
- "percent-encoding",
- "rand",
- "thiserror",
 ]
 
 [[package]]
@@ -6329,7 +6283,7 @@ dependencies = [
  "futures-util",
  "glob",
  "once_cell",
- "opentelemetry 0.27.0",
+ "opentelemetry",
  "percent-encoding",
  "rand",
  "serde_json",
@@ -9846,24 +9800,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-opentelemetry"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc58af5d3f6c5811462cabb3289aec0093f7338e367e5a33d28c0433b3c7360b"
-dependencies = [
- "js-sys",
- "once_cell",
- "opentelemetry 0.26.0",
- "opentelemetry_sdk 0.26.0",
- "smallvec",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber",
- "web-time",
-]
-
-[[package]]
 name = "tracing-serde"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10089,7 +10025,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand",
  "static_assertions",
 ]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [features]
 default = []
 test-context = []
-opentelemetry = ["opentelemetry_sdk", "opentelemetry-otlp", "opentelemetry-appender-tracing", "tonic"]
+opentelemetry = ["opentelemetry_sdk", "opentelemetry-otlp", "tonic"]
 
 [dependencies]
 thiserror.workspace = true
@@ -32,7 +32,6 @@ exo-sql = { path = "../../libs/exo-sql" }
 
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
-tracing-opentelemetry = "0.27"
 opentelemetry = { version = "0.27", default-features = false, features = [
   "trace",
 ] }
@@ -45,7 +44,6 @@ opentelemetry-otlp = { version = "0.27", features = [
   "http-proto",
   "tls",
 ], optional = true }
-opentelemetry-appender-tracing = { version = "0.27", optional = true }
 # Tonic isn't used directly but we need these flags to establish a TLS connection
 tonic = { version = "0.12.3", features = ["tls", "tls-roots"], optional = true }
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -32,6 +32,7 @@ exo-sql = { path = "../../libs/exo-sql" }
 
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
+tracing-opentelemetry = "0.28"
 opentelemetry = { version = "0.27", default-features = false, features = [
   "trace",
 ] }


### PR DESCRIPTION
We were setting tracing layers only if OpenTelemetry is enabled. As a result, no traces were shown in the console in such situations.