### PR TITLE
Fix loading of assets in the playground mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9260,6 +9260,7 @@ dependencies = [
  "core-router",
  "exo-env",
  "graphql-router",
+ "http 1.1.0",
  "playground-router",
  "rest-router",
  "tracing",

--- a/crates/common/src/introspection.rs
+++ b/crates/common/src/introspection.rs
@@ -29,5 +29,6 @@ pub fn introspection_mode(env: &dyn Environment) -> Result<IntrospectionMode, En
 
 /// Should we allow introspection queries?
 pub fn allow_introspection(env: &dyn Environment) -> bool {
-    introspection_mode(env).unwrap_or(IntrospectionMode::Disabled) == IntrospectionMode::Enabled
+    let effective_mode = introspection_mode(env).unwrap_or(IntrospectionMode::Disabled);
+    effective_mode == IntrospectionMode::Enabled || effective_mode == IntrospectionMode::Only
 }

--- a/crates/playground-router/src/lib.rs
+++ b/crates/playground-router/src/lib.rs
@@ -11,4 +11,4 @@ mod graphiql;
 mod playground_router;
 
 #[cfg(not(target_family = "wasm"))]
-pub use playground_router::PlaygroundRouter;
+pub use playground_router::{PlaygroundRouter, PlaygroundRouterConfig};

--- a/crates/system-router/Cargo.toml
+++ b/crates/system-router/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 async-trait.workspace = true
 tracing.workspace = true
+http.workspace = true
 
 common = { path = "../common" }
 graphql-router = { path = "../graphql-router" }

--- a/crates/system-router/src/system_router.rs
+++ b/crates/system-router/src/system_router.rs
@@ -213,6 +213,7 @@ pub struct SystemRouter {
     underlying: CorsRouter<CompositeRouter<RequestContextRouter>>,
     env: Arc<dyn Environment>,
     authenticator: Arc<Option<JwtAuthenticator>>,
+    #[cfg(not(target_family = "wasm"))]
     playground_config: Option<Arc<PlaygroundRouterConfig>>,
 }
 


### PR DESCRIPTION
The `SystemRouter` didn't correctly resolve playground assets requests. So, we introduce `PlaygroundConfig` to check for asset requests and locally resolve such requests.