### PR TITLE
Support migration scope specified schema.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3815,6 +3815,7 @@ dependencies = [
  "wasm-bindgen-test",
  "wasm-bindgen-test-macro",
  "which 6.0.3",
+ "wildmatch",
 ]
 
 [[package]]

--- a/crates/cli/src/commands/schema/create.rs
+++ b/crates/cli/src/commands/schema/create.rs
@@ -16,8 +16,10 @@ use std::{io::Write, path::PathBuf};
 use exo_sql::schema::database_spec::DatabaseSpec;
 
 use crate::{
-    commands::command::{default_model_file, get, output_arg, CommandDefinition},
-    commands::util::use_ir_arg,
+    commands::{
+        command::{default_model_file, get, output_arg, CommandDefinition},
+        util::{migration_scope_from_env, use_ir_arg},
+    },
     util::open_file_for_output,
 };
 
@@ -49,6 +51,7 @@ impl CommandDefinition for CreateCommandDefinition {
         let migrations = Migration::from_schemas(
             &DatabaseSpec::new(vec![], vec![]),
             &DatabaseSpec::from_database(&database),
+            &migration_scope_from_env(),
         );
         migrations.write(&mut buffer, true)?;
 

--- a/crates/cli/src/commands/schema/migrate.rs
+++ b/crates/cli/src/commands/schema/migrate.rs
@@ -14,8 +14,10 @@ use exo_sql::{database_error::DatabaseError, DatabaseClientManager};
 use postgres_core_model::migration::Migration;
 
 use crate::{
-    commands::command::{database_arg, default_model_file, get, output_arg, CommandDefinition},
-    commands::util::use_ir_arg,
+    commands::{
+        command::{database_arg, default_model_file, get, output_arg, CommandDefinition},
+        util::{migration_scope_from_env, use_ir_arg},
+    },
     util::open_file_for_output,
 };
 
@@ -70,7 +72,9 @@ impl CommandDefinition for MigrateCommandDefinition {
         let database = util::extract_postgres_database(&model, None, use_ir).await?;
 
         let db_client = open_database(database_url.as_deref()).await?;
-        let migrations = Migration::from_db_and_model(&db_client, &database).await?;
+        let migrations =
+            Migration::from_db_and_model(&db_client, &database, &migration_scope_from_env())
+                .await?;
 
         if apply_to_database {
             if migrations.has_destructive_changes() {

--- a/crates/cli/src/commands/schema/verify.rs
+++ b/crates/cli/src/commands/schema/verify.rs
@@ -14,7 +14,7 @@ use postgres_core_model::migration::{Migration, VerificationErrors};
 use std::path::PathBuf;
 
 use crate::commands::command::{database_arg, default_model_file, get, CommandDefinition};
-use crate::commands::util::use_ir_arg;
+use crate::commands::util::{migration_scope_from_env, use_ir_arg};
 
 use super::{migrate::open_database, util};
 
@@ -38,7 +38,8 @@ impl CommandDefinition for VerifyCommandDefinition {
 
         let db_client = open_database(database.as_deref()).await?;
         let database = util::extract_postgres_database(&model, None, use_ir).await?;
-        let verification_result = Migration::verify(&db_client, &database).await;
+        let verification_result =
+            Migration::verify(&db_client, &database, &migration_scope_from_env()).await;
 
         match &verification_result {
             Ok(()) => eprintln!("This model is compatible with the database schema!"),

--- a/crates/cli/src/commands/util.rs
+++ b/crates/cli/src/commands/util.rs
@@ -10,6 +10,7 @@
 use std::io::stdin;
 
 use clap::Arg;
+use exo_sql::schema::spec::{MigrationScope, MigrationScopeMatches, NameMatching};
 use rand::Rng;
 
 pub(super) fn generate_random_string() -> String {
@@ -36,4 +37,59 @@ pub(crate) fn use_ir_arg() -> Arg {
         .long("use-ir")
         .required(false)
         .num_args(0)
+}
+
+pub(crate) fn migration_scope_from_env() -> MigrationScope {
+    // The env of the form "schema1.table1, schema2.table2, schema3".
+    // - wildcards allowed for schema and table names (e.g. "*.table1" or "schema1.*")
+    // - table names defaults to '*' (e.g. "schema1" is equivalent to "schema1.*")
+    let scope_env = std::env::var("EXO_POSTGRES_MIGRATION_SCOPE").ok();
+
+    if let Some(scope_env) = scope_env {
+        let schema_and_table_names = scope_env
+            .trim()
+            .split(',')
+            .map(|s| {
+                let mut parts = s.trim().split('.');
+                let schema_name = parts.next().unwrap().trim();
+                let table_name = parts.next().unwrap_or("*").trim();
+                (
+                    NameMatching::new(schema_name),
+                    NameMatching::new(table_name),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        MigrationScope::Specified(MigrationScopeMatches(schema_and_table_names))
+    } else {
+        MigrationScope::FromNewSpec
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_migration_scope_from_env_with_no_env() {
+        std::env::remove_var("EXO_POSTGRES_MIGRATION_SCOPE");
+        assert_eq!(migration_scope_from_env(), MigrationScope::FromNewSpec);
+    }
+
+    #[test]
+    fn test_migration_scope_from_env_with_env() {
+        std::env::set_var(
+            "EXO_POSTGRES_MIGRATION_SCOPE",
+            "schema1.table1,*.table2,schema3.*, schema4",
+        );
+        assert_eq!(
+            migration_scope_from_env(),
+            MigrationScope::Specified(MigrationScopeMatches(vec![
+                (NameMatching::new("schema1"), NameMatching::new("table1")),
+                (NameMatching::new("*"), NameMatching::new("table2")),
+                (NameMatching::new("schema3"), NameMatching::new("*")),
+                (NameMatching::new("schema4"), NameMatching::new("*")),
+            ]))
+        );
+    }
 }

--- a/crates/cli/src/commands/util.rs
+++ b/crates/cli/src/commands/util.rs
@@ -71,13 +71,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_migration_scope_from_env_with_no_env() {
+    fn test_migration_scope_from_env() {
+        // Separating the non-env and env cases into separate tests makes the test
+        // flaky (since the test run parallelly and we one test may set the env
+        // variable and the other test may read it).
         std::env::remove_var("EXO_POSTGRES_MIGRATION_SCOPE");
         assert_eq!(migration_scope_from_env(), MigrationScope::FromNewSpec);
-    }
 
-    #[test]
-    fn test_migration_scope_from_env_with_env() {
         std::env::set_var(
             "EXO_POSTGRES_MIGRATION_SCOPE",
             "schema1.table1,*.table2,schema3.*, schema4",

--- a/crates/cli/src/commands/yolo.rs
+++ b/crates/cli/src/commands/yolo.rs
@@ -30,6 +30,8 @@ use crate::{
 };
 use common::env_const::{EXO_JWT_SECRET, EXO_POSTGRES_URL};
 
+use crate::commands::util::migration_scope_from_env;
+
 use super::command::{
     default_model_file, enforce_trusted_documents_arg, ensure_exo_project_dir, get, port_arg,
     seed_arg, setup_trusted_documents_enforcement, CommandDefinition,
@@ -147,7 +149,8 @@ async fn run_server(
 
     // generate migrations for current database
     let database = util::extract_postgres_database(model, None, false).await?;
-    let migrations = Migration::from_db_and_model(&db_client, &database).await?;
+    let migrations =
+        Migration::from_db_and_model(&db_client, &database, &migration_scope_from_env()).await?;
 
     // execute migration
     println!("Applying migrations...");

--- a/docs/docs/cli-reference/development/schema.md
+++ b/docs/docs/cli-reference/development/schema.md
@@ -75,6 +75,12 @@ The `exo schema migrate` command offers a couple of options:
 - The `--allow-destructive-changes` will not comment out destructive changes. If you are sure that you want to perform those changes, you can use this option.
 - The `--apply-to-database` will apply changes to the database. This option is useful when applying the changes without running a separate `psql` command.
 
+## Specifying the scope of the schema
+
+By default, the `schema` subcommand operates on all tables of schemas used in your project (specified using either `@postgres(schema="...")` or `@table(schema="...")` in your exo files). This works well for brownfield projects where you want to create a new Exograph project that works with an existing database but skip migrating other schemas (which would suggest deleting any tables not referenced in your exo files). 
+
+The default behavior works for most projects. However, you can specify a different migration scope using the `EXO_POSTGRES_MIGRATION_SCOPE` environment variable, which is a comma-separated list in the form: `<schema-wildcard>[.<table-wildcard>]?` with `table-wildcard` being set to `*` by default. For example, to migrate only the `public` and `concerts` schemas, you can set the `EXO_POSTGRES_MIGRATION_SCOPE` environment variable to `public.*,concerts.*`, or simply `public,concerts`. You may also specify a specific schema and table, for example, `public.concerts*` or even `*.concerts*`, etc.
+
 # Creating an Exograph model from an existing database
 
 :::warning

--- a/libs/exo-sql/Cargo.toml
+++ b/libs/exo-sql/Cargo.toml
@@ -46,6 +46,7 @@ tokio = { workspace = true, features = ["rt"] }
 tracing.workspace = true
 typed-generational-arena.workspace = true
 url.workspace = true
+wildmatch.workspace = true
 
 which = { workspace = true, optional = true }
 rand.workspace = true
@@ -75,3 +76,6 @@ features = ["testing", "postgres-url", "tls", "bigdecimal", "pool"]
 
 [lib]
 doctest = false
+
+[package.metadata.cargo-shear]
+ignored = ["exo-sql"]


### PR DESCRIPTION
Earlier, all `exo schema` subcommands (and schema migration invoked through `exo yolo` and `exo dev`) considered all tables in all schemas. In a brownfield project, this leads the migration logic to suggest dropping all tables not referenced.

With this change:
- By default, the `schema` subcommand operates on all schemas used in the exo project (specified using either `@postgres(schema="...")` or `@table(schema=...)` in exo files).
- Support specifying a different migration scope using the `EXO_POSTGRES_MIGRATION_SCOPE` environment variable, which is a comma-separated list in the form: `<schema-wildcard>[.<table-wildcard>?]` with `table-wildcard` being set to `*` by default. For example, to migrate only the `public` and `concerts` schemas, developers can set the `EXO_POSTGRES_MIGRATION_SCOPE` environment variable to `public.*,concerts.*`, or simply `public,concerts`. Developers may also specify a specific schema and table, for example, `public.concerts*` or even `*public*.concerts*.venue*`, etc.