### PR TITLE
Publish a Docker image to include cli and server

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -31,6 +31,7 @@ jobs:
         include:
           - image: cli
           - image: server
+          - image: cli-server
           - image: dev
 
     steps:

--- a/docker/Dockerfile.cli-server.ci
+++ b/docker/Dockerfile.cli-server.ci
@@ -1,0 +1,35 @@
+# We must use "debian:bullseye*" (and not "debian:buster") as the base runtime image to match the libc version used while building the binaries
+
+## Create a builder image with exograph release binaries
+FROM debian:bullseye-slim as builder
+
+RUN apt-get update && apt-get -y install unzip
+
+WORKDIR /usr/src
+COPY exograph-x86_64-unknown-linux-gnu.zip ./exograph-x86_64-unknown-linux-gnu.zip
+RUN unzip ./exograph-x86_64-unknown-linux-gnu.zip
+
+
+## Build the runtime image with just the binary we need for both the cli and the server
+FROM debian:bullseye-slim
+
+### Install ca-certificates and tzdata (needed to establish TLS connections and set the timezone)
+RUN apt-get update \
+  && apt-get install -y ca-certificates tzdata \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/src/exo /usr/local/bin/exo
+COPY --from=builder /usr/src/exo-server /usr/local/bin/exo-server
+
+ENV TZ=Etc/UTC
+ENV APP_USER=exo
+ENV APP_DIR=/usr/src/app
+
+### Create a non-root user to run either the cli or the server
+RUN groupadd $APP_USER \
+  && useradd -g $APP_USER $APP_USER \
+  && mkdir -p ${APP_DIR}
+RUN chown -R $APP_USER:$APP_USER ${APP_DIR}
+USER $APP_USER
+
+WORKDIR ${APP_DIR}


### PR DESCRIPTION
This allows, for example, to run migrations (exo schema migrate) from the same image as the server.