### PR TITLE
Support specifying schema with `@postgres`

### DIFF
--- a/crates/postgres-subsystem/postgres-builder/src/plugin.rs
+++ b/crates/postgres-subsystem/postgres-builder/src/plugin.rs
@@ -47,7 +47,10 @@ impl SubsystemBuilder for PostgresSubsystemBuilder {
                     targets: &[AnnotationTarget::Module],
                     no_params: true,
                     single_params: false,
-                    mapped_params: None,
+                    mapped_params: Some(&[MappedAnnotationParamSpec {
+                        name: "schema",
+                        optional: true,
+                    }]),
                 },
             ),
             (

--- a/docs/docs/postgres/customizing-types.md
+++ b/docs/docs/postgres/customizing-types.md
@@ -62,6 +62,25 @@ type User {
 
 The `User` type will be mapped to the `auth` schema, and the table name will be `t_users`.
 
+A common use case is to set the schema of all tables to a specific schema. You can achieve this by setting the `schema` attribute of the `@postgres` annotation. For example, to set the schema of all tables to `entertainment`, you can use the `@postgres` annotation as follows:
+
+```exo
+@postgres(schema="entertainment")
+module ConcertModule {
+  type Concert {
+    ...
+    venue: Venue
+  }
+
+  type Venue {
+    ...
+    concerts: Set<Concert>?
+  }
+}
+```
+
+You may still override the schema of a specific table using the `@table` annotation and the `schema` attribute.
+
 ### Pluralization
 
 By default, Exograph will use a simple algorithm to pluralize the name of the type. However, it doesn't work well for names with irregular pluralization. For example, Exograph will pluralize `person` to `persons`, but you will likely want to name it `people`. You can control the plural form using the `@plural` annotation:

--- a/integration-tests/non-public-schema/basic-model-no-auth-module-level-schema/NOTES.md
+++ b/integration-tests/non-public-schema/basic-model-no-auth-module-level-schema/NOTES.md
@@ -1,0 +1,1 @@
+The "tests" directory is a soft-link to ../../basic-model-no-auth/tests, since the model is identical from the API perspective (table/schema names are different, but that's it)

--- a/integration-tests/non-public-schema/basic-model-no-auth-module-level-schema/src/index.exo
+++ b/integration-tests/non-public-schema/basic-model-no-auth-module-level-schema/src/index.exo
@@ -1,0 +1,21 @@
+@postgres(schema="entertainment")
+module ConcertModule {
+  @access(true)
+  type Concert {
+    @pk
+    id: Int = autoIncrement();
+    title: String
+    @column("venueid") venue: Venue 
+    published: Boolean
+    @precision(20) @scale(2) price: Decimal 
+  }
+
+  @access(true)
+  type Venue {
+    @pk id: Int = autoIncrement() 
+    name: String
+    @column("venueid") concerts: Set<Concert>? 
+    published: Boolean
+    @singlePrecision latitude: Float
+  }
+}

--- a/integration-tests/non-public-schema/basic-model-no-auth-module-level-schema/tests
+++ b/integration-tests/non-public-schema/basic-model-no-auth-module-level-schema/tests
@@ -1,0 +1,1 @@
+../../basic-model-no-auth/tests


### PR DESCRIPTION
This supports the common use-case where all tables in a module must have the same schema. Rather than repeating `@table(schema="..")` with each type, this change allows specifying it as the module level:

```exo
@postgres(schema="entertainment")
module ConcertModule {
  type Concert {
    ...
    venue: Venue
  }

  type Venue {
    ...
    concerts: Set<Concert>?
  }
}
```