### PR TITLE
Support expression to specify JSON path in @jwt

### DIFF
--- a/docs/docs/authentication/overview.md
+++ b/docs/docs/authentication/overview.md
@@ -40,6 +40,26 @@ context AuthContext {
 }
 ```
 
+If the JWT token contains nested claims, you can access them using the dot notation. For example, if the JWT token contains the `sub` as a direct claim and the `role` as a nested claim under a `user` field such as:
+
+```json
+{ 
+  "sub": "1234567890", 
+  "user": { 
+    "role": "admin" 
+  } 
+}
+```
+
+You can access them in the context as follows (note the use of `user.role`):
+
+```exo
+context AuthContext {
+  @jwt("sub") id: string
+  @jwt("user.role") role: string
+}
+```
+
 Once we have the context, we can use it in access control rules, as default values for fields, and as injected arguments to queries, mutations, and interceptors defined in Deno modules.
 
 ## Using in access control rules

--- a/integration-tests/todo-external-auth/.gitignore
+++ b/integration-tests/todo-external-auth/.gitignore
@@ -1,2 +1,0 @@
-target/
-generated/

--- a/integration-tests/todo-jwt-expr/src/index.exo
+++ b/integration-tests/todo-jwt-expr/src/index.exo
@@ -1,0 +1,20 @@
+// Test for JWT expression such as `@jwt("user.role")` and `@jwt("user.sub")`
+// The test focuses only on (otherwise the same setup as ../todo-extractor):
+// - Creating todos (to ensure that the default value is set correctly)
+// - Querying todos (for access control)
+
+context AuthContext {
+  @jwt("user.sub") id: String
+  @jwt("user.role") role: String = "user"
+}
+
+@postgres
+module TodoDatabase {
+  @access(self.userId == AuthContext.id || AuthContext.role == "admin")
+  type Todo {
+    @pk id: Int = autoIncrement()
+    title: String
+    completed: Boolean
+    userId: String = AuthContext.id
+  }
+}

--- a/integration-tests/todo-jwt-expr/tests/create-todo-admin.exotest
+++ b/integration-tests/todo-jwt-expr/tests/create-todo-admin.exotest
@@ -1,0 +1,77 @@
+
+stages:
+  - operation: |
+        mutation createTodo($title: String!, $completed: Boolean!, $userId: Int!) {
+          createTodo(data: { title: $title, completed: $completed, userId: $userId }) {
+            id
+            title
+            completed
+            userId
+          }
+        }
+    variable: |
+      {
+        "title": "U1-T3-by-admin",
+        "completed": true,
+        "userId": "u1"
+      }
+    auth: |
+      {
+          "user": {
+            "role": "admin",
+            "sub": null
+          }
+      } 
+    response: |
+      {
+        "data": {
+          "createTodo": {
+            "id": 5,
+            "title": "U1-T3-by-admin",
+            "completed": true,
+            "userId": "u1"
+          }
+        }
+      }
+      
+  - operation: |
+      query {
+        todos(orderBy: {id: ASC}) {
+          id
+          title
+          completed
+          userId
+        }
+      }
+    auth: |
+      {
+          "user": {
+            "sub": "u1",
+            "role": null
+          }
+      } 
+    response: |
+      {
+        "data": {
+          "todos": [
+            {
+              "id": 1,
+              "title": "U1-T1",
+              "completed": false,
+              "userId": "u1"
+            },
+            {
+              "id": 2,
+              "title": "U1-T2",
+              "completed": true,
+              "userId": "u1"
+            },
+            {
+              "id": 5,
+              "title": "U1-T3-by-admin",
+              "completed": true,
+              "userId": "u1"
+            }
+          ]
+        }
+      }

--- a/integration-tests/todo-jwt-expr/tests/create-todo-user.exotest
+++ b/integration-tests/todo-jwt-expr/tests/create-todo-user.exotest
@@ -1,0 +1,108 @@
+
+stages:
+  - operation: |
+        mutation createTodo($title: String!, $completed: Boolean) {
+          createTodo(data: { title: $title, completed: $completed }) {
+            id
+            title
+            completed
+            userId
+          }
+        }
+    variable: |
+      {
+        "title": "U1-T3",
+        "completed": true
+      }
+    auth: |
+      {
+          "user": {
+            "role": null,
+            "sub": "u1"
+          }
+      } 
+    response: |
+      {
+        "data": {
+          "createTodo": {
+            "id": 5,
+            "title": "U1-T3",
+            "completed": true,
+            "userId": "u1"
+          }
+        }
+      }
+      
+  - operation: |
+      query {
+        todos(orderBy: {id: ASC}) {
+          id
+          title
+          completed
+          userId
+        }
+      }
+    auth: |
+      {
+          "user": {
+            "sub": "u1",
+            "role": null
+          }
+      } 
+    response: |
+      {
+        "data": {
+          "todos": [
+            {
+              "id": 1,
+              "title": "U1-T1",
+              "completed": false,
+              "userId": "u1"
+            },
+            {
+              "id": 2,
+              "title": "U1-T2",
+              "completed": true,
+              "userId": "u1"
+            },
+            {
+              "id": 5,
+              "title": "U1-T3",
+              "completed": true,
+              "userId": "u1"
+            }
+          ]
+        }
+      }
+
+  # User 2 trying to create a todo for user 1; should fail
+  - operation: |
+        mutation createTodo($title: String!, $completed: Boolean, $userId: String!) {
+          createTodo(data: { title: $title, completed: $completed, userId: $userId }) {
+            id
+            title
+            completed
+            userId
+          }
+        }
+    variable: |
+      {
+        "title": "U1-T3",
+        "completed": true,
+        "userId": "u2"
+      }
+    auth: |
+      {
+          "user": {
+            "sub": "u1",
+            "role": null
+          }
+      } 
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Not authorized"
+          }
+        ]
+      }

--- a/integration-tests/todo-jwt-expr/tests/init.gql
+++ b/integration-tests/todo-jwt-expr/tests/init.gql
@@ -1,0 +1,20 @@
+# Create a completed and an incomplete todo for two users
+operation: |
+    mutation {
+        createTodos(data: [
+            {title: "U1-T1", completed: false, userId: "u1"},
+            {title: "U1-T2", completed: true, userId: "u1"},
+            {title: "U2-T1", completed: false, userId: "u2"},
+            {title: "U2-T2", completed: true, userId: "u2"}
+        ]) {
+            id
+        }
+       
+    }
+auth: |
+  {
+      "user": {
+        "role": "admin",
+        "sub": "null"
+      },
+  }     


### PR DESCRIPTION
This support JWT tokens with nested structure such as:

```json
{
  "sub": "1234567890",
  "user": {
    "role": "admin"
  }
}
```

Which can now be extracted as as follows:

```exo
context AuthContext {
  @jwt("sub") id: string
  @jwt("user.role") role: string
}
```

Fixes #60