### PR TITLE
Allow untracked types to not have a primary key

### DIFF
--- a/crates/postgres-subsystem/postgres-graphql-builder/src/mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/mutation_builder.rs
@@ -107,14 +107,14 @@ pub trait MutationBuilder {
             return vec![];
         }
 
-        let single_mutation = PostgresMutation {
+        let single_mutation = entity_type.pk_field().map(|_| PostgresMutation {
             name: Self::single_mutation_name(entity_type),
             parameters: Self::single_mutation_parameters(entity_type, building),
             return_type: Self::single_mutation_modified_type(BaseOperationReturnType {
                 associated_type_id: entity_type_id,
                 type_name: entity_type.name.clone(),
             }),
-        };
+        });
 
         let multi_mutation = PostgresMutation {
             name: Self::multi_mutation_name(entity_type),
@@ -127,7 +127,10 @@ pub trait MutationBuilder {
             ))),
         };
 
-        vec![single_mutation, multi_mutation]
+        match single_mutation {
+            Some(single_mutation) => vec![single_mutation, multi_mutation],
+            None => vec![multi_mutation],
+        }
     }
 }
 

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/type_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/type_builder.rs
@@ -34,10 +34,11 @@ fn expand_query_mutation_map(
     resolved_type: &ResolvedCompositeType,
     building: &mut SystemContextBuilding,
 ) {
-    let pk_query = building
-        .pk_queries
-        .get_id(&resolved_type.pk_query())
-        .unwrap();
+    let existing_type_id = building.get_entity_type_id(&resolved_type.name).unwrap();
+
+    if let Some(pk_query) = building.pk_queries.get_id(&resolved_type.pk_query()) {
+        building.pk_queries_map.insert(existing_type_id, pk_query);
+    }
 
     let collection_query = building
         .collection_queries
@@ -49,9 +50,6 @@ fn expand_query_mutation_map(
         .get_id(&resolved_type.aggregate_query())
         .unwrap();
 
-    let existing_type_id = building.get_entity_type_id(&resolved_type.name).unwrap();
-
-    building.pk_queries_map.insert(existing_type_id, pk_query);
     building
         .collection_queries_map
         .insert(existing_type_id, collection_query);

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/postgres_mutation.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/postgres_mutation.rs
@@ -7,11 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::{
-    auth_util::check_access,
-    sql_mapper::SQLOperationKind,
-    util::{find_arg, return_type_info},
-};
+use super::{auth_util::check_access, sql_mapper::SQLOperationKind, util::find_arg};
 
 use postgres_core_resolver::postgres_execution_error::PostgresExecutionError;
 
@@ -131,7 +127,7 @@ async fn delete_operation<'content>(
     subsystem: &'content PostgresGraphQLSubsystem,
     request_context: &'content RequestContext<'content>,
 ) -> Result<AbstractDelete, PostgresExecutionError> {
-    let (table_id, _, _) = return_type_info(return_type, subsystem);
+    let table_id = subsystem.core_subsystem.entity_types[return_type.typ_id()].table_id;
 
     let access_predicate = check_access(
         return_type.typ(&subsystem.core_subsystem.entity_types),

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/update_data_param_mapper.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/update_data_param_mapper.rs
@@ -29,7 +29,7 @@ use postgres_graphql_model::{
 use crate::{
     auth_util::check_access,
     sql_mapper::{SQLMapper, SQLOperationKind},
-    util::{get_argument_field, return_type_info},
+    util::get_argument_field,
 };
 
 use postgres_core_resolver::{cast, postgres_execution_error::PostgresExecutionError};
@@ -52,7 +52,9 @@ impl<'a> SQLMapper<'a, AbstractUpdate> for UpdateOperation<'a> {
         let data_type = &subsystem.mutation_types[self.data_param.typ.innermost().type_id];
 
         let self_update_columns = compute_update_columns(data_type, argument, subsystem);
-        let (table_id, _, _) = return_type_info(self.return_type, subsystem);
+
+        let return_type = &subsystem.core_subsystem.entity_types[self.return_type.typ_id()];
+        let table_id = return_type.table_id;
 
         let (nested_updates, nested_inserts, nested_deletes) =
             compute_nested_ops(data_type, argument, subsystem, request_context).await?;

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/util.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/util.rs
@@ -9,15 +9,7 @@
 
 use indexmap::IndexMap;
 
-use postgres_core_model::types::EntityType;
-
 use common::value::Val;
-use core_plugin_interface::core_model::types::OperationReturnType;
-use exo_sql::TableId;
-use postgres_graphql_model::{
-    query::{CollectionQuery, PkQuery},
-    subsystem::PostgresGraphQLSubsystem,
-};
 
 use postgres_core_resolver::postgres_execution_error::PostgresExecutionError;
 
@@ -63,21 +55,4 @@ pub(super) fn to_pg_vector(
     }?;
 
     Ok(vec_value)
-}
-
-///
-/// # Returns
-/// - A (table associated with the return type, pk query, collection query) tuple.
-pub(crate) fn return_type_info<'a>(
-    return_type: &'a OperationReturnType<EntityType>,
-    subsystem: &'a PostgresGraphQLSubsystem,
-) -> (TableId, &'a PkQuery, &'a CollectionQuery) {
-    let typ_id = return_type.typ_id();
-    let typ = &subsystem.core_subsystem.entity_types[typ_id];
-
-    (
-        typ.table_id,
-        subsystem.get_pk_query(typ_id),
-        subsystem.get_collection_query(typ_id),
-    )
 }

--- a/docs/docs/postgres/customizing-types.md
+++ b/docs/docs/postgres/customizing-types.md
@@ -149,8 +149,10 @@ Exograph will map the `ProductProfit` type to the `product_profits` view (it cou
 
 Exograph will apply access control and infer queries for the `ProductProfit` type as usual, including [aggregated queries](operations/queries.md#aggregated-query).
 
+An untracked type may skip marking a field as `@pk` if it doesn't have a primary key. For such a type, Exograph offers only collection and aggregate queries. For example, the `ProductProfit` type will have the `productProfits` and `productProfitsAgg` query but not the `productProfit` query (which would take the primary key as an argument).
+
 :::warning
-You must set `mutation=false` for any untracked type and mark a field as the primary key. We will lift this restriction in the future.
+You must set `mutation=false` for any untracked type. We will lift this restriction in the future.
 :::
 
 ## Field-level customization

--- a/docs/docs/postgres/customizing-types.md
+++ b/docs/docs/postgres/customizing-types.md
@@ -102,10 +102,22 @@ Use the `@plural` annotation to deal with type names with irregular pluralizatio
 
 ### Using untracked tables
 
-Sometimes, you may want to use a table or view that already exists in your database. For example, you may want to use a view or a foreign table that you have created in your database. Exograph supports this use case using the `tracked=false` attribute of the `@table` annotation.
+Sometimes, you may want to expose a view or a foreign table in your database through Exograph APIs. For this purpose, you may use the `tracked=false` attribute of the `@table` annotation.
 
+Consider the following view:
 
-For example, to use the `product_profits` view, you can define the following Exograph module:
+```sql
+CREATE VIEW product_profits AS
+SELECT
+    p.id,
+    p.name,
+    p.sale_price,
+    p.purchase_price,
+    p.sale_price - p.purchase_price AS profit
+FROM products p;
+```
+
+You can define a type for this view as follows:
 
 ```exo
 @postgres
@@ -132,28 +144,26 @@ module TodoDatabase {
 }
 ```
 
-Here, we assume that you have the following `product_profits` view in your database:
+Exograph will map the `ProductProfit` type to the `product_profits` view (it could also be a table). However, Exograph will ignore the `ProductProfit` type for schema migration.
 
-```sql
-CREATE VIEW product_profits AS
-SELECT
-    p.id,
-    p.name,
-    p.sale_price,
-    p.purchase_price,
-    p.sale_price - p.purchase_price AS profit
-FROM products p;
+Exograph will apply access control and infer queries for the `ProductProfit` type as usual, including [aggregated queries](operations/queries.md#aggregated-query). If you have an untracked type representing a view, you will want to set `mutation=false`, thus removing the mutation APIs for untracked types. However, this is not a restriction imposed by Exograph. Therefore, you may put any other access control rules if you want to modify the underlying data through the tracked type.
+
+If you allow mutation through a tracked type for a view, you will want to make any derived fields read-only. For example, if you allow mutation through the `ProductProfit` type, you will want to make the `profit` field read-only.
+
+```exo
+  @table(tracked=false)
+  @access(query=true, mutation=true)
+  type ProductProfit {
+    @pk id: Int
+    name: String
+    salePrice: Float
+    purchasePrice: Float
+    // highlight-next-line
+    @readonly profit: Float
+  }
 ```
 
-Exograph will map the `ProductProfit` type to the `product_profits` view (it could also be a table). However, Exograph will ignore the `ProductProfit` type for schema migration. 
-
-Exograph will apply access control and infer queries for the `ProductProfit` type as usual, including [aggregated queries](operations/queries.md#aggregated-query).
-
 An untracked type may skip marking a field as `@pk` if it doesn't have a primary key. For such a type, Exograph offers only collection and aggregate queries. For example, the `ProductProfit` type will have the `productProfits` and `productProfitsAgg` query but not the `productProfit` query (which would take the primary key as an argument).
-
-:::warning
-You must set `mutation=false` for any untracked type. We will lift this restriction in the future.
-:::
 
 ## Field-level customization
 

--- a/integration-tests/untracked-views/no-auth/src/index.exo
+++ b/integration-tests/untracked-views/no-auth/src/index.exo
@@ -10,12 +10,12 @@ module TodoDatabase {
   }
 
   @table(tracked=false)
-  @access(query=true, mutation=false)
+  @access(true)
   type ProductProfit {
-    @pk id: Int
+    @pk id: Int = autoIncrement()
     name: String
     salePrice: Float
     purchasePrice: Float
-    profit: Float
+    @readonly profit: Float
   }
 }

--- a/integration-tests/untracked-views/no-auth/tests/create-through-view.exotest
+++ b/integration-tests/untracked-views/no-auth/tests/create-through-view.exotest
@@ -1,0 +1,97 @@
+
+stages:
+  - operation: |
+        mutation {
+          createProductProfit(data: { name: "P3", salePrice: 80, purchasePrice: 50 }) {
+            id @bind(name: "p3Id")
+            name
+            salePrice
+            purchasePrice
+            profit
+          }
+        }
+    response: |
+        {
+          "data": {
+            "createProductProfit": {
+              "id": $.p3Id,
+              "name": "P3",
+              "salePrice": 80,
+              "purchasePrice": 50,
+              "profit": 30
+            }
+          }
+        }
+  - operation: |
+        query {
+          productProfits @unordered {
+            id
+            name
+            salePrice
+            purchasePrice
+            profit
+          }
+        }
+    response: |
+        {
+          "data": {
+            "productProfits": [
+              {
+                "id": $.p1Id,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+                "profit": 50
+              },
+              {
+                "id": $.p2Id,
+                "name": "P2",
+                "salePrice": 20,
+                "purchasePrice": 30,
+                "profit": -10
+              },
+              {
+                "id": $.p3Id,
+                "name": "P3",
+                "salePrice": 80,
+                "purchasePrice": 50,
+                "profit": 30
+              }
+            ]
+          }
+        }
+  - operation: |
+        query {
+          products @unordered {
+            id
+            name
+            salePrice
+            purchasePrice
+          }
+        }
+    response: |
+        {
+          "data": {
+            "products": [
+              {
+                "id": $.p1Id,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+              },
+              {
+                "id": $.p2Id,
+                "name": "P2",
+                "salePrice": 20,
+                "purchasePrice": 30,
+              },
+              {
+                "id": $.p3Id,
+                "name": "P3",
+                "salePrice": 80,
+                "purchasePrice": 50,
+              }
+            ]
+          }
+        }
+      

--- a/integration-tests/untracked-views/no-auth/tests/delete-through-view.exotest
+++ b/integration-tests/untracked-views/no-auth/tests/delete-through-view.exotest
@@ -1,0 +1,75 @@
+
+stages:
+  - operation: |
+        mutation($id: Int!) {
+          deleteProductProfit(id: $id) {
+            id
+            name
+            salePrice
+            purchasePrice
+            profit
+          }
+        }
+    variable: |
+      {
+        "id": $.p2Id
+      }
+    response: |
+      {
+        "data": {
+          "deleteProductProfit": {
+            "id": $.p2Id,
+            "name": "P2",
+            "salePrice": 20,
+            "purchasePrice": 30,
+            "profit": -10
+          }
+        }
+      }
+  - operation: |
+      query {
+        productProfits @unordered {
+          id
+          name
+          salePrice
+          purchasePrice
+          profit
+        }
+      }
+    response: |
+        {
+          "data": {
+            "productProfits": [
+              {
+                "id": $.p1Id,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+                "profit": 50
+              }
+            ]
+          }
+        }
+  - operation: |
+        query {
+          products @unordered {
+            id
+            name
+            salePrice
+            purchasePrice
+          }
+        }
+    response: |
+        {
+          "data": {
+            "products": [
+              {
+                "id": $.p1Id,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+              }
+            ]
+          }
+        }
+      

--- a/integration-tests/untracked-views/no-auth/tests/update-through-view.exotest
+++ b/integration-tests/untracked-views/no-auth/tests/update-through-view.exotest
@@ -1,0 +1,88 @@
+
+stages:
+  - operation: |
+        mutation($id: Int!) {
+          updateProductProfit(id: $id, data: { name: "P2-updated", salePrice: 800, purchasePrice: 500 }) {
+            id
+            name
+            salePrice
+            purchasePrice
+            profit
+          }
+        }
+    variable: |
+      {
+        "id": $.p2Id
+      }
+    response: |
+        {
+          "data": {
+            "updateProductProfit": {
+              "id": $.p2Id,
+              "name": "P2-updated",
+              "salePrice": 800,
+              "purchasePrice": 500,
+              "profit": 300
+            }
+          }
+        }
+  - operation: |
+        query {
+          productProfits @unordered {
+            id
+            name
+            salePrice
+            purchasePrice
+            profit
+          }
+        }
+    response: |
+        {
+          "data": {
+            "productProfits": [
+              {
+                "id": $.p1Id,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+                "profit": 50
+              },
+              {
+                "id": $.p2Id,
+                "name": "P2-updated",
+                "salePrice": 800,
+                "purchasePrice": 500,
+                "profit": 300
+              }
+            ]
+          }
+        }
+  - operation: |
+        query {
+          products @unordered {
+            id
+            name
+            salePrice
+            purchasePrice
+          }
+        }
+    response: |
+        {
+          "data": {
+            "products": [
+              {
+                "id": $.p1Id,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+              },
+              {
+                "id": $.p2Id,
+                "name": "P2-updated",
+                "salePrice": 800,
+                "purchasePrice": 500,
+              }
+            ]
+          }
+        }
+      

--- a/integration-tests/untracked-views/no-pk/src/index.exo
+++ b/integration-tests/untracked-views/no-pk/src/index.exo
@@ -10,12 +10,12 @@ module TodoDatabase {
   }
 
   @table(tracked=false)
-  @access(query=true, mutation=false)
+  @access(query=true, delete=true, update=true) // Not allowed to create (what PK would be?)
   type ProductProfit {
     id: Int
     name: String
     salePrice: Float
     purchasePrice: Float
-    profit: Float
+    @readonly profit: Float
   }
 }

--- a/integration-tests/untracked-views/no-pk/src/index.exo
+++ b/integration-tests/untracked-views/no-pk/src/index.exo
@@ -1,0 +1,21 @@
+
+@postgres
+module TodoDatabase {
+  @access(true)
+  type Product {
+    @pk id: Int = autoIncrement()
+    name: String
+    salePrice: Float
+    purchasePrice: Float
+  }
+
+  @table(tracked=false)
+  @access(query=true, mutation=false)
+  type ProductProfit {
+    id: Int
+    name: String
+    salePrice: Float
+    purchasePrice: Float
+    profit: Float
+  }
+}

--- a/integration-tests/untracked-views/no-pk/tests/collection-queries.exotest
+++ b/integration-tests/untracked-views/no-pk/tests/collection-queries.exotest
@@ -1,0 +1,98 @@
+
+stages:
+  - operation: |
+        fragment productProfitFragment on ProductProfit {
+          id
+          name
+          salePrice
+          purchasePrice
+          profit
+        }
+        query {
+          all: productProfits @unordered {
+            ...productProfitFragment
+          }
+          allOrderedAsc: productProfits(orderBy: {profit: ASC}) {
+            ...productProfitFragment
+          }
+          allOrderedDesc: productProfits(orderBy: {profit: DESC}) {
+            ...productProfitFragment
+          }
+          allProfitable: productProfits(where: {profit: {gt: 0}}) {
+            ...productProfitFragment
+          }
+          allUnprofitable: productProfits(where: {profit: {lt: 0}}) {
+            ...productProfitFragment
+          }
+        }
+    response: |
+        {
+          "data": {
+            "all": [
+              {
+                "id": 1,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+                "profit": 50
+              },
+              {
+                "id": 2,
+                "name": "P2",
+                "salePrice": 20,
+                "purchasePrice": 30,
+                "profit": -10
+              }
+            ],
+            "allOrderedAsc": [
+              {
+                "id": 2,
+                "name": "P2",
+                "salePrice": 20,
+                "purchasePrice": 30,
+                "profit": -10
+              },
+              {
+                "id": 1,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+                "profit": 50
+              }
+            ],
+            "allOrderedDesc": [
+              {
+                "id": 1,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+                "profit": 50
+              },
+              {
+                "id": 2,
+                "name": "P2",
+                "salePrice": 20,
+                "purchasePrice": 30,
+                "profit": -10
+              }
+            ],
+            "allProfitable": [
+              {
+                "id": 1,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+                "profit": 50
+              }
+            ],
+            "allUnprofitable": [
+              {
+                "id": 2,
+                "name": "P2",
+                "salePrice": 20,
+                "purchasePrice": 30,
+                "profit": -10
+              }
+            ]
+          }
+        }

--- a/integration-tests/untracked-views/no-pk/tests/delete-through-view.exotest
+++ b/integration-tests/untracked-views/no-pk/tests/delete-through-view.exotest
@@ -1,0 +1,73 @@
+
+stages:
+  - operation: |
+        mutation {
+          deleteProductProfits(where: { salePrice: { lt: 50 } }) {
+            id
+            name
+            salePrice
+            purchasePrice
+            profit
+          }
+        }
+    response: |
+      {
+        "data": {
+          "deleteProductProfits": [
+            {
+              "id": $.p2Id,
+              "name": "P2",
+              "salePrice": 20,
+              "purchasePrice": 30,
+              "profit": -10
+            }
+          ]
+        }
+      }
+  - operation: |
+      query {
+        productProfits @unordered {
+          id
+          name
+          salePrice
+          purchasePrice
+          profit
+        }
+      }
+    response: |
+        {
+          "data": {
+            "productProfits": [
+              {
+                "id": $.p1Id,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+                "profit": 50
+              }
+            ]
+          }
+        }
+  - operation: |
+        query {
+          products @unordered {
+            id
+            name
+            salePrice
+            purchasePrice
+          }
+        }
+    response: |
+        {
+          "data": {
+            "products": [
+              {
+                "id": $.p1Id,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+              }
+            ]
+          }
+        }
+      

--- a/integration-tests/untracked-views/no-pk/tests/init-add-products.gql
+++ b/integration-tests/untracked-views/no-pk/tests/init-add-products.gql
@@ -1,0 +1,9 @@
+operation: |
+    mutation {
+        profitable: createProduct(data: {name: "P1", salePrice: 100, purchasePrice: 50}) {
+            id @bind(name: "p1Id")
+        }
+        unprofitable: createProduct(data: {name: "P2", salePrice: 20, purchasePrice: 30}) {
+            id @bind(name: "p2Id")
+        }
+    }

--- a/integration-tests/untracked-views/no-pk/tests/init-create-views.sql
+++ b/integration-tests/untracked-views/no-pk/tests/init-create-views.sql
@@ -1,0 +1,9 @@
+CREATE VIEW product_profits AS
+SELECT
+    p.id,
+    p.name,
+    p.sale_price,
+    p.purchase_price,
+    p.sale_price - p.purchase_price AS profit
+FROM products p;
+

--- a/integration-tests/untracked-views/no-pk/tests/single-query.exotest
+++ b/integration-tests/untracked-views/no-pk/tests/single-query.exotest
@@ -1,0 +1,30 @@
+
+stages:
+  - operation: |
+        query($p1Id: Int!) {
+          productProfit(id: $p1Id) {
+            id
+            name
+            salePrice
+            purchasePrice
+            profit
+          }
+        }
+    variable: |
+      {
+        "p1Id": $.p1Id,
+      }
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Field 'productProfit' is not valid for type 'Query'",
+            "locations": [
+              {
+                "line": 2,
+                "column": 3
+              }
+            ]
+          }
+        ]
+      }

--- a/integration-tests/untracked-views/no-pk/tests/update-through-view.exotest
+++ b/integration-tests/untracked-views/no-pk/tests/update-through-view.exotest
@@ -1,0 +1,86 @@
+
+stages:
+  - operation: |
+        mutation {
+          updateProductProfits(where: { salePrice: { lt: 50 } }, data: { name: "inexpensive" }) {
+            id
+            name
+            salePrice
+            purchasePrice
+            profit
+          }
+        }
+    response: |
+      {
+        "data": {
+          "updateProductProfits": [
+            {
+              "id": $.p2Id,
+              "name": "inexpensive",
+              "salePrice": 20,
+              "purchasePrice": 30,
+              "profit": -10
+            }
+          ]
+        }
+      }
+  - operation: |
+      query {
+        productProfits @unordered {
+          id
+          name
+          salePrice
+          purchasePrice
+          profit
+        }
+      }
+    response: |
+        {
+          "data": {
+            "productProfits": [
+              {
+                "id": $.p1Id,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+                "profit": 50
+              },
+              {
+                "id": $.p2Id,
+                "name": "inexpensive",
+                "salePrice": 20,
+                "purchasePrice": 30,
+                "profit": -10
+              }
+            ]
+          }
+        }
+  - operation: |
+        query {
+          products @unordered {
+            id
+            name
+            salePrice
+            purchasePrice
+          }
+        }
+    response: |
+        {
+          "data": {
+            "products": [
+              {
+                "id": $.p1Id,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+              },
+              {
+                "id": $.p2Id,
+                "name": "inexpensive",
+                "salePrice": 20,
+                "purchasePrice": 30,
+              }
+            ]
+          }
+        }
+      

--- a/integration-tests/untracked-views/with-auth/src/index.exo
+++ b/integration-tests/untracked-views/with-auth/src/index.exo
@@ -12,14 +12,14 @@ module TodoDatabase {
     purchasePrice: Int
   }
 
-  // Non-admin users can only see profitable products
+  // Non-admin users can only see profitable products and only admin can create/update/delete them
   @table(tracked=false)
-  @access(query=AuthContext.role == "admin" || self.profit > 0, mutation=false)
+  @access(query=AuthContext.role == "admin" || self.profit > 0, mutation=AuthContext.role == "admin")
   type ProductProfit {
-    @pk id: Int
+    @pk id: Int = autoIncrement()
     name: String
     salePrice: Int
     purchasePrice: Int
-    profit: Int
+    @readonly profit: Int
   }
 }

--- a/integration-tests/untracked-views/with-auth/tests/create-through-view-admin.exotest
+++ b/integration-tests/untracked-views/with-auth/tests/create-through-view-admin.exotest
@@ -1,0 +1,109 @@
+
+stages:
+  - operation: |
+        mutation {
+          createProductProfit(data: { name: "P3", salePrice: 80, purchasePrice: 50 }) {
+            id @bind(name: "p3Id")
+            name
+            salePrice
+            purchasePrice
+            profit
+          }
+        }
+    auth: |
+      {
+        "role": "admin"
+      }
+    response: |
+        {
+          "data": {
+            "createProductProfit": {
+              "id": $.p3Id,
+              "name": "P3",
+              "salePrice": 80,
+              "purchasePrice": 50,
+              "profit": 30
+            }
+          }
+        }
+  - operation: |
+        query {
+          productProfits @unordered {
+            id
+            name
+            salePrice
+            purchasePrice
+            profit
+          }
+        }
+    auth: |
+      {
+        "role": "admin"
+      }        
+    response: |
+        {
+          "data": {
+            "productProfits": [
+              {
+                "id": $.p1Id,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+                "profit": 50
+              },
+              {
+                "id": $.p2Id,
+                "name": "P2",
+                "salePrice": 20,
+                "purchasePrice": 30,
+                "profit": -10
+              },
+              {
+                "id": $.p3Id,
+                "name": "P3",
+                "salePrice": 80,
+                "purchasePrice": 50,
+                "profit": 30
+              }
+            ]
+          }
+        }
+  - operation: |
+        query {
+          products @unordered {
+            id
+            name
+            salePrice
+            purchasePrice
+          }
+        }
+    auth: |
+      {
+        "role": "admin"
+      }        
+    response: |
+        {
+          "data": {
+            "products": [
+              {
+                "id": $.p1Id,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+              },
+              {
+                "id": $.p2Id,
+                "name": "P2",
+                "salePrice": 20,
+                "purchasePrice": 30,
+              },
+              {
+                "id": $.p3Id,
+                "name": "P3",
+                "salePrice": 80,
+                "purchasePrice": 50,
+              }
+            ]
+          }
+        }
+      

--- a/integration-tests/untracked-views/with-auth/tests/create-through-view-user.exotest
+++ b/integration-tests/untracked-views/with-auth/tests/create-through-view-user.exotest
@@ -1,0 +1,93 @@
+
+stages:
+  - operation: |
+        mutation {
+          createProductProfit(data: { name: "P3", salePrice: 80, purchasePrice: 50 }) {
+            id
+            name
+            salePrice
+            purchasePrice
+            profit
+          }
+        }
+    auth: |
+      {
+        "role": "user"
+      }
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Not authorized"
+          }
+        ]
+      }
+
+  - operation: |
+        query {
+          productProfits @unordered {
+            id
+            name
+            salePrice
+            purchasePrice
+            profit
+          }
+        }
+    auth: |
+      {
+        "role": "admin"
+      }
+    response: |
+        {
+          "data": {
+            "productProfits": [
+              {
+                "id": $.p1Id,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+                "profit": 50
+              },
+              {
+                "id": $.p2Id,
+                "name": "P2",
+                "salePrice": 20,
+                "purchasePrice": 30,
+                "profit": -10
+              }
+            ]
+          }
+        }
+  - operation: |
+        query {
+          products @unordered {
+            id
+            name
+            salePrice
+            purchasePrice
+          }
+        }
+    auth: |
+      {
+        "role": "admin"
+      }
+    response: |
+        {
+          "data": {
+            "products": [
+              {
+                "id": $.p1Id,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+              },
+              {
+                "id": $.p2Id,
+                "name": "P2",
+                "salePrice": 20,
+                "purchasePrice": 30,
+              }
+            ]
+          }
+        }
+      

--- a/integration-tests/untracked-views/with-auth/tests/delete-through-view-admin.exotest
+++ b/integration-tests/untracked-views/with-auth/tests/delete-through-view-admin.exotest
@@ -1,0 +1,87 @@
+
+stages:
+  - operation: |
+        mutation($id: Int!) {
+          deleteProductProfit(id: $id) {
+            id
+            name
+            salePrice
+            purchasePrice
+            profit
+          }
+        }
+    variable: |
+      {
+        "id": $.p2Id
+      }
+    auth: |
+      {
+        "role": "admin"
+      }
+    response: |
+        {
+          "data": {
+            "deleteProductProfit": {
+              "id": $.p2Id,
+              "name": "P2",
+              "salePrice": 20,
+              "purchasePrice": 30,
+              "profit": -10
+            }
+          }
+        }
+  - operation: |
+        query {
+          productProfits @unordered {
+            id
+            name
+            salePrice
+            purchasePrice
+            profit
+          }
+        }
+    auth: |
+      {
+        "role": "admin"
+      }
+    response: |
+        {
+          "data": {
+            "productProfits": [
+              {
+                "id": $.p1Id,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+                "profit": 50
+              }
+            ]
+          }
+        }
+  - operation: |
+        query {
+          products @unordered {
+            id
+            name
+            salePrice
+            purchasePrice
+          }
+        }
+    auth: |
+      {
+        "role": "admin"
+      }
+    response: |
+        {
+          "data": {
+            "products": [
+              {
+                "id": $.p1Id,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+              }
+            ]
+          }
+        }
+      

--- a/integration-tests/untracked-views/with-auth/tests/delete-through-view-user.exotest
+++ b/integration-tests/untracked-views/with-auth/tests/delete-through-view-user.exotest
@@ -1,0 +1,97 @@
+
+stages:
+  - operation: |
+        mutation($id: Int!) {
+          deleteProductProfit(id: $id) {
+            id
+            name
+            salePrice
+            purchasePrice
+            profit
+          }
+        }
+    variable: |
+      {
+        "id": $.p2Id
+      }
+    auth: |
+      {
+        "role": "user"
+      }
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Not authorized"
+          }
+        ]
+      }
+
+  - operation: |
+        query {
+          productProfits @unordered {
+            id
+            name
+            salePrice
+            purchasePrice
+            profit
+          }
+        }
+    auth: |
+      {
+        "role": "admin"
+      }
+    response: |
+        {
+          "data": {
+            "productProfits": [
+              {
+                "id": $.p1Id,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+                "profit": 50
+              },
+              {
+                "id": $.p2Id,
+                "name": "P2",
+                "salePrice": 20,
+                "purchasePrice": 30,
+                "profit": -10
+              }
+            ]
+          }
+        }
+  - operation: |
+        query {
+          products @unordered {
+            id
+            name
+            salePrice
+            purchasePrice
+          }
+        }
+    auth: |
+      {
+        "role": "admin"
+      }
+    response: |
+        {
+          "data": {
+            "products": [
+              {
+                "id": $.p1Id,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+              },
+              {
+                "id": $.p2Id,
+                "name": "P2",
+                "salePrice": 20,
+                "purchasePrice": 30
+              }
+            ]
+          }
+        }
+      

--- a/integration-tests/untracked-views/with-auth/tests/update-through-view-admin.exotest
+++ b/integration-tests/untracked-views/with-auth/tests/update-through-view-admin.exotest
@@ -1,0 +1,100 @@
+
+stages:
+  - operation: |
+        mutation($id: Int!) {
+          updateProductProfit(id: $id, data: { name: "P2-updated" }) {
+            id
+            name
+            salePrice
+            purchasePrice
+            profit
+          }
+        }
+    variable: |
+      {
+        "id": $.p2Id
+      }
+    auth: |
+      {
+        "role": "admin"
+      }
+    response: |
+        {
+          "data": {
+            "updateProductProfit": {
+              "id": $.p2Id,
+              "name": "P2-updated",
+              "salePrice": 20,
+              "purchasePrice": 30,
+              "profit": -10
+            }
+          }
+        }
+  - operation: |
+        query {
+          productProfits @unordered {
+            id
+            name
+            salePrice
+            purchasePrice
+            profit
+          }
+        }
+    auth: |
+      {
+        "role": "admin"
+      }
+    response: |
+        {
+          "data": {
+            "productProfits": [
+              {
+                "id": $.p1Id,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+                "profit": 50
+              },
+              {
+                "id": $.p2Id,
+                "name": "P2-updated",
+                "salePrice": 20,
+                "purchasePrice": 30,
+                "profit": -10
+              }
+            ]
+          }
+        }
+  - operation: |
+        query {
+          products @unordered {
+            id
+            name
+            salePrice
+            purchasePrice
+          }
+        }
+    auth: |
+      {
+        "role": "admin"
+      }
+    response: |
+        {
+          "data": {
+            "products": [
+              {
+                "id": $.p1Id,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+              },
+              {
+                "id": $.p2Id,
+                "name": "P2-updated",
+                "salePrice": 20,
+                "purchasePrice": 30,
+              }
+            ]
+          }
+        }
+      

--- a/integration-tests/untracked-views/with-auth/tests/update-through-view-user.exotest
+++ b/integration-tests/untracked-views/with-auth/tests/update-through-view-user.exotest
@@ -1,0 +1,97 @@
+
+stages:
+  - operation: |
+        mutation($id: Int!) {
+          updateProductProfit(id: $id, data: { name: "P2-updated" }) {
+            id
+            name
+            salePrice
+            purchasePrice
+            profit
+          }
+        }
+    variable: |
+      {
+        "id": $.p2Id
+      }
+    auth: |
+      {
+        "role": "user"
+      }
+    response: |
+        {
+          "errors": [
+            {
+              "message": "Not authorized"
+            }
+          ]
+        }
+
+  - operation: |
+        query {
+          productProfits @unordered {
+            id
+            name
+            salePrice
+            purchasePrice
+            profit
+          }
+        }
+    auth: |
+      {
+        "role": "admin"
+      }
+    response: |
+        {
+          "data": {
+            "productProfits": [
+              {
+                "id": $.p1Id,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+                "profit": 50
+              },
+              {
+                "id": $.p2Id,
+                "name": "P2",
+                "salePrice": 20,
+                "purchasePrice": 30,
+                "profit": -10
+              }
+            ]
+          }
+        }
+  - operation: |
+        query {
+          products @unordered {
+            id
+            name
+            salePrice
+            purchasePrice
+          }
+        }
+    auth: |
+      {
+        "role": "admin"
+      }
+    response: |
+        {
+          "data": {
+            "products": [
+              {
+                "id": $.p1Id,
+                "name": "P1",
+                "salePrice": 100,
+                "purchasePrice": 50,
+              },
+              {
+                "id": $.p2Id,
+                "name": "P2",
+                "salePrice": 20,
+                "purchasePrice": 30,
+              }
+            ]
+          }
+        }
+      


### PR DESCRIPTION
This let's accommodate more varied view definitions. For such a type, Exograph does not infer the query that takes the primary key as the parameter.