### PR TITLE
Simplify passing of configuration to playground

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6708,6 +6708,8 @@ dependencies = [
  "http 1.1.0",
  "include_dir",
  "mime_guess",
+ "serde",
+ "serde_json",
  "which 6.0.3",
 ]
 

--- a/crates/playground-router/Cargo.toml
+++ b/crates/playground-router/Cargo.toml
@@ -9,6 +9,8 @@ mime_guess = "2.0.5"
 async-trait.workspace = true
 include_dir.workspace = true
 http.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 
 common = { path = "../common" }
 exo-env = { path = "../../libs/exo-env" }

--- a/graphiql/app/index.html
+++ b/graphiql/app/index.html
@@ -11,10 +11,7 @@
 
     <title>Exograph Playground</title>
     <script>
-      window.exoGraphQLHttpPath = "%%GRAPHQL_HTTP_PATH%%";
-      window.exoUpstreamGraphQLEndpoint = "%%UPSTREAM_ENDPOINT_URL%%";
-      window.enableSchemaLiveUpdate = %%ENABLE_INTROSPECTION_LIVE_UPDATE%%;
-      window.exoOidcUrl = "%%OIDC_URL%%";
+      window.exoConfig = {};
     </script>
   </head>
 

--- a/graphiql/app/src/config.d.ts
+++ b/graphiql/app/src/config.d.ts
@@ -1,0 +1,12 @@
+// Make sure this file matches the PlaygroundConfig config in the playground-router crate
+
+export type PlaygroundConfig = {
+  playgroundHttpPath: string;
+  graphqlHttpPath: string;
+
+  enableSchemaLiveUpdate: boolean;
+
+  upstreamGraphQLEndpoint?: string;
+
+  oidcUrl?: string;
+};

--- a/graphiql/app/src/index.tsx
+++ b/graphiql/app/src/index.tsx
@@ -15,9 +15,12 @@ import {
   Fetcher,
   createGraphiQLFetcher,
 } from "exograph-playground-lib";
+import { PlaygroundConfig } from "./config";
+
+let playgroundConfig = (window as any).exoConfig as PlaygroundConfig;
 
 const urlFetcher: Fetcher = createGraphiQLFetcher({
-  url: (window as any).exoGraphQLHttpPath,
+  url: playgroundConfig.graphqlHttpPath,
 });
 
 const container = document.getElementById("root");
@@ -25,12 +28,8 @@ const root = createRoot(container as HTMLElement);
 root.render(
   <GraphiQLPlayground
     fetcher={urlFetcher}
-    oidcUrl={(window as any).exoOidcUrl as string | undefined}
-    upstreamGraphQLEndpoint={
-      (window as any).exoUpstreamGraphQLEndpoint as string | undefined
-    }
-    enableSchemaLiveUpdate={
-      ((window as any).enableSchemaLiveUpdate as boolean) || false
-    }
+    oidcUrl={playgroundConfig.oidcUrl}
+    upstreamGraphQLEndpoint={playgroundConfig.upstreamGraphQLEndpoint}
+    enableSchemaLiveUpdate={playgroundConfig.enableSchemaLiveUpdate}
   />
 );


### PR DESCRIPTION
We now consolidate all configuration such as OIDC url, various HTTP path, enabling of live schema update into a type. Also create a TypeScript type to make it type-safe.