### PR TITLE
Use JWT source setting in playground

### DIFF
--- a/crates/playground-router/src/graphiql.rs
+++ b/crates/playground-router/src/graphiql.rs
@@ -9,7 +9,10 @@
 
 #![cfg(not(target_family = "wasm"))]
 
-use common::env_const::{EXO_INTROSPECTION_LIVE_UPDATE, _EXO_UPSTREAM_ENDPOINT_URL};
+use common::env_const::{
+    EXO_INTROSPECTION_LIVE_UPDATE, EXO_JWT_SOURCE_COOKIE, EXO_JWT_SOURCE_HEADER,
+    _EXO_UPSTREAM_ENDPOINT_URL,
+};
 use exo_env::Environment;
 use include_dir::{include_dir, Dir};
 use serde::Serialize;
@@ -63,6 +66,12 @@ struct PlaygroundConfig {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     oidc_url: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    jwt_source_header: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    jwt_source_cookie: Option<String>,
 }
 
 fn exo_playground_config(env: &dyn Environment) -> PlaygroundConfig {
@@ -76,6 +85,9 @@ fn exo_playground_config(env: &dyn Environment) -> PlaygroundConfig {
     let graphql_http_path = get_graphql_http_path(env);
     let upstream_graphql_endpoint = env.get(_EXO_UPSTREAM_ENDPOINT_URL);
 
+    let jwt_source_header = env.get(EXO_JWT_SOURCE_HEADER);
+    let jwt_source_cookie = env.get(EXO_JWT_SOURCE_COOKIE);
+
     PlaygroundConfig {
         playground_http_path,
         graphql_http_path,
@@ -83,5 +95,8 @@ fn exo_playground_config(env: &dyn Environment) -> PlaygroundConfig {
         enable_schema_live_update,
         oidc_url,
         upstream_graphql_endpoint,
+
+        jwt_source_header,
+        jwt_source_cookie,
     }
 }

--- a/graphiql/app/src/config.d.ts
+++ b/graphiql/app/src/config.d.ts
@@ -9,4 +9,7 @@ export type PlaygroundConfig = {
   upstreamGraphQLEndpoint?: string;
 
   oidcUrl?: string;
+
+  jwtSourceHeader?: string;
+  jwtSourceCookie?: string;
 };

--- a/graphiql/app/src/index.tsx
+++ b/graphiql/app/src/index.tsx
@@ -25,11 +25,14 @@ const urlFetcher: Fetcher = createGraphiQLFetcher({
 
 const container = document.getElementById("root");
 const root = createRoot(container as HTMLElement);
+
 root.render(
   <GraphiQLPlayground
     fetcher={urlFetcher}
     oidcUrl={playgroundConfig.oidcUrl}
     upstreamGraphQLEndpoint={playgroundConfig.upstreamGraphQLEndpoint}
     enableSchemaLiveUpdate={playgroundConfig.enableSchemaLiveUpdate}
+    jwtSourceHeader={playgroundConfig.jwtSourceHeader}
+    jwtSourceCookie={playgroundConfig.jwtSourceCookie}
   />
 );

--- a/graphiql/lib/src/GraphiQLPlayground.tsx
+++ b/graphiql/lib/src/GraphiQLPlayground.tsx
@@ -45,6 +45,8 @@ interface _GraphiQLPlaygroundProps extends GraphiQLPassThroughProps {
   upstreamGraphQLEndpoint?: string;
   enableSchemaLiveUpdate: boolean;
   schemaId?: number;
+  jwtSourceHeader?: string;
+  jwtSourceCookie?: string;
 }
 
 export function GraphiQLPlayground({
@@ -57,6 +59,8 @@ export function GraphiQLPlayground({
   initialQuery,
   theme,
   storageKey,
+  jwtSourceHeader,
+  jwtSourceCookie,
 }: GraphiQLPlaygroundProps) {
   return (
     <AuthContextProvider oidcUrl={oidcUrl} jwtSecret={jwtSecret}>
@@ -64,6 +68,8 @@ export function GraphiQLPlayground({
         fetcher={fetcher}
         upstreamGraphQLEndpoint={upstreamGraphQLEndpoint}
         enableSchemaLiveUpdate={enableSchemaLiveUpdate}
+        jwtSourceHeader={jwtSourceHeader}
+        jwtSourceCookie={jwtSourceCookie}
         schemaId={schemaId}
         initialQuery={initialQuery}
         theme={theme}
@@ -84,6 +90,8 @@ function _GraphiQLPlayground({
   fetcher,
   upstreamGraphQLEndpoint,
   enableSchemaLiveUpdate,
+  jwtSourceHeader,
+  jwtSourceCookie,
   schemaId,
   initialQuery,
   theme,
@@ -103,11 +111,18 @@ function _GraphiQLPlayground({
     if (getTokenFn) {
       let authToken = await getTokenFn();
 
-      additionalHeaders = {
-        ...additionalHeaders,
-        Authorization: `Bearer ${authToken}`,
-      };
+      if (jwtSourceCookie) {
+        document.cookie = `${jwtSourceCookie}=${authToken}`;
+      } else {
+        let authHeader = jwtSourceHeader || "Authorization";
+
+        additionalHeaders = {
+          ...additionalHeaders,
+          [authHeader]: `Bearer ${authToken}`,
+        };
+      }
     }
+
     return fetcher(graphQLParams, {
       ...opts,
       headers: { ...opts?.headers, ...additionalHeaders },


### PR DESCRIPTION
If the server has set EXO_JWT_SOURCE_COOKIE or EXO_JWT_SOURCE_HEADER, use that from the playground instead of the default `Authorization` header to pass the JWT token.