### PR TITLE
Minimize the GraphQL schema

### DIFF
--- a/crates/core-subsystem/core-model/src/mapped_arena.rs
+++ b/crates/core-subsystem/core-model/src/mapped_arena.rs
@@ -73,6 +73,11 @@ impl<V> MappedArena<V> {
     }
 
     pub fn add(&mut self, key: &str, typ: V) -> SerializableSlabIndex<V> {
+        let existing = self.get_id(key);
+        if let Some(existing) = existing {
+            return existing;
+        }
+
         let id = self.values.insert(typ);
         self.map.insert(key.to_string(), id);
         id

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/mutation_builder.rs
@@ -35,7 +35,6 @@ use postgres_core_model::{
 
 use crate::utils::{to_mutation_type, MutationTypeKind};
 use postgres_core_builder::access_utils::parent_predicate;
-use postgres_core_builder::shallow::Shallow;
 
 use postgres_core_builder::resolved_type::{
     ResolvedCompositeType, ResolvedField, ResolvedFieldTypeHelper, ResolvedType,
@@ -514,7 +513,7 @@ pub trait DataParamBuilder<D> {
             .get_by_key(&existing_type_name)
             .unwrap_or_else(|| panic!("Could not find type {existing_type_name} to expand"));
 
-        if existing.entity_id == SerializableSlabIndex::shallow() {
+        if existing.fields.is_empty() {
             // If not already expanded
             self.expanded_data_type(
                 field_type,


### PR DESCRIPTION
Earlier, we created many `TypeDefinition` that went unused. In this PR, we retain only those used by traversing from the root types (query, mutations, etc).