### PR TITLE
Rename PostgresSubsystem to PostgresGraphQLSubsystem

### DIFF
--- a/crates/postgres-subsystem/postgres-builder/src/plugin.rs
+++ b/crates/postgres-subsystem/postgres-builder/src/plugin.rs
@@ -314,7 +314,7 @@ mod tests {
     use exo_sql::{
         Database, FloatBits, IntBits, PhysicalColumn, PhysicalColumnType, PhysicalTable,
     };
-    use postgres_graphql_model::subsystem::PostgresSubsystem;
+    use postgres_graphql_model::subsystem::PostgresGraphQLSubsystem;
 
     #[cfg_attr(not(target_family = "wasm"), tokio::test)]
     #[cfg_attr(target_family = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
@@ -508,7 +508,7 @@ mod tests {
         assert!(!mutation_type_names.contains("TodoUpdateInput"));
     }
 
-    fn get_mutation_type_names(system: &PostgresSubsystem) -> HashSet<String> {
+    fn get_mutation_type_names(system: &PostgresGraphQLSubsystem) -> HashSet<String> {
         system
             .mutation_types
             .iter()
@@ -649,7 +649,7 @@ mod tests {
         panic!("No such column {name}")
     }
 
-    async fn create_system(src: &str) -> PostgresSubsystem {
+    async fn create_system(src: &str) -> PostgresGraphQLSubsystem {
         crate::test_utils::create_postgres_system_from_str(src, "test.exo".to_string())
             .await
             .unwrap()

--- a/crates/postgres-subsystem/postgres-builder/src/test_utils.rs
+++ b/crates/postgres-subsystem/postgres-builder/src/test_utils.rs
@@ -13,13 +13,13 @@ use core_plugin_interface::{
     system_serializer::SystemSerializer,
 };
 #[cfg(test)]
-use postgres_graphql_model::subsystem::PostgresSubsystem;
+use postgres_graphql_model::subsystem::PostgresGraphQLSubsystem;
 
 #[cfg(test)]
 pub(crate) async fn create_postgres_system_from_str(
     model_str: &str,
     file_name: String,
-) -> Result<PostgresSubsystem, ModelSerializationError> {
+) -> Result<PostgresGraphQLSubsystem, ModelSerializationError> {
     let system = builder::build_system_from_str(
         model_str,
         file_name,
@@ -34,7 +34,7 @@ pub(crate) async fn create_postgres_system_from_str(
 #[cfg(test)]
 fn deserialize_postgres_subsystem(
     system: SerializableSystem,
-) -> Result<PostgresSubsystem, ModelSerializationError> {
+) -> Result<PostgresGraphQLSubsystem, ModelSerializationError> {
     use std::sync::Arc;
 
     use postgres_core_model::subsystem::PostgresCoreSubsystem;
@@ -47,11 +47,11 @@ fn deserialize_postgres_subsystem(
     match postgres_subsystem {
         Some(subsystem) => {
             let mut postgres_subsystem =
-                PostgresSubsystem::deserialize(subsystem.graphql.unwrap().0)?;
+                PostgresGraphQLSubsystem::deserialize(subsystem.graphql.unwrap().0)?;
             let postgres_core_subsystem = PostgresCoreSubsystem::deserialize(subsystem.core.0)?;
             postgres_subsystem.database = Arc::new(postgres_core_subsystem.database);
             Ok(postgres_subsystem)
         }
-        None => Ok(PostgresSubsystem::default()),
+        None => Ok(PostgresGraphQLSubsystem::default()),
     }
 }

--- a/crates/postgres-subsystem/postgres-core-model/src/migration.rs
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration.rs
@@ -240,7 +240,7 @@ mod tests {
     use core_plugin_interface::{
         error::ModelSerializationError, serializable_system::SerializableSystem,
     };
-    use postgres_graphql_model::subsystem::PostgresSubsystem;
+    use postgres_graphql_model::subsystem::PostgresGraphQLSubsystem;
     use stripmargin::StripMargin;
 
     #[cfg_attr(not(target_family = "wasm"), tokio::test)]
@@ -1709,7 +1709,7 @@ mod tests {
     async fn create_postgres_system_from_str(
         model_str: &str,
         file_name: String,
-    ) -> Result<PostgresSubsystem, ModelSerializationError> {
+    ) -> Result<PostgresGraphQLSubsystem, ModelSerializationError> {
         let system = builder::build_system_from_str(
             model_str,
             file_name,
@@ -1725,7 +1725,7 @@ mod tests {
 
     fn deserialize_postgres_subsystem(
         system: SerializableSystem,
-    ) -> Result<PostgresSubsystem, ModelSerializationError> {
+    ) -> Result<PostgresGraphQLSubsystem, ModelSerializationError> {
         use std::sync::Arc;
 
         let postgres_subsystem = system
@@ -1737,12 +1737,12 @@ mod tests {
         match postgres_subsystem {
             Some(subsystem) => {
                 let mut postgres_subsystem =
-                    PostgresSubsystem::deserialize(subsystem.graphql.unwrap().0)?;
+                    PostgresGraphQLSubsystem::deserialize(subsystem.graphql.unwrap().0)?;
                 let postgres_core_subsystem = PostgresCoreSubsystem::deserialize(subsystem.core.0)?;
                 postgres_subsystem.database = Arc::new(postgres_core_subsystem.database);
                 Ok(postgres_subsystem)
             }
-            None => Ok(PostgresSubsystem::default()),
+            None => Ok(PostgresGraphQLSubsystem::default()),
         }
     }
 

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/system_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/system_builder.rs
@@ -24,7 +24,7 @@ use postgres_graphql_model::{
     order::OrderByParameterType,
     predicate::PredicateParameterType,
     query::{AggregateQuery, CollectionQuery, PkQuery, UniqueQuery},
-    subsystem::PostgresSubsystem,
+    subsystem::PostgresGraphQLSubsystem,
     types::{EntityType, MutationType, PostgresPrimitiveType},
     vector_distance::VectorDistanceType,
 };
@@ -42,7 +42,7 @@ pub fn build(
     resolved_env: &ResolvedTypeEnv,
     base_system: &BaseModelSystem,
     database: Arc<Database>,
-) -> Result<Option<PostgresSubsystem>, ModelBuildingError> {
+) -> Result<Option<PostgresGraphQLSubsystem>, ModelBuildingError> {
     let mut building = SystemContextBuilding {
         database,
         ..SystemContextBuilding::default()
@@ -52,7 +52,7 @@ pub fn build(
         build_shallow(resolved_env, &mut building);
         build_expanded(resolved_env, &mut building)?;
 
-        PostgresSubsystem {
+        PostgresGraphQLSubsystem {
             contexts: base_system.contexts.clone(),
             primitive_types: building.primitive_types.values(),
             entity_types: building.entity_types.values(),

--- a/crates/postgres-subsystem/postgres-graphql-model/src/aggregate.rs
+++ b/crates/postgres-subsystem/postgres-graphql-model/src/aggregate.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::query::AggregateQueryParameters;
 use crate::relation::{OneToManyRelation, PostgresRelation};
-use crate::subsystem::PostgresSubsystem;
+use crate::subsystem::PostgresGraphQLSubsystem;
 use core_plugin_interface::core_model::mapped_arena::SerializableSlabIndex;
 use core_plugin_interface::core_model::type_normalization::{
     default_positioned, default_positioned_name, FieldDefinitionProvider, InputValueProvider,
@@ -68,8 +68,8 @@ impl ScalarAggregateFieldKind {
     }
 }
 
-impl TypeDefinitionProvider<PostgresSubsystem> for AggregateType {
-    fn type_definition(&self, system: &PostgresSubsystem) -> TypeDefinition {
+impl TypeDefinitionProvider<PostgresGraphQLSubsystem> for AggregateType {
+    fn type_definition(&self, system: &PostgresGraphQLSubsystem) -> TypeDefinition {
         let kind = {
             let fields: Vec<_> = self
                 .fields
@@ -92,8 +92,8 @@ impl TypeDefinitionProvider<PostgresSubsystem> for AggregateType {
     }
 }
 
-impl FieldDefinitionProvider<PostgresSubsystem> for AggregateField {
-    fn field_definition(&self, system: &PostgresSubsystem) -> FieldDefinition {
+impl FieldDefinitionProvider<PostgresGraphQLSubsystem> for AggregateField {
+    fn field_definition(&self, system: &PostgresGraphQLSubsystem) -> FieldDefinition {
         let arguments = match &self.relation {
             Some(relation) => match relation {
                 PostgresRelation::Pk { .. }

--- a/crates/postgres-subsystem/postgres-graphql-model/src/limit_offset.rs
+++ b/crates/postgres-subsystem/postgres-graphql-model/src/limit_offset.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::{subsystem::PostgresSubsystem, types::PostgresPrimitiveType};
+use crate::{subsystem::PostgresGraphQLSubsystem, types::PostgresPrimitiveType};
 use async_graphql_parser::types::{Type, TypeDefinition, TypeKind};
 use core_plugin_interface::core_model::{
     mapped_arena::SerializableSlabIndex,
@@ -48,8 +48,8 @@ impl Parameter for LimitParameter {
     }
 }
 
-impl TypeDefinitionProvider<PostgresSubsystem> for LimitParameter {
-    fn type_definition(&self, _system: &PostgresSubsystem) -> TypeDefinition {
+impl TypeDefinitionProvider<PostgresGraphQLSubsystem> for LimitParameter {
+    fn type_definition(&self, _system: &PostgresGraphQLSubsystem) -> TypeDefinition {
         TypeDefinition {
             extend: false,
             description: None,
@@ -92,8 +92,8 @@ impl Parameter for OffsetParameter {
     }
 }
 
-impl TypeDefinitionProvider<PostgresSubsystem> for OffsetParameter {
-    fn type_definition(&self, _system: &PostgresSubsystem) -> TypeDefinition {
+impl TypeDefinitionProvider<PostgresGraphQLSubsystem> for OffsetParameter {
+    fn type_definition(&self, _system: &PostgresGraphQLSubsystem) -> TypeDefinition {
         TypeDefinition {
             extend: false,
             description: None,

--- a/crates/postgres-subsystem/postgres-graphql-model/src/order.rs
+++ b/crates/postgres-subsystem/postgres-graphql-model/src/order.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::{access::Access, subsystem::PostgresSubsystem};
+use crate::{access::Access, subsystem::PostgresGraphQLSubsystem};
 
 use async_graphql_parser::{
     types::{
@@ -89,8 +89,8 @@ impl Parameter for OrderByParameter {
     }
 }
 
-impl TypeDefinitionProvider<PostgresSubsystem> for OrderByParameterType {
-    fn type_definition(&self, _system: &PostgresSubsystem) -> TypeDefinition {
+impl TypeDefinitionProvider<PostgresGraphQLSubsystem> for OrderByParameterType {
+    fn type_definition(&self, _system: &PostgresGraphQLSubsystem) -> TypeDefinition {
         match &self.kind {
             OrderByParameterTypeKind::Composite { parameters } => {
                 let fields = parameters
@@ -163,8 +163,8 @@ impl TypeDefinitionProvider<PostgresSubsystem> for OrderByParameterType {
     }
 }
 
-impl TypeDefinitionProvider<PostgresSubsystem> for OrderByParameterTypeWrapper {
-    fn type_definition(&self, system: &PostgresSubsystem) -> TypeDefinition {
+impl TypeDefinitionProvider<PostgresGraphQLSubsystem> for OrderByParameterTypeWrapper {
+    fn type_definition(&self, system: &PostgresGraphQLSubsystem) -> TypeDefinition {
         let typ = &system.order_by_types[self.type_id];
         typ.type_definition(system)
     }

--- a/crates/postgres-subsystem/postgres-graphql-model/src/predicate.rs
+++ b/crates/postgres-subsystem/postgres-graphql-model/src/predicate.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::{access::Access, subsystem::PostgresSubsystem};
+use crate::{access::Access, subsystem::PostgresGraphQLSubsystem};
 use async_graphql_parser::types::{
     InputObjectType, InputValueDefinition, Type, TypeDefinition, TypeKind,
 };
@@ -95,8 +95,8 @@ impl Parameter for PredicateParameter {
     }
 }
 
-impl TypeDefinitionProvider<PostgresSubsystem> for PredicateParameterType {
-    fn type_definition(&self, _system: &PostgresSubsystem) -> TypeDefinition {
+impl TypeDefinitionProvider<PostgresGraphQLSubsystem> for PredicateParameterType {
+    fn type_definition(&self, _system: &PostgresGraphQLSubsystem) -> TypeDefinition {
         match &self.kind {
             PredicateParameterTypeKind::Operator(parameters)
             | PredicateParameterTypeKind::Reference(parameters) => {

--- a/crates/postgres-subsystem/postgres-graphql-model/src/subsystem.rs
+++ b/crates/postgres-subsystem/postgres-graphql-model/src/subsystem.rs
@@ -35,7 +35,7 @@ use exo_sql::Database;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct PostgresSubsystem {
+pub struct PostgresGraphQLSubsystem {
     pub contexts: MappedArena<ContextType>,
     pub primitive_types: SerializableSlab<PostgresPrimitiveType>,
     pub entity_types: SerializableSlab<EntityType>,
@@ -64,7 +64,7 @@ pub struct PostgresSubsystem {
     pub database: Arc<Database>,
 }
 
-impl PostgresSubsystem {
+impl PostgresGraphQLSubsystem {
     pub fn schema_queries(&self) -> Vec<FieldDefinition> {
         let pk_queries_defn = self
             .pk_queries
@@ -131,7 +131,7 @@ impl PostgresSubsystem {
     }
 }
 
-impl Default for PostgresSubsystem {
+impl Default for PostgresGraphQLSubsystem {
     fn default() -> Self {
         Self {
             contexts: MappedArena::default(),
@@ -155,7 +155,7 @@ impl Default for PostgresSubsystem {
     }
 }
 
-impl SystemSerializer for PostgresSubsystem {
+impl SystemSerializer for PostgresGraphQLSubsystem {
     type Underlying = Self;
 
     fn serialize(&self) -> Result<Vec<u8>, ModelSerializationError> {
@@ -169,7 +169,7 @@ impl SystemSerializer for PostgresSubsystem {
     }
 }
 
-impl ContextContainer for PostgresSubsystem {
+impl ContextContainer for PostgresGraphQLSubsystem {
     fn contexts(&self) -> &MappedArena<ContextType> {
         &self.contexts
     }

--- a/crates/postgres-subsystem/postgres-graphql-model/src/types.rs
+++ b/crates/postgres-subsystem/postgres-graphql-model/src/types.rs
@@ -13,7 +13,7 @@ use crate::access::{DatabaseAccessPrimitiveExpression, InputAccessPrimitiveExpre
 use crate::aggregate::AggregateField;
 use crate::query::{AggregateQuery, CollectionQuery, CollectionQueryParameters, PkQuery};
 use crate::relation::OneToManyRelation;
-use crate::subsystem::PostgresSubsystem;
+use crate::subsystem::PostgresGraphQLSubsystem;
 use crate::vector_distance::VectorDistanceField;
 use async_graphql_parser::types::{
     FieldDefinition, InputObjectType, ObjectType, Type, TypeDefinition, TypeKind,
@@ -203,8 +203,8 @@ pub fn base_type<'a, CT>(
         .to_type(primitive_types, entity_types)
 }
 
-impl TypeDefinitionProvider<PostgresSubsystem> for PostgresPrimitiveType {
-    fn type_definition(&self, _system: &PostgresSubsystem) -> TypeDefinition {
+impl TypeDefinitionProvider<PostgresGraphQLSubsystem> for PostgresPrimitiveType {
+    fn type_definition(&self, _system: &PostgresGraphQLSubsystem) -> TypeDefinition {
         TypeDefinition {
             extend: false,
             description: None,
@@ -215,8 +215,8 @@ impl TypeDefinitionProvider<PostgresSubsystem> for PostgresPrimitiveType {
     }
 }
 
-impl TypeDefinitionProvider<PostgresSubsystem> for EntityType {
-    fn type_definition(&self, system: &PostgresSubsystem) -> TypeDefinition {
+impl TypeDefinitionProvider<PostgresGraphQLSubsystem> for EntityType {
+    fn type_definition(&self, system: &PostgresGraphQLSubsystem) -> TypeDefinition {
         let EntityType {
             fields,
             agg_fields,
@@ -257,8 +257,8 @@ impl TypeDefinitionProvider<PostgresSubsystem> for EntityType {
     }
 }
 
-impl TypeDefinitionProvider<PostgresSubsystem> for MutationType {
-    fn type_definition(&self, _system: &PostgresSubsystem) -> TypeDefinition {
+impl TypeDefinitionProvider<PostgresGraphQLSubsystem> for MutationType {
+    fn type_definition(&self, _system: &PostgresGraphQLSubsystem) -> TypeDefinition {
         let kind = {
             let fields = self
                 .fields
@@ -279,8 +279,8 @@ impl TypeDefinitionProvider<PostgresSubsystem> for MutationType {
     }
 }
 
-impl<CT> FieldDefinitionProvider<PostgresSubsystem> for PostgresField<CT> {
-    fn field_definition(&self, system: &PostgresSubsystem) -> FieldDefinition {
+impl<CT> FieldDefinitionProvider<PostgresGraphQLSubsystem> for PostgresField<CT> {
+    fn field_definition(&self, system: &PostgresGraphQLSubsystem) -> FieldDefinition {
         let field_type = default_positioned((&self.typ).into());
         let mut directives = vec![];
 

--- a/crates/postgres-subsystem/postgres-graphql-model/src/vector_distance.rs
+++ b/crates/postgres-subsystem/postgres-graphql-model/src/vector_distance.rs
@@ -10,7 +10,7 @@ use core_plugin_interface::core_model::type_normalization::{
 use exo_sql::{ColumnId, VectorDistanceFunction};
 use serde::{Deserialize, Serialize};
 
-use crate::{access::Access, subsystem::PostgresSubsystem};
+use crate::{access::Access, subsystem::PostgresGraphQLSubsystem};
 
 /// Field for a vector distance function
 /// Represents:
@@ -48,8 +48,8 @@ impl VectorDistanceType {
 pub struct VectorDistanceTypeField {}
 
 /// The definition of a vector distance field. Takes and argument
-impl FieldDefinitionProvider<PostgresSubsystem> for VectorDistanceField {
-    fn field_definition(&self, _system: &PostgresSubsystem) -> FieldDefinition {
+impl FieldDefinitionProvider<PostgresGraphQLSubsystem> for VectorDistanceField {
+    fn field_definition(&self, _system: &PostgresGraphQLSubsystem) -> FieldDefinition {
         // {to: [Float!]!}
         let argument = InputValueDefinition {
             description: None,
@@ -78,8 +78,8 @@ impl FieldDefinitionProvider<PostgresSubsystem> for VectorDistanceField {
     }
 }
 
-impl TypeDefinitionProvider<PostgresSubsystem> for VectorDistanceType {
-    fn type_definition(&self, system: &PostgresSubsystem) -> TypeDefinition {
+impl TypeDefinitionProvider<PostgresGraphQLSubsystem> for VectorDistanceType {
+    fn type_definition(&self, system: &PostgresGraphQLSubsystem) -> TypeDefinition {
         let kind = {
             let fields: Vec<_> = self
                 .fields
@@ -102,8 +102,8 @@ impl TypeDefinitionProvider<PostgresSubsystem> for VectorDistanceType {
     }
 }
 
-impl FieldDefinitionProvider<PostgresSubsystem> for VectorDistanceTypeField {
-    fn field_definition(&self, _system: &PostgresSubsystem) -> FieldDefinition {
+impl FieldDefinitionProvider<PostgresGraphQLSubsystem> for VectorDistanceTypeField {
+    fn field_definition(&self, _system: &PostgresGraphQLSubsystem) -> FieldDefinition {
         FieldDefinition {
             description: None,
             name: default_positioned_name("distance"),

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/access_solver.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/access_solver.rs
@@ -29,7 +29,7 @@ use core_plugin_interface::{
 use exo_sql::{AbstractPredicate, ColumnPath, PhysicalColumnPath, SQLParamContainer};
 use postgres_graphql_model::{
     access::{DatabaseAccessPrimitiveExpression, InputAccessPrimitiveExpression},
-    subsystem::PostgresSubsystem,
+    subsystem::PostgresGraphQLSubsystem,
 };
 
 use postgres_core_resolver::cast;
@@ -76,7 +76,7 @@ pub enum SolvedJsonPrimitiveExpression {
 
 #[async_trait]
 impl<'a> AccessSolver<'a, DatabaseAccessPrimitiveExpression, AbstractPredicateWrapper>
-    for PostgresSubsystem
+    for PostgresGraphQLSubsystem
 {
     async fn solve_relational_op(
         &self,
@@ -85,7 +85,7 @@ impl<'a> AccessSolver<'a, DatabaseAccessPrimitiveExpression, AbstractPredicateWr
         op: &AccessRelationalOp<DatabaseAccessPrimitiveExpression>,
     ) -> Result<Option<AbstractPredicateWrapper>, AccessSolverError> {
         async fn reduce_primitive_expression<'a>(
-            solver: &PostgresSubsystem,
+            solver: &PostgresGraphQLSubsystem,
             request_context: &'a RequestContext<'a>,
             expr: &'a DatabaseAccessPrimitiveExpression,
         ) -> Result<Option<SolvedPrimitiveExpression>, AccessSolverError> {
@@ -216,7 +216,7 @@ impl<'a> AccessSolver<'a, DatabaseAccessPrimitiveExpression, AbstractPredicateWr
 
 #[async_trait]
 impl<'a> AccessSolver<'a, InputAccessPrimitiveExpression, AbstractPredicateWrapper>
-    for PostgresSubsystem
+    for PostgresGraphQLSubsystem
 {
     async fn solve_relational_op(
         &self,
@@ -225,7 +225,7 @@ impl<'a> AccessSolver<'a, InputAccessPrimitiveExpression, AbstractPredicateWrapp
         op: &AccessRelationalOp<InputAccessPrimitiveExpression>,
     ) -> Result<Option<AbstractPredicateWrapper>, AccessSolverError> {
         async fn reduce_primitive_expression<'a>(
-            solver: &PostgresSubsystem,
+            solver: &PostgresGraphQLSubsystem,
             request_context: &'a RequestContext<'a>,
             expr: &'a InputAccessPrimitiveExpression,
         ) -> Result<Option<SolvedJsonPrimitiveExpression>, AccessSolverError> {
@@ -382,7 +382,7 @@ mod tests {
     use super::*;
 
     struct TestSystem {
-        system: PostgresSubsystem,
+        system: PostgresGraphQLSubsystem,
         published_column_path: PhysicalColumnPath,
         owner_id_column_path: PhysicalColumnPath,
         dept1_id_column_path: PhysicalColumnPath,
@@ -566,7 +566,7 @@ mod tests {
     async fn solve_access<'a>(
         expr: &'a AccessPredicateExpression<DatabaseAccessPrimitiveExpression>,
         request_context: &'a RequestContext<'a>,
-        subsystem: &'a PostgresSubsystem,
+        subsystem: &'a PostgresGraphQLSubsystem,
     ) -> AbstractPredicate {
         subsystem
             .solve(request_context, None, expr)
@@ -1306,7 +1306,7 @@ mod tests {
         let test_system_router = test_system_router.as_ref();
         let env = &MapEnvironment::from(HashMap::new());
         // Scenario: true or false
-        let system = PostgresSubsystem::default();
+        let system = PostgresGraphQLSubsystem::default();
 
         let test_ae = AccessPredicateExpression::BooleanLiteral(true);
         let context = test_request_context(Value::Null, test_system_router, env); // irrelevant context content

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/aggregate_query.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/aggregate_query.rs
@@ -23,7 +23,7 @@ use exo_sql::{
 };
 use futures::StreamExt;
 use postgres_graphql_model::{
-    query::AggregateQuery, relation::PostgresRelation, subsystem::PostgresSubsystem,
+    query::AggregateQuery, relation::PostgresRelation, subsystem::PostgresGraphQLSubsystem,
     types::EntityType,
 };
 
@@ -33,7 +33,7 @@ impl OperationSelectionResolver for AggregateQuery {
         &'a self,
         field: &'a ValidatedField,
         request_context: &'a RequestContext<'a>,
-        subsystem: &'a PostgresSubsystem,
+        subsystem: &'a PostgresGraphQLSubsystem,
     ) -> Result<AbstractSelect, PostgresExecutionError> {
         let access_predicate = check_access(
             self.return_type.typ(&subsystem.entity_types),
@@ -80,7 +80,7 @@ impl OperationSelectionResolver for AggregateQuery {
 async fn content_select<'content>(
     return_type: &OperationReturnType<EntityType>,
     fields: &'content [ValidatedField],
-    subsystem: &'content PostgresSubsystem,
+    subsystem: &'content PostgresGraphQLSubsystem,
     request_context: &'content RequestContext<'content>,
 ) -> Result<Vec<AliasedSelectionElement>, PostgresExecutionError> {
     futures::stream::iter(fields.iter())
@@ -94,7 +94,7 @@ async fn content_select<'content>(
 async fn map_field<'content>(
     return_type: &OperationReturnType<EntityType>,
     field: &'content ValidatedField,
-    subsystem: &'content PostgresSubsystem,
+    subsystem: &'content PostgresGraphQLSubsystem,
     _request_context: &'content RequestContext<'content>,
 ) -> Result<AliasedSelectionElement, PostgresExecutionError> {
     let selection_elem = if field.name == "__typename" {

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/auth_util.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/auth_util.rs
@@ -25,13 +25,13 @@ use core_plugin_interface::core_resolver::{
     access_solver::AccessSolver, validation::field::ValidatedField,
 };
 use exo_sql::{AbstractPredicate, Predicate};
-use postgres_graphql_model::subsystem::PostgresSubsystem;
+use postgres_graphql_model::subsystem::PostgresGraphQLSubsystem;
 
 pub(crate) async fn check_access<'a>(
     return_type: &'a EntityType,
     selection: &'a [ValidatedField],
     kind: &SQLOperationKind,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
     request_context: &'a RequestContext<'a>,
     input_context: Option<&'a Val>,
 ) -> Result<AbstractPredicate, PostgresExecutionError> {
@@ -145,7 +145,7 @@ pub(crate) async fn check_access<'a>(
 
 async fn check_create_access<'a>(
     expr: &AccessPredicateExpression<InputAccessPrimitiveExpression>,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
     request_context: &'a RequestContext<'a>,
     input_context: Option<&'a Val>,
 ) -> Result<AbstractPredicate, PostgresExecutionError> {
@@ -158,7 +158,7 @@ async fn check_create_access<'a>(
 
 pub(super) async fn check_retrieve_access<'a>(
     expr: &AccessPredicateExpression<DatabaseAccessPrimitiveExpression>,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
     request_context: &'a RequestContext<'a>,
 ) -> Result<AbstractPredicate, PostgresExecutionError> {
     Ok(subsystem
@@ -170,7 +170,7 @@ pub(super) async fn check_retrieve_access<'a>(
 
 async fn check_update_access<'a>(
     expr: &UpdateAccessExpression,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
     request_context: &'a RequestContext<'a>,
     input_context: Option<&'a Val>,
 ) -> Result<AbstractPredicate, PostgresExecutionError> {
@@ -205,7 +205,7 @@ async fn check_update_access<'a>(
 
 async fn check_delete_access<'a>(
     expr: &AccessPredicateExpression<DatabaseAccessPrimitiveExpression>,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
     request_context: &'a RequestContext<'a>,
 ) -> Result<AbstractPredicate, PostgresExecutionError> {
     Ok(subsystem
@@ -218,7 +218,7 @@ async fn check_delete_access<'a>(
 async fn check_selection_access<'a>(
     selection: &'a [ValidatedField],
     return_type: &'a EntityType,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
     request_context: &'a RequestContext<'a>,
 ) -> Result<AbstractPredicate, PostgresExecutionError> {
     futures::stream::iter(selection.iter().map(Ok))
@@ -268,7 +268,7 @@ async fn check_selection_access<'a>(
 async fn check_input_access<'a>(
     input_context: Option<&'a Val>,
     return_type: &'a EntityType,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
     request_context: &'a RequestContext<'a>,
     field_access: fn(
         &PostgresField<EntityType>,

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/create_data_param_mapper.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/create_data_param_mapper.rs
@@ -20,7 +20,7 @@ use futures::future::{join_all, try_join_all};
 use postgres_graphql_model::{
     mutation::DataParameter,
     relation::{ManyToOneRelation, OneToManyRelation, PostgresRelation},
-    subsystem::PostgresSubsystem,
+    subsystem::PostgresGraphQLSubsystem,
     types::{base_type, MutationType, PostgresField, PostgresType},
 };
 
@@ -44,7 +44,7 @@ impl<'a> SQLMapper<'a, AbstractInsert> for InsertOperation<'a> {
     async fn to_sql(
         self,
         argument: &'a Val,
-        subsystem: &'a PostgresSubsystem,
+        subsystem: &'a PostgresGraphQLSubsystem,
         request_context: &'a RequestContext<'a>,
     ) -> Result<AbstractInsert, PostgresExecutionError> {
         let data_type = &subsystem.mutation_types[self.data_param.typ.innermost().type_id];
@@ -69,7 +69,7 @@ impl<'a> SQLMapper<'a, AbstractInsert> for InsertOperation<'a> {
 pub(crate) async fn map_argument<'a>(
     data_type: &'a MutationType,
     argument: &'a Val,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
     request_context: &'a RequestContext<'a>,
 ) -> Result<Vec<InsertionRow>, PostgresExecutionError> {
     match argument {
@@ -90,7 +90,7 @@ pub(crate) async fn map_argument<'a>(
 async fn map_single<'a>(
     data_type: &'a MutationType,
     argument: &'a Val,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
     request_context: &'a RequestContext<'a>,
 ) -> Result<InsertionRow, PostgresExecutionError> {
     check_access(
@@ -157,7 +157,7 @@ async fn map_self_column<'a>(
     key_column_id: ColumnId,
     field: &'a PostgresField<MutationType>,
     argument: &'a Val,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
 ) -> Result<InsertionElement, PostgresExecutionError> {
     let key_column = key_column_id.get_column(&subsystem.database);
     let argument_value = match &field.relation {
@@ -198,7 +198,7 @@ async fn map_foreign<'a>(
     field: &'a PostgresField<MutationType>, // "concerts"
     argument: &'a Val,                      // [{<concert-info1>}, {<concert-info2>}]
     one_to_many_relation: &OneToManyRelation,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
     request_context: &'a RequestContext<'a>,
 ) -> Result<InsertionElement, PostgresExecutionError> {
     let field_type = base_type(

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/limit_offset_mapper.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/limit_offset_mapper.rs
@@ -13,7 +13,7 @@ use common::value::Val;
 use exo_sql::{Limit, Offset};
 use postgres_graphql_model::{
     limit_offset::{LimitParameter, OffsetParameter},
-    subsystem::PostgresSubsystem,
+    subsystem::PostgresGraphQLSubsystem,
 };
 
 use postgres_core_resolver::postgres_execution_error::PostgresExecutionError;
@@ -34,7 +34,7 @@ impl<'a> SQLMapper<'a, Limit> for &LimitParameter {
     async fn to_sql(
         self,
         argument: &'a Val,
-        _subsystem: &'a PostgresSubsystem,
+        _subsystem: &'a PostgresGraphQLSubsystem,
         _request_context: &'a RequestContext<'a>,
     ) -> Result<Limit, PostgresExecutionError> {
         cast_to_i64(argument).map(Limit)
@@ -50,7 +50,7 @@ impl<'a> SQLMapper<'a, Offset> for &OffsetParameter {
     async fn to_sql(
         self,
         argument: &'a Val,
-        _subsystem: &'a PostgresSubsystem,
+        _subsystem: &'a PostgresGraphQLSubsystem,
         _request_context: &'a RequestContext<'a>,
     ) -> Result<Offset, PostgresExecutionError> {
         cast_to_i64(argument).map(Offset)

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/operation_resolver.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/operation_resolver.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use common::context::RequestContext;
 use core_plugin_interface::core_resolver::validation::field::ValidatedField;
 use exo_sql::{AbstractOperation, AbstractSelect};
-use postgres_graphql_model::subsystem::PostgresSubsystem;
+use postgres_graphql_model::subsystem::PostgresGraphQLSubsystem;
 
 use postgres_core_resolver::postgres_execution_error::PostgresExecutionError;
 
@@ -21,7 +21,7 @@ pub trait OperationSelectionResolver {
         &'a self,
         field: &'a ValidatedField,
         request_context: &'a RequestContext<'a>,
-        subsystem: &'a PostgresSubsystem,
+        subsystem: &'a PostgresGraphQLSubsystem,
     ) -> Result<AbstractSelect, PostgresExecutionError>;
 }
 
@@ -31,7 +31,7 @@ pub trait OperationResolver {
         &'a self,
         field: &'a ValidatedField,
         request_context: &'a RequestContext<'a>,
-        subsystem: &'a PostgresSubsystem,
+        subsystem: &'a PostgresGraphQLSubsystem,
     ) -> Result<AbstractOperation, PostgresExecutionError>;
 }
 
@@ -41,7 +41,7 @@ impl<T: OperationSelectionResolver + Send + Sync> OperationResolver for T {
         &'a self,
         field: &'a ValidatedField,
         request_context: &'a RequestContext<'a>,
-        subsystem: &'a PostgresSubsystem,
+        subsystem: &'a PostgresGraphQLSubsystem,
     ) -> Result<AbstractOperation, PostgresExecutionError> {
         self.resolve_select(field, request_context, subsystem)
             .await

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/order_by_mapper.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/order_by_mapper.rs
@@ -25,7 +25,7 @@ use exo_sql::{ColumnPath, SQLParamContainer, VectorDistanceFunction};
 
 use postgres_graphql_model::{
     order::{OrderByParameter, OrderByParameterType, OrderByParameterTypeKind},
-    subsystem::PostgresSubsystem,
+    subsystem::PostgresGraphQLSubsystem,
 };
 
 pub(crate) struct OrderByParameterInput<'a> {
@@ -38,7 +38,7 @@ impl<'a> SQLMapper<'a, AbstractOrderBy> for OrderByParameterInput<'a> {
     async fn to_sql(
         self,
         argument: &'a Val,
-        subsystem: &'a PostgresSubsystem,
+        subsystem: &'a PostgresGraphQLSubsystem,
         request_context: &'a RequestContext<'a>,
     ) -> Result<AbstractOrderBy, PostgresExecutionError> {
         let parameter_type = &subsystem.order_by_types[self.param.typ.innermost().type_id];
@@ -91,7 +91,7 @@ async fn order_by_pair<'a>(
     parameter_name: &str,
     parameter_value: &'a Val,
     parent_column_path: Option<PhysicalColumnPath>,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
     request_context: &'a RequestContext<'a>,
 ) -> Result<AbstractOrderBy, PostgresExecutionError> {
     match &typ.kind {

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/postgres_mutation.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/postgres_mutation.rs
@@ -31,7 +31,7 @@ use exo_sql::{
 use postgres_graphql_model::{
     mutation::{DataParameter, PostgresMutation, PostgresMutationParameters},
     predicate::PredicateParameter,
-    subsystem::PostgresSubsystem,
+    subsystem::PostgresGraphQLSubsystem,
     types::EntityType,
 };
 
@@ -41,7 +41,7 @@ impl OperationResolver for PostgresMutation {
         &'a self,
         field: &'a ValidatedField,
         request_context: &'a RequestContext<'a>,
-        subsystem: &'a PostgresSubsystem,
+        subsystem: &'a PostgresGraphQLSubsystem,
     ) -> Result<AbstractOperation, PostgresExecutionError> {
         let return_type = &self.return_type;
 
@@ -106,7 +106,7 @@ async fn create_operation<'content>(
     data_param: &'content DataParameter,
     field: &'content ValidatedField,
     select: AbstractSelect,
-    subsystem: &'content PostgresSubsystem,
+    subsystem: &'content PostgresGraphQLSubsystem,
     request_context: &'content RequestContext<'content>,
 ) -> Result<AbstractInsert, PostgresExecutionError> {
     let data_arg = find_arg(&field.arguments, &data_param.name);
@@ -128,7 +128,7 @@ async fn delete_operation<'content>(
     predicate_param: &'content PredicateParameter,
     field: &'content ValidatedField,
     select: AbstractSelect,
-    subsystem: &'content PostgresSubsystem,
+    subsystem: &'content PostgresGraphQLSubsystem,
     request_context: &'content RequestContext<'content>,
 ) -> Result<AbstractDelete, PostgresExecutionError> {
     let (table_id, _, _) = return_type_info(return_type, subsystem);
@@ -165,7 +165,7 @@ async fn update_operation<'content>(
     predicate_param: &'content PredicateParameter,
     field: &'content ValidatedField,
     select: AbstractSelect,
-    subsystem: &'content PostgresSubsystem,
+    subsystem: &'content PostgresGraphQLSubsystem,
     request_context: &'content RequestContext<'content>,
 ) -> Result<AbstractUpdate, PostgresExecutionError> {
     let data_arg = find_arg(&field.arguments, &data_param.name);

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/postgres_query.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/postgres_query.rs
@@ -34,7 +34,7 @@ use postgres_graphql_model::{
     order::OrderByParameter,
     query::{CollectionQuery, CollectionQueryParameters, PkQuery},
     relation::{ManyToOneRelation, OneToManyRelation, PostgresRelation, RelationCardinality},
-    subsystem::PostgresSubsystem,
+    subsystem::PostgresGraphQLSubsystem,
     types::{EntityType, PostgresField},
 };
 
@@ -44,7 +44,7 @@ impl OperationSelectionResolver for PkQuery {
         &'a self,
         field: &'a ValidatedField,
         request_context: &'a RequestContext<'a>,
-        subsystem: &'a PostgresSubsystem,
+        subsystem: &'a PostgresGraphQLSubsystem,
     ) -> Result<AbstractSelect, PostgresExecutionError> {
         let predicate = compute_predicate(
             &self.parameters.predicate_param,
@@ -74,7 +74,7 @@ impl OperationSelectionResolver for UniqueQuery {
         &'a self,
         field: &'a ValidatedField,
         request_context: &'a RequestContext<'a>,
-        subsystem: &'a PostgresSubsystem,
+        subsystem: &'a PostgresGraphQLSubsystem,
     ) -> Result<AbstractSelect, PostgresExecutionError> {
         let predicate = futures::stream::iter(
             self.parameters
@@ -109,7 +109,7 @@ impl OperationSelectionResolver for CollectionQuery {
         &'a self,
         field: &'a ValidatedField,
         request_context: &'a RequestContext<'a>,
-        subsystem: &'a PostgresSubsystem,
+        subsystem: &'a PostgresGraphQLSubsystem,
     ) -> Result<AbstractSelect, PostgresExecutionError> {
         let CollectionQueryParameters {
             predicate_param,
@@ -142,7 +142,7 @@ pub(super) async fn compute_select<'content>(
     offset: Option<Offset>,
     return_type: &'content OperationReturnType<EntityType>,
     selection: &'content [ValidatedField],
-    subsystem: &'content PostgresSubsystem,
+    subsystem: &'content PostgresGraphQLSubsystem,
     request_context: &'content RequestContext<'content>,
 ) -> Result<AbstractSelect, PostgresExecutionError> {
     let return_entity_type = return_type.typ(&subsystem.entity_types);
@@ -179,7 +179,7 @@ pub(super) async fn compute_select<'content>(
 async fn compute_order_by<'content>(
     param: &'content OrderByParameter,
     arguments: &'content Arguments,
-    subsystem: &'content PostgresSubsystem,
+    subsystem: &'content PostgresGraphQLSubsystem,
     request_context: &'content RequestContext<'content>,
 ) -> Result<Option<AbstractOrderBy>, PostgresExecutionError> {
     extract_and_map(
@@ -198,7 +198,7 @@ async fn compute_order_by<'content>(
 async fn content_select<'content>(
     return_type: &EntityType,
     fields: &'content [ValidatedField],
-    subsystem: &'content PostgresSubsystem,
+    subsystem: &'content PostgresGraphQLSubsystem,
     request_context: &'content RequestContext<'content>,
 ) -> Result<Vec<AliasedSelectionElement>, PostgresExecutionError> {
     futures::stream::iter(fields.iter())
@@ -212,7 +212,7 @@ async fn content_select<'content>(
 async fn map_field<'content>(
     return_type: &EntityType,
     field: &'content ValidatedField,
-    subsystem: &'content PostgresSubsystem,
+    subsystem: &'content PostgresGraphQLSubsystem,
     request_context: &'content RequestContext<'content>,
 ) -> Result<AliasedSelectionElement, PostgresExecutionError> {
     let selection_elem = if field.name == "__typename" {
@@ -251,7 +251,7 @@ async fn map_field<'content>(
 async fn map_persistent_field<'content>(
     entity_field: &PostgresField<EntityType>,
     field: &'content ValidatedField,
-    subsystem: &'content PostgresSubsystem,
+    subsystem: &'content PostgresGraphQLSubsystem,
     request_context: &'content RequestContext<'content>,
 ) -> Result<SelectionElement, PostgresExecutionError> {
     match &entity_field.relation {
@@ -315,7 +315,7 @@ async fn map_persistent_field<'content>(
 async fn map_aggregate_field<'content>(
     agg_field: &AggregateField,
     field: &'content ValidatedField,
-    subsystem: &'content PostgresSubsystem,
+    subsystem: &'content PostgresGraphQLSubsystem,
     request_context: &'content RequestContext<'content>,
 ) -> Result<SelectionElement, PostgresExecutionError> {
     if let Some(PostgresRelation::OneToMany(relation)) = &agg_field.relation {

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/predicate_mapper.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/predicate_mapper.rs
@@ -22,7 +22,7 @@ use exo_sql::{NumericComparator, SQLParamContainer};
 use futures::future::try_join_all;
 use postgres_graphql_model::{
     predicate::{PredicateParameter, PredicateParameterTypeKind},
-    subsystem::PostgresSubsystem,
+    subsystem::PostgresGraphQLSubsystem,
 };
 
 use crate::{
@@ -49,7 +49,7 @@ impl<'a> SQLMapper<'a, AbstractPredicate> for PredicateParamInput<'a> {
     async fn to_sql(
         self,
         argument: &'a Val,
-        subsystem: &'a PostgresSubsystem,
+        subsystem: &'a PostgresGraphQLSubsystem,
         request_context: &'a RequestContext<'a>,
     ) -> Result<AbstractPredicate, PostgresExecutionError> {
         let parameter_type = &subsystem.predicate_types[self.param.typ.innermost().type_id];
@@ -398,7 +398,7 @@ fn operands<'a>(
     op_value: &'a Val,
     op_value_type: Option<&PhysicalColumnType>,
     parent_column_path: &Option<PhysicalColumnPath>,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
 ) -> Result<(ColumnPath, ColumnPath), PostgresExecutionError> {
     let op_physical_column_id = param
         .column_path_link
@@ -418,7 +418,7 @@ fn operands<'a>(
 pub async fn compute_predicate<'a>(
     param: &'a PredicateParameter,
     arguments: &'a Arguments,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
     request_context: &'a RequestContext<'a>,
 ) -> Result<AbstractPredicate, PostgresExecutionError> {
     extract_and_map(

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/resolver.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/resolver.rs
@@ -26,11 +26,11 @@ use core_plugin_interface::{
 };
 use exo_sql::DatabaseExecutor;
 use postgres_core_resolver::postgres_execution_error::PostgresExecutionError;
-use postgres_graphql_model::subsystem::PostgresSubsystem;
+use postgres_graphql_model::subsystem::PostgresGraphQLSubsystem;
 
 pub struct PostgresSubsystemResolver {
     pub id: &'static str,
-    pub subsystem: PostgresSubsystem,
+    pub subsystem: PostgresGraphQLSubsystem,
     pub executor: Arc<DatabaseExecutor>,
 }
 

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/sql_mapper.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/sql_mapper.rs
@@ -10,7 +10,7 @@
 use async_trait::async_trait;
 use common::context::RequestContext;
 use common::value::Val;
-use postgres_graphql_model::subsystem::PostgresSubsystem;
+use postgres_graphql_model::subsystem::PostgresGraphQLSubsystem;
 
 use crate::util::{find_arg, Arguments};
 
@@ -28,7 +28,7 @@ pub(crate) trait SQLMapper<'a, R> {
     async fn to_sql(
         self,
         argument: &'a Val,
-        subsystem: &'a PostgresSubsystem,
+        subsystem: &'a PostgresGraphQLSubsystem,
         request_context: &'a RequestContext<'a>,
     ) -> Result<R, PostgresExecutionError>;
 
@@ -38,7 +38,7 @@ pub(crate) trait SQLMapper<'a, R> {
 pub(crate) async fn extract_and_map<'a, P, R>(
     param: P,
     arguments: &'a Arguments,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
     request_context: &'a RequestContext<'a>,
 ) -> Result<Option<R>, PostgresExecutionError>
 where

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/test_utils.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/test_utils.rs
@@ -13,13 +13,13 @@ use core_plugin_interface::{
     error::ModelSerializationError, serializable_system::SerializableSystem,
 };
 #[cfg(test)]
-use postgres_graphql_model::subsystem::PostgresSubsystem;
+use postgres_graphql_model::subsystem::PostgresGraphQLSubsystem;
 
 #[cfg(test)]
 pub(crate) async fn create_postgres_system_from_str(
     model_str: &str,
     file_name: String,
-) -> Result<PostgresSubsystem, ModelSerializationError> {
+) -> Result<PostgresGraphQLSubsystem, ModelSerializationError> {
     let system = builder::build_system_from_str(
         model_str,
         file_name,
@@ -36,7 +36,7 @@ pub(crate) async fn create_postgres_system_from_str(
 #[cfg(test)]
 fn deserialize_postgres_subsystem(
     system: SerializableSystem,
-) -> Result<PostgresSubsystem, ModelSerializationError> {
+) -> Result<PostgresGraphQLSubsystem, ModelSerializationError> {
     use std::sync::Arc;
 
     let postgres_subsystem = system
@@ -49,11 +49,11 @@ fn deserialize_postgres_subsystem(
     match postgres_subsystem {
         Some(subsystem) => {
             let mut postgres_subsystem =
-                PostgresSubsystem::deserialize(subsystem.graphql.unwrap().0)?;
+                PostgresGraphQLSubsystem::deserialize(subsystem.graphql.unwrap().0)?;
             let postgres_core_subsystem = PostgresCoreSubsystem::deserialize(subsystem.core.0)?;
             postgres_subsystem.database = Arc::new(postgres_core_subsystem.database);
             Ok(postgres_subsystem)
         }
-        None => Ok(PostgresSubsystem::default()),
+        None => Ok(PostgresGraphQLSubsystem::default()),
     }
 }

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/update_data_param_mapper.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/update_data_param_mapper.rs
@@ -21,7 +21,7 @@ use futures::StreamExt;
 use postgres_graphql_model::{
     mutation::DataParameter,
     relation::{ManyToOneRelation, OneToManyRelation, PostgresRelation},
-    subsystem::PostgresSubsystem,
+    subsystem::PostgresGraphQLSubsystem,
     types::{base_type, EntityType, MutationType, PostgresType, TypeIndex},
 };
 
@@ -45,7 +45,7 @@ impl<'a> SQLMapper<'a, AbstractUpdate> for UpdateOperation<'a> {
     async fn to_sql(
         self,
         argument: &'a Val,
-        subsystem: &'a PostgresSubsystem,
+        subsystem: &'a PostgresGraphQLSubsystem,
         request_context: &'a RequestContext<'a>,
     ) -> Result<AbstractUpdate, PostgresExecutionError> {
         let data_type = &subsystem.mutation_types[self.data_param.typ.innermost().type_id];
@@ -77,7 +77,7 @@ impl<'a> SQLMapper<'a, AbstractUpdate> for UpdateOperation<'a> {
 fn compute_update_columns<'a>(
     data_type: &'a MutationType,
     argument: &'a Val,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
 ) -> Vec<(ColumnId, Column)> {
     data_type
         .fields
@@ -130,7 +130,7 @@ fn compute_update_columns<'a>(
 async fn compute_nested_ops<'a>(
     arg_type: &'a MutationType,
     arg: &'a Val,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
     request_context: &'a RequestContext<'a>,
 ) -> Result<
     (
@@ -202,7 +202,7 @@ async fn compute_nested_update<'a>(
     field_entity_type: &'a MutationType,
     argument: &'a Val,
     nesting_relation: &OneToMany,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
     request_context: &'a RequestContext<'a>,
 ) -> Result<Vec<NestedAbstractUpdate>, PostgresExecutionError> {
     let (update_arg, field_entity_type) =
@@ -246,7 +246,7 @@ async fn compute_nested_update_object_arg<'a>(
     field_entity_type: &'a MutationType,
     argument: &'a Val,
     nesting_relation: &OneToMany,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
     request_context: &'a RequestContext<'a>,
 ) -> Result<NestedAbstractUpdate, PostgresExecutionError> {
     assert!(matches!(argument, Val::Object(..)));
@@ -317,14 +317,14 @@ async fn compute_nested_inserts<'a>(
     field_entity_type: &'a MutationType,
     argument: &'a Val,
     nesting_relation: &OneToMany,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
     request_context: &'a RequestContext<'a>,
 ) -> Result<NestedAbstractInsertSet, PostgresExecutionError> {
     async fn create_nested<'a>(
         field_entity_type: &'a MutationType,
         argument: &'a Val,
         nesting_relation: &OneToMany,
-        subsystem: &'a PostgresSubsystem,
+        subsystem: &'a PostgresGraphQLSubsystem,
         request_context: &'a RequestContext<'a>,
     ) -> Result<NestedAbstractInsert, PostgresExecutionError> {
         let table_id = subsystem.entity_types[field_entity_type.entity_id].table_id;
@@ -409,7 +409,7 @@ async fn compute_nested_delete<'a>(
     field_entity_type: &'a MutationType,
     argument: &'a Val,
     nesting_relation: &OneToMany,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
     request_context: &'a RequestContext<'a>,
 ) -> Result<Vec<NestedAbstractDelete>, PostgresExecutionError> {
     // This is not the right way. But current API needs to be updated to not even take the "id" parameter (the same issue exists in the "update" case).
@@ -456,7 +456,7 @@ async fn compute_nested_delete_object_arg<'a>(
     field_mutation_type: &'a MutationType,
     argument: &'a Val,
     nesting_relation: &OneToMany,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
     request_context: &'a RequestContext<'a>,
 ) -> Result<NestedAbstractDelete, PostgresExecutionError> {
     assert!(matches!(argument, Val::Object(..)));
@@ -522,7 +522,7 @@ fn extract_argument<'a>(
     argument: &'a Val,
     arg_type: &'a MutationType,
     arg_name: &str,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
 ) -> (Option<&'a Val>, &'a MutationType) {
     let arg = get_argument_field(argument, arg_name);
 

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/util.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/util.rs
@@ -16,7 +16,7 @@ use core_plugin_interface::core_model::types::OperationReturnType;
 use exo_sql::TableId;
 use postgres_graphql_model::{
     query::{CollectionQuery, PkQuery},
-    subsystem::PostgresSubsystem,
+    subsystem::PostgresGraphQLSubsystem,
 };
 
 use postgres_core_resolver::postgres_execution_error::PostgresExecutionError;
@@ -70,7 +70,7 @@ pub(super) fn to_pg_vector(
 /// - A (table associated with the return type, pk query, collection query) tuple.
 pub(crate) fn return_type_info<'a>(
     return_type: &'a OperationReturnType<EntityType>,
-    subsystem: &'a PostgresSubsystem,
+    subsystem: &'a PostgresGraphQLSubsystem,
 ) -> (TableId, &'a PkQuery, &'a CollectionQuery) {
     let typ = return_type.typ(&subsystem.entity_types);
 

--- a/crates/postgres-subsystem/postgres-resolver/src/plugin/subsystem_loader.rs
+++ b/crates/postgres-subsystem/postgres-resolver/src/plugin/subsystem_loader.rs
@@ -24,7 +24,7 @@ use core_plugin_interface::{
 use exo_env::Environment;
 use exo_sql::DatabaseClientManager;
 use postgres_core_resolver::database_helper::create_database_executor;
-use postgres_graphql_model::subsystem::PostgresSubsystem;
+use postgres_graphql_model::subsystem::PostgresGraphQLSubsystem;
 use postgres_rest_model::subsystem::{PostgresRestSubsystem, PostgresRestSubsystemWithRouter};
 use postgres_rest_resolver::PostgresSubsystemRestResolver;
 
@@ -61,7 +61,7 @@ impl SubsystemLoader for PostgresSubsystemLoader {
 
         let graphql_system = graphql
             .map(|graphql| {
-                let mut subsystem = PostgresSubsystem::deserialize(graphql.0)?;
+                let mut subsystem = PostgresGraphQLSubsystem::deserialize(graphql.0)?;
                 subsystem.database = database.clone();
                 Ok::<_, SubsystemLoadingError>(Box::new(PostgresSubsystemResolver {
                     id: self.id(),


### PR DESCRIPTION
This is a purely mechanical change. This clarifies the distinction between REST and GraphQL subsystems.