### PR TITLE
Support initialization using SQL in integration tests

### DIFF
--- a/crates/testing/src/execution/integration_test.rs
+++ b/crates/testing/src/execution/integration_test.rs
@@ -34,7 +34,7 @@ use std::{collections::HashMap, time::SystemTime};
 
 use exo_env::MapEnvironment;
 
-use crate::model::{resolve_testvariable, IntegrationTest, IntegrationTestOperation};
+use crate::model::{resolve_testvariable, IntegrationTest, Operation};
 
 use super::assertion::{dynamic_assert_using_deno, evaluate_using_deno};
 use super::{TestResult, TestResultKind};
@@ -250,15 +250,12 @@ enum OperationResult {
     Fail(anyhow::Error),
 }
 
-async fn run_operation(
-    gql: &IntegrationTestOperation,
-    ctx: &mut TestfileContext,
-) -> Result<OperationResult> {
-    let IntegrationTestOperation {
+async fn run_operation(gql: &Operation, ctx: &mut TestfileContext) -> Result<OperationResult> {
+    let Operation {
         document,
-        operations_metadata,
+        metadata: operations_metadata,
         variables,
-        expected_payload,
+        expected_response: expected_payload,
         auth,
         headers,
         deno_prelude,

--- a/crates/testing/src/loader/integration_test.rs
+++ b/crates/testing/src/loader/integration_test.rs
@@ -18,9 +18,7 @@ use anyhow::{bail, Context, Result};
 use async_graphql_parser::parse_query;
 use serde::Deserialize;
 
-use crate::model::{
-    build_operations_metadata, IntegrationTest, IntegrationTestOperation, OperationsMetadata,
-};
+use crate::model::{build_operations_metadata, IntegrationTest, Operation, OperationMetadata};
 
 // serde file formats
 #[derive(Deserialize, Debug, Clone)]
@@ -79,10 +77,7 @@ impl IntegrationTest {
         project_dir.join("target").join("index.exo_ir")
     }
 
-    pub fn load(
-        testfile_path: &PathBuf,
-        init_ops: Vec<IntegrationTestOperation>,
-    ) -> Result<IntegrationTest> {
+    pub fn load(testfile_path: &PathBuf, init_ops: Vec<Operation>) -> Result<IntegrationTest> {
         let mut file = File::open(testfile_path).context("Could not open test file")?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)
@@ -124,15 +119,15 @@ impl IntegrationTest {
                         eprintln!(
                             "Invalid GraphQL document; defaulting test variables binding to empty"
                         );
-                        OperationsMetadata::default()
+                        OperationMetadata::default()
                     });
 
-                Ok(IntegrationTestOperation {
+                Ok(Operation {
                     document: stage.operation,
-                    operations_metadata,
+                    metadata: operations_metadata,
                     auth: stage.auth,
                     variables: stage.variable,
-                    expected_payload: stage.response,
+                    expected_response: stage.response,
                     headers: stage.headers,
                     deno_prelude: stage.deno,
                 })

--- a/crates/testing/src/loader/test_suite.rs
+++ b/crates/testing/src/loader/test_suite.rs
@@ -13,7 +13,7 @@ use wildmatch::WildMatch;
 
 use anyhow::Result;
 
-use crate::model::{IntegrationTest, IntegrationTestOperation, TestSuite};
+use crate::model::{IntegrationTest, Operation, TestSuite};
 
 impl TestSuite {
     /// Load and parse testfiles from a given directory and pattern.
@@ -42,7 +42,7 @@ impl TestSuite {
 
 fn load_tests_dir(
     test_directory: &Path, // directory that contains "src/index.exo"
-    init_ops: &[IntegrationTestOperation],
+    init_ops: &[Operation],
     pattern: &Option<String>,
 ) -> Result<Vec<IntegrationTest>> {
     // Begin directory traversal

--- a/crates/testing/src/loader/test_suite.rs
+++ b/crates/testing/src/loader/test_suite.rs
@@ -13,7 +13,7 @@ use wildmatch::WildMatch;
 
 use anyhow::Result;
 
-use crate::model::{IntegrationTest, Operation, TestSuite};
+use crate::model::{InitOperation, IntegrationTest, TestSuite};
 
 impl TestSuite {
     /// Load and parse testfiles from a given directory and pattern.
@@ -42,7 +42,7 @@ impl TestSuite {
 
 fn load_tests_dir(
     test_directory: &Path, // directory that contains "src/index.exo"
-    init_ops: &[Operation],
+    init_ops: &[InitOperation],
     pattern: &Option<String>,
 ) -> Result<Vec<IntegrationTest>> {
     // Begin directory traversal
@@ -81,8 +81,8 @@ fn load_tests_dir(
     let mut init_ops = init_ops.to_owned();
 
     for initfile_path in init_files.iter() {
-        let init_op = IntegrationTest::load(initfile_path, vec![])?;
-        init_ops.extend(init_op.test_operations);
+        let init_op = IntegrationTest::load_init_operations(initfile_path)?;
+        init_ops.extend(init_op);
     }
 
     // Parse test files

--- a/crates/testing/src/model/mod.rs
+++ b/crates/testing/src/model/mod.rs
@@ -24,13 +24,25 @@ pub struct TestSuite {
 pub struct IntegrationTest {
     pub testfile_path: PathBuf,
     pub retries: usize,
-    pub init_operations: Vec<Operation>,
-    pub test_operations: Vec<Operation>,
+    pub init_operations: Vec<InitOperation>,
+    pub test_operations: Vec<ApiOperation>,
     pub extra_envs: HashMap<String, String>, // extra envvars to be set when starting the exo server
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
-pub struct Operation {
+pub enum InitOperation {
+    Database(DatabaseOperation),
+    Api(ApiOperation),
+}
+
+#[derive(Debug, Clone)]
+pub struct DatabaseOperation {
+    pub sql: String, // SQL statements separated by semicolons
+}
+
+#[derive(Debug, Clone)]
+pub struct ApiOperation {
     pub document: String,
     pub metadata: OperationMetadata,
     pub variables: Option<String>, // stringified

--- a/crates/testing/src/model/mod.rs
+++ b/crates/testing/src/model/mod.rs
@@ -11,9 +11,7 @@ use std::{collections::HashMap, path::PathBuf};
 
 mod operations_metadata;
 
-pub use operations_metadata::{
-    build_operations_metadata, resolve_testvariable, OperationsMetadata,
-};
+pub use operations_metadata::{build_operations_metadata, resolve_testvariable, OperationMetadata};
 
 /// Tests for a particular model
 pub struct TestSuite {
@@ -26,18 +24,19 @@ pub struct TestSuite {
 pub struct IntegrationTest {
     pub testfile_path: PathBuf,
     pub retries: usize,
-    pub init_operations: Vec<IntegrationTestOperation>,
-    pub test_operations: Vec<IntegrationTestOperation>,
+    pub init_operations: Vec<Operation>,
+    pub test_operations: Vec<Operation>,
     pub extra_envs: HashMap<String, String>, // extra envvars to be set when starting the exo server
 }
 
 #[derive(Debug, Clone)]
-pub struct IntegrationTestOperation {
+pub struct Operation {
     pub document: String,
-    pub operations_metadata: OperationsMetadata,
-    pub variables: Option<String>,        // stringified
-    pub expected_payload: Option<String>, // stringified
+    pub metadata: OperationMetadata,
+    pub variables: Option<String>, // stringified
     pub deno_prelude: Option<String>,
     pub auth: Option<String>,    // stringified
     pub headers: Option<String>, // stringified
+
+    pub expected_response: Option<String>, // stringified
 }

--- a/crates/testing/src/model/operations_metadata.rs
+++ b/crates/testing/src/model/operations_metadata.rs
@@ -23,16 +23,16 @@ type SelectionElement = String;
 
 /// Meta-information about the operation defined in the test.
 #[derive(Clone, Debug, Default, Serialize)]
-pub struct OperationsMetadata {
+pub struct OperationMetadata {
     /// Bindings defined using the `@bind` directive.
     pub bindings: TestvariableBindings,
     /// Path whose order shouldn't be considered while asserting (based on the `@unordered` directive)
     pub unordered_paths: HashSet<SelectionPath>,
 }
 
-impl OperationsMetadata {
-    pub fn combine(elems: Vec<OperationsMetadata>) -> Self {
-        let mut res = OperationsMetadata::default();
+impl OperationMetadata {
+    pub fn combine(elems: Vec<OperationMetadata>) -> Self {
+        let mut res = OperationMetadata::default();
 
         for elem in elems {
             res.extend(elem);
@@ -76,7 +76,7 @@ impl OperationsMetadata {
 //
 // This function generates variable bindings from GraphQL fields marked with the @bind directive.
 // See unit tests for usage.
-pub fn build_operations_metadata(document: &ExecutableDocument) -> OperationsMetadata {
+pub fn build_operations_metadata(document: &ExecutableDocument) -> OperationMetadata {
     match &document.operations {
         DocumentOperations::Single(operation) => {
             let selection_set = &operation.node.selection_set.node;
@@ -87,7 +87,7 @@ pub fn build_operations_metadata(document: &ExecutableDocument) -> OperationsMet
                 HashSet::new(),
             )
         }
-        DocumentOperations::Multiple(operations) => OperationsMetadata::combine(
+        DocumentOperations::Multiple(operations) => OperationMetadata::combine(
             operations
                 .iter()
                 .map(|(_, operation)| {
@@ -109,7 +109,7 @@ fn process_selection_set(
     current_path: Vec<SelectionElement>,
     fragments: &HashMap<Name, Positioned<FragmentDefinition>>,
     fragment_trail: HashSet<String>,
-) -> OperationsMetadata {
+) -> OperationMetadata {
     let metadatas = selection_set
         .items
         .iter()
@@ -125,7 +125,7 @@ fn process_selection_set(
                     let mut new_path = current_path.clone();
                     new_path.push(field_name);
 
-                    let mut operations_metadata = OperationsMetadata::default();
+                    let mut operations_metadata = OperationMetadata::default();
 
                     if let Some(bind_directive) = field
                         .directives
@@ -213,7 +213,7 @@ fn process_selection_set(
         })
         .collect::<Vec<_>>();
 
-    OperationsMetadata::combine(metadatas)
+    OperationMetadata::combine(metadatas)
 }
 
 // Resolve the value of a test variable from `response` using its name and the set of variable bindings.


### PR DESCRIPTION
This allows testing brownfield scenarios (untracked tables, views, etc).