### PR TITLE
Renamed 'tracked' to 'managed'

### DIFF
--- a/crates/postgres-subsystem/postgres-builder/src/plugin.rs
+++ b/crates/postgres-subsystem/postgres-builder/src/plugin.rs
@@ -213,7 +213,7 @@ impl SubsystemBuilder for PostgresSubsystemBuilder {
                             optional: true,
                         },
                         MappedAnnotationParamSpec {
-                            name: "tracked",
+                            name: "managed",
                             optional: true,
                         },
                     ]),

--- a/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
@@ -41,10 +41,10 @@ pub fn build(resolved_env: &ResolvedTypeEnv) -> Result<Database, ModelBuildingEr
         database: Database::default(),
     };
 
-    // Ensure that all types have a primary key (skip JSON and untracked types)
+    // Ensure that all types have a primary key (skip JSON and unmanaged types)
     for (_, resolved_type) in resolved_env.resolved_types.iter() {
         if let ResolvedType::Composite(c) = &resolved_type {
-            if c.representation == EntityRepresentation::Tracked && c.pk_field().is_none() {
+            if c.representation == EntityRepresentation::Managed && c.pk_field().is_none() {
                 let diagnostic = Diagnostic {
                     level: Level::Error,
                     message: format!(
@@ -102,7 +102,7 @@ fn expand_database_info(
         name: resolved_type.table_name.clone(),
         columns: vec![],
         indices: vec![],
-        tracked: resolved_type.representation == EntityRepresentation::Tracked,
+        managed: resolved_type.representation == EntityRepresentation::Managed,
     };
 
     let table_id = building.database.insert_table(table);

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/column_names_for_non_standard_relational_field_names.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/column_names_for_non_standard_relational_field_names.snap
@@ -40,7 +40,7 @@ values:
     - Composite:
         name: Concert
         plural_name: Concerts
-        representation: Tracked
+        representation: Managed
         fields:
           - name: id
             typ:
@@ -148,7 +148,7 @@ values:
     - Composite:
         name: Venue
         plural_name: Venues
-        representation: Tracked
+        representation: Managed
         fields:
           - name: id
             typ:

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/field_name_variations.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/field_name_variations.snap
@@ -40,7 +40,7 @@ values:
     - Composite:
         name: Entity
         plural_name: Entitys
-        representation: Tracked
+        representation: Managed
         fields:
           - name: _id
             typ:

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/non_public_schema.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/non_public_schema.snap
@@ -40,7 +40,7 @@ values:
     - Composite:
         name: AuthSchemaTable
         plural_name: AuthSchemaTables
-        representation: Tracked
+        representation: Managed
         fields:
           - name: id
             typ:
@@ -102,7 +102,7 @@ values:
     - Composite:
         name: AuthSchemaTableWithCustomName
         plural_name: AuthSchemaTableWithCustomNames
-        representation: Tracked
+        representation: Managed
         fields:
           - name: id
             typ:

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_access.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_access.snap
@@ -40,7 +40,7 @@ values:
     - Composite:
         name: Concert
         plural_name: Concerts
-        representation: Tracked
+        representation: Managed
         fields:
           - name: id
             typ:
@@ -167,7 +167,7 @@ values:
     - Composite:
         name: Venue
         plural_name: Venues
-        representation: Tracked
+        representation: Managed
         fields:
           - name: id
             typ:
@@ -231,7 +231,7 @@ values:
     - Composite:
         name: Artist
         plural_name: Artists
-        representation: Tracked
+        representation: Managed
         fields:
           - name: id
             typ:

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_access_default_values.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_access_default_values.snap
@@ -40,7 +40,7 @@ values:
     - Composite:
         name: Concert
         plural_name: Concerts
-        representation: Tracked
+        representation: Managed
         fields:
           - name: id
             typ:

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_annotations.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_annotations.snap
@@ -40,7 +40,7 @@ values:
     - Composite:
         name: Concert
         plural_name: Concerts
-        representation: Tracked
+        representation: Managed
         fields:
           - name: id
             typ:
@@ -208,7 +208,7 @@ values:
     - Composite:
         name: Venue
         plural_name: Venuess
-        representation: Tracked
+        representation: Managed
         fields:
           - name: id
             typ:

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_camel_case_model_and_fields.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_camel_case_model_and_fields.snap
@@ -40,7 +40,7 @@ values:
     - Composite:
         name: ConcertInfo
         plural_name: ConcertInfos
-        representation: Tracked
+        representation: Managed
         fields:
           - name: concertId
             typ:

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_defaults.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_defaults.snap
@@ -40,7 +40,7 @@ values:
     - Composite:
         name: Concert
         plural_name: Concerts
-        representation: Tracked
+        representation: Managed
         fields:
           - name: id
             typ:
@@ -177,7 +177,7 @@ values:
     - Composite:
         name: Venue
         plural_name: Venues
-        representation: Tracked
+        representation: Managed
         fields:
           - name: id
             typ:

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_multiple_matching_field_with_column_annotation.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_multiple_matching_field_with_column_annotation.snap
@@ -40,7 +40,7 @@ values:
     - Composite:
         name: Concert
         plural_name: Concerts
-        representation: Tracked
+        representation: Managed
         fields:
           - name: id
             typ:
@@ -148,7 +148,7 @@ values:
     - Composite:
         name: Venue
         plural_name: Venues
-        representation: Tracked
+        representation: Managed
         fields:
           - name: id
             typ:

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_optional_fields.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_optional_fields.snap
@@ -40,7 +40,7 @@ values:
     - Composite:
         name: Concert
         plural_name: Concerts
-        representation: Tracked
+        representation: Managed
         fields:
           - name: id
             typ:
@@ -150,7 +150,7 @@ values:
     - Composite:
         name: Venue
         plural_name: Venues
-        representation: Tracked
+        representation: Managed
         fields:
           - name: id
             typ:

--- a/crates/postgres-subsystem/postgres-core-model/src/migration.rs
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration.rs
@@ -1997,12 +1997,12 @@ mod tests {
 
     #[cfg_attr(not(target_family = "wasm"), tokio::test)]
     #[cfg_attr(target_family = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn untracked_type_change() {
+    async fn unmanaged_type_change() {
         assert_changes_with_scope(
             r#"
                 @postgres
                 module LogModule {
-                    @table(tracked=false)
+                    @table(managed=false)
                     type User {
                         @pk id: Int
                         name: String
@@ -2012,7 +2012,7 @@ mod tests {
             r#"
                 @postgres
                 module LogModule {
-                    @table(tracked=false)
+                    @table(managed=false)
                     type User {
                         @pk id: Int
                         name: String
@@ -2031,7 +2031,7 @@ mod tests {
 
     #[cfg_attr(not(target_family = "wasm"), tokio::test)]
     #[cfg_attr(target_family = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
-    async fn tracked_to_untracked_type_change() {
+    async fn managed_to_unmanaged_type_change() {
         assert_changes_with_scope(
             r#"
                 @postgres
@@ -2045,7 +2045,7 @@ mod tests {
             r#"
                 @postgres
                 module LogModule {
-                    @table(tracked=false)
+                    @table(managed=false)
                     type User {
                         @pk id: Int
                         name: String

--- a/crates/postgres-subsystem/postgres-core-model/src/types.rs
+++ b/crates/postgres-subsystem/postgres-core-model/src/types.rs
@@ -65,8 +65,8 @@ pub struct PostgresPrimitiveType {
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 pub enum EntityRepresentation {
     Json,
-    Tracked,
-    Untracked,
+    Managed,
+    NotManaged,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/delete_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/delete_mutation_builder.rs
@@ -65,7 +65,7 @@ impl Builder for DeleteMutationBuilder {
     }
 
     fn needs_mutation_type(&self, composite_type: &ResolvedCompositeType) -> bool {
-        composite_type.representation == EntityRepresentation::Tracked
+        composite_type.representation == EntityRepresentation::Managed
     }
 }
 

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/reference_input_type_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/reference_input_type_builder.rs
@@ -45,7 +45,7 @@ impl Builder for ReferenceInputTypeBuilder {
             .core_subsystem
             .entity_types
             .iter()
-            .filter(|(_, et)| et.representation == EntityRepresentation::Tracked)
+            .filter(|(_, et)| et.representation == EntityRepresentation::Managed)
         {
             for (existing_id, expanded_type) in expanded_reference_types(entity_type, building) {
                 building.mutation_types[existing_id] = expanded_type;
@@ -56,7 +56,7 @@ impl Builder for ReferenceInputTypeBuilder {
     }
 
     fn needs_mutation_type(&self, composite_type: &ResolvedCompositeType) -> bool {
-        composite_type.representation == EntityRepresentation::Tracked
+        composite_type.representation == EntityRepresentation::Managed
     }
 }
 

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/utils.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/utils.rs
@@ -33,7 +33,7 @@ pub(super) fn to_mutation_type(
             TypeIndex::Composite(index) => {
                 let entity_type = &building.core_subsystem.entity_types[*index];
 
-                if entity_type.representation == EntityRepresentation::Tracked {
+                if entity_type.representation == EntityRepresentation::Managed {
                     panic!("Composite field in mutation: {:?}", type_name);
                 }
                 let entity_type_name = &entity_type.name;

--- a/docs/docs/postgres/customizing-types.md
+++ b/docs/docs/postgres/customizing-types.md
@@ -100,9 +100,9 @@ If both `@plural` and `@table` annotations are present, Exograph will use the ar
 Use the `@plural` annotation to deal with type names with irregular pluralization and the `@table` annotation to follow your organization's naming conventions.
 :::
 
-### Using untracked tables
+### Using unmanaged tables
 
-Sometimes, you may want to expose a view or a foreign table in your database through Exograph APIs. For this purpose, you may use the `tracked=false` attribute of the `@table` annotation.
+Sometimes, you may want to expose a view or a foreign table in your database through Exograph APIs, but not have Exograph manage them for schema migration purposes. For this purpose, you may use the `managed=false` attribute of the `@table` annotation.
 
 Consider the following view:
 
@@ -131,7 +131,7 @@ module TodoDatabase {
   }
 
   // highlight-start
-  @table(tracked=false)
+  @table(managed=false)
   @access(query=true, mutation=false)
   type ProductProfit {
     @pk id: Int
@@ -144,14 +144,14 @@ module TodoDatabase {
 }
 ```
 
-Exograph will map the `ProductProfit` type to the `product_profits` view (it could also be a table). However, Exograph will ignore the `ProductProfit` type for schema migration.
+Exograph will map the `ProductProfit` type to the `product_profits` view (it could also be a table, possibly a foreign table). However, Exograph will ignore the `ProductProfit` type during schema migration.
 
-Exograph will apply access control and infer queries for the `ProductProfit` type as usual, including [aggregated queries](operations/queries.md#aggregated-query). If you have an untracked type representing a view, you will want to set `mutation=false`, thus removing the mutation APIs for untracked types. However, this is not a restriction imposed by Exograph. Therefore, you may put any other access control rules if you want to modify the underlying data through the tracked type.
+Exograph will apply access control and infer queries for the `ProductProfit` type as usual, including [aggregated queries](operations/queries.md#aggregated-query). If you have an unmanaged type representing a view, you will typically want to set `mutation=false`, thus removing the mutation APIs for it. However, this is more of a convention than a restriction imposed by Exograph. Therefore, you may put any other access control rules if you want to modify the underlying data through the unmanaged type.
 
-If you allow mutation through a tracked type for a view, you will want to make any derived fields read-only. For example, if you allow mutation through the `ProductProfit` type, you will want to make the `profit` field read-only.
+If you allow mutation through a managed type for a view, you will want to make any derived fields read-only. For example, if you allow mutation through the `ProductProfit` type, you will want to make the `profit` field read-only.
 
 ```exo
-  @table(tracked=false)
+  @table(managed=false)
   @access(query=true, mutation=true)
   type ProductProfit {
     @pk id: Int
@@ -163,7 +163,7 @@ If you allow mutation through a tracked type for a view, you will want to make a
   }
 ```
 
-An untracked type may skip marking a field as `@pk` if it doesn't have a primary key. For such a type, Exograph offers only collection and aggregate queries. For example, the `ProductProfit` type will have the `productProfits` and `productProfitsAgg` query but not the `productProfit` query (which would take the primary key as an argument).
+An unmanaged type may skip marking a field as `@pk` if it doesn't have a primary key. For such a type, Exograph offers only collection and aggregate queries. For example, the `ProductProfit` type will have the `productProfits` and `productProfitsAgg` query but not the `productProfit` query (which would take the primary key as an argument).
 
 ## Field-level customization
 

--- a/integration-tests/untracked-views/no-auth/src/index.exo
+++ b/integration-tests/untracked-views/no-auth/src/index.exo
@@ -9,7 +9,7 @@ module TodoDatabase {
     purchasePrice: Float
   }
 
-  @table(tracked=false)
+  @table(managed=false)
   @access(true)
   type ProductProfit {
     @pk id: Int = autoIncrement()

--- a/integration-tests/untracked-views/no-pk/src/index.exo
+++ b/integration-tests/untracked-views/no-pk/src/index.exo
@@ -9,7 +9,7 @@ module TodoDatabase {
     purchasePrice: Float
   }
 
-  @table(tracked=false)
+  @table(managed=false)
   @access(query=true, delete=true, update=true) // Not allowed to create (what PK would be?)
   type ProductProfit {
     id: Int

--- a/integration-tests/untracked-views/with-auth/src/index.exo
+++ b/integration-tests/untracked-views/with-auth/src/index.exo
@@ -13,7 +13,7 @@ module TodoDatabase {
   }
 
   // Non-admin users can only see profitable products and only admin can create/update/delete them
-  @table(tracked=false)
+  @table(managed=false)
   @access(query=AuthContext.role == "admin" || self.profit > 0, mutation=AuthContext.role == "admin")
   type ProductProfit {
     @pk id: Int = autoIncrement()

--- a/libs/exo-sql/src/schema/database_spec.rs
+++ b/libs/exo-sql/src/schema/database_spec.rs
@@ -67,7 +67,7 @@ impl DatabaseSpec {
         let tables: Vec<(TableId, Vec<ColumnSpec>, Vec<IndexSpec>)> = self
             .tables
             .into_iter()
-            .filter(|table_spec| table_spec.tracked)
+            .filter(|table_spec| table_spec.managed)
             .map(|table| {
                 let table_id = database.insert_table(table.to_column_less_table());
                 (table_id, table.columns, table.indices)
@@ -196,7 +196,7 @@ impl DatabaseSpec {
                         })
                         .collect(),
                     trigger_specs,
-                    table.tracked,
+                    table.managed,
                 )
             })
             .collect();

--- a/libs/exo-sql/src/schema/spec.rs
+++ b/libs/exo-sql/src/schema/spec.rs
@@ -140,7 +140,7 @@ pub fn diff<'a>(
     }
 
     // try to find a table that needs to be created
-    for new_table in new_tables.iter().filter(|table| table.tracked) {
+    for new_table in new_tables.iter().filter(|table| table.managed) {
         if !old_tables
             .iter()
             .any(|old_table| new_table.sql_name() == old_table.sql_name())

--- a/libs/exo-sql/src/schema/table_spec.rs
+++ b/libs/exo-sql/src/schema/table_spec.rs
@@ -27,7 +27,7 @@ pub struct TableSpec {
     pub columns: Vec<ColumnSpec>,
     pub indices: Vec<IndexSpec>,
     pub triggers: Vec<TriggerSpec>,
-    pub tracked: bool,
+    pub managed: bool,
 }
 
 impl TableSpec {
@@ -36,14 +36,14 @@ impl TableSpec {
         columns: Vec<ColumnSpec>,
         indices: Vec<IndexSpec>,
         triggers: Vec<TriggerSpec>,
-        tracked: bool,
+        managed: bool,
     ) -> Self {
         Self {
             name,
             columns,
             indices,
             triggers,
-            tracked,
+            managed,
         }
     }
 
@@ -52,7 +52,7 @@ impl TableSpec {
             name: self.name.clone(),
             columns: vec![],
             indices: vec![],
-            tracked: self.tracked,
+            managed: self.managed,
         }
     }
 
@@ -171,7 +171,7 @@ impl TableSpec {
                 columns,
                 indices,
                 triggers,
-                tracked: true,
+                managed: true,
             },
             issues,
         })
@@ -194,8 +194,8 @@ impl TableSpec {
     }
 
     pub fn diff<'a>(&'a self, new: &'a Self) -> Vec<SchemaOp<'a>> {
-        // If the exograph model is not tracked, we don't need to apply any changes
-        if !new.tracked {
+        // If the exograph model is not managed, we don't need to apply any changes
+        if !new.managed {
             return vec![];
         }
 

--- a/libs/exo-sql/src/sql/physical_table.rs
+++ b/libs/exo-sql/src/sql/physical_table.rs
@@ -71,7 +71,7 @@ pub struct PhysicalTable {
 
     pub indices: Vec<PhysicalIndex>,
 
-    pub tracked: bool,
+    pub managed: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]


### PR DESCRIPTION
Following user feedback, "tracked" is now renamed to "managed".

Note: Given how recent the change was and the limited expected usage, we aren't going through a deprecation process.