### PR TITLE
Provide better error reporting of cast errors

### DIFF
--- a/crates/postgres-subsystem/postgres-core-resolver/src/postgres_execution_error.rs
+++ b/crates/postgres-subsystem/postgres-core-resolver/src/postgres_execution_error.rs
@@ -59,7 +59,8 @@ impl PostgresExecutionError {
         match self {
             PostgresExecutionError::Authorization => "Not authorized".to_string(),
             PostgresExecutionError::Validation(_, _) => self.to_string(),
-            PostgresExecutionError::CastError(_) => {
+            PostgresExecutionError::CastError(e) => {
+                error!("Cast error: {}", e);
                 "Unable to convert input to the expected type".to_string()
             }
             PostgresExecutionError::WithContext(context, e) => {

--- a/integration-tests/casting/src/index.exo
+++ b/integration-tests/casting/src/index.exo
@@ -1,0 +1,11 @@
+@postgres
+module NumbersDatabase {
+  @access(true)
+  type Number {
+    @pk id: Int = autoIncrement()
+    @bits16 int16: Int?
+    @bits32 int32: Int?
+    @singlePrecision singlePrecision: Float?
+  }
+}
+

--- a/integration-tests/casting/tests/errors.exotest
+++ b/integration-tests/casting/tests/errors.exotest
@@ -1,0 +1,91 @@
+stages:
+  - operation: |
+      mutation {
+          minInt16: createNumber(data: {int16: -32769}) {
+              int16
+          }
+      }
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Unable to convert input to the expected type: trying to convert the 'int16' field to the '16-bit integer' type"
+          }
+        ]
+      }
+
+  - operation: |
+      mutation {
+          maxInt16: createNumber(data: {int16: 32768}) {
+              int16
+          }
+      }
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Unable to convert input to the expected type: trying to convert the 'int16' field to the '16-bit integer' type"
+          }
+        ]
+      }
+
+  - operation: |
+      mutation {
+          minInt32: createNumber(data: {int32: -2147483649}) {
+              int32
+          }
+      }
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Unable to convert input to the expected type: trying to convert the 'int32' field to the '32-bit integer' type"
+          }
+        ]
+      }
+
+  - operation: |
+      mutation {
+          maxInt32: createNumber(data: {int32: 2147483648}) {
+              int32
+          }
+      }
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Unable to convert input to the expected type: trying to convert the 'int32' field to the '32-bit integer' type"
+          }
+        ]
+      }
+
+
+  - operation: |
+      mutation {
+          minSinglePrecision: createNumber(data: {singlePrecision: -3.40282347e+38}) {
+              singlePrecision
+          }
+      }
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Unable to convert input to the expected type: trying to convert the 'singlePrecision' field to the 'Single precision floating point' type"
+          }
+        ]
+      }
+
+  - operation: |
+      mutation {
+          maxSinglePrecision: createNumber(data: {singlePrecision: 3.40282347e+38}) {
+              singlePrecision
+          }
+      }
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Unable to convert input to the expected type: trying to convert the 'singlePrecision' field to the 'Single precision floating point' type"
+          }
+        ]
+      }      

--- a/integration-tests/casting/tests/min-max-numbers.exotest
+++ b/integration-tests/casting/tests/min-max-numbers.exotest
@@ -1,0 +1,39 @@
+stages:
+  - operation: |
+      mutation {
+          mins: createNumber(data: {int16: -32768, int32: -2147483648, singlePrecision: -3.40282346e+38}) {
+              int16
+              int32
+              singlePrecision
+          }
+      }
+    response: |
+      {
+        "data": {
+          "mins": {
+            "int16": -32768,
+            "int32": -2147483648,
+            "singlePrecision": -3.4028235e38,
+          }
+        }
+      }
+
+  - operation: |
+      mutation {
+          maxes: createNumber(data: {int16: 32767, int32: 2147483647,singlePrecision: 3.40282346e+38}) {
+              int16
+              int32
+              singlePrecision
+          }
+      }
+    response: |
+      {
+        "data": {
+          "maxes": {
+            "int16": 32767,
+            "int32": 2147483647,
+            "singlePrecision": 3.4028235e38,
+          }
+        }
+      }
+    

--- a/libs/exo-sql/src/sql/physical_column.rs
+++ b/libs/exo-sql/src/sql/physical_column.rs
@@ -113,6 +113,16 @@ pub enum IntBits {
     _64,
 }
 
+impl IntBits {
+    pub fn bits(&self) -> usize {
+        match self {
+            IntBits::_16 => 16,
+            IntBits::_32 => 32,
+            IntBits::_64 => 64,
+        }
+    }
+}
+
 /// Number of bits in the float's mantissa.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FloatBits {
@@ -123,7 +133,7 @@ pub enum FloatBits {
 impl PhysicalColumnType {
     pub fn type_string(&self) -> String {
         match self {
-            PhysicalColumnType::Int { bits } => format!("Int of size {bits:?} bits"),
+            PhysicalColumnType::Int { bits } => format!("{}-bit integer", bits.bits()),
             PhysicalColumnType::String { max_length } => {
                 format!("String of max length {max_length:?}")
             }
@@ -143,7 +153,10 @@ impl PhysicalColumnType {
             PhysicalColumnType::Uuid => "Uuid".to_string(),
             PhysicalColumnType::Vector { size } => format!("Vector of size {size:?}"),
             PhysicalColumnType::Array { typ } => format!("Array of {typ:?}"),
-            PhysicalColumnType::Float { bits } => format!("Float of size {bits:?} bits"),
+            PhysicalColumnType::Float { bits } => match bits {
+                FloatBits::_24 => "Single precision floating point".to_string(),
+                FloatBits::_53 => "Double precision floating point".to_string(),
+            },
             PhysicalColumnType::Numeric { precision, scale } => {
                 format!("Numeric with precision: {precision:?}, scale: {scale:?}")
             }


### PR DESCRIPTION
When we can't cast the input value, for example, number overflow, we now provide a trace (at the `error` level) for better diagnostics.