### PR TITLE
Simplify migration and make it extensible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6831,13 +6831,15 @@ dependencies = [
  "anyhow",
  "bincode",
  "builder",
+ "colored",
  "core-plugin-interface",
  "exo-sql",
  "postgres-builder",
  "serde",
- "stripmargin",
+ "sqlparser",
  "tokio",
  "wasm-bindgen-test",
+ "wildmatch",
 ]
 
 [[package]]
@@ -8597,6 +8599,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
+name = "sqlparser"
+version = "0.53.0"
+source = "git+https://github.com/exograph/datafusion-sqlparser-rs.git?branch=optional-columns-foreign-reference#de8858305a1ba77de495091d0cb313b8133c519a"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8652,12 +8662,6 @@ checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
 dependencies = [
  "vte",
 ]
-
-[[package]]
-name = "stripmargin"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784dea3618a8c4f8bba0af715e4075f6d743d766d46f7c3339525dd95776c004"
 
 [[package]]
 name = "strsim"

--- a/crates/postgres-subsystem/postgres-core-model/Cargo.toml
+++ b/crates/postgres-subsystem/postgres-core-model/Cargo.toml
@@ -13,14 +13,17 @@ exo-sql = { path = "../../../libs/exo-sql" }
 core-plugin-interface = { path = "../../core-subsystem/core-plugin-interface" }
 
 [dev-dependencies]
-stripmargin = "0.1.1"
 tokio.workspace = true
 wasm-bindgen-test.workspace = true
 bincode.workspace = true
 exo-sql = { path = "../../../libs/exo-sql", features = ["bigdecimal"] }
+sqlparser = { git = "https://github.com/exograph/datafusion-sqlparser-rs.git", branch = "optional-columns-foreign-reference" }
+colored.workspace = true
+wildmatch.workspace = true
 
 builder = { path = "../../builder" }
 postgres-builder = { path = "../postgres-builder" }
 
 [lib]
 doctest = false
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/.gitignore
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/.gitignore
@@ -1,0 +1,1 @@
+*.actual.sql

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-field/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-field/new/src/index.exo
@@ -1,0 +1,8 @@
+@postgres
+module ConcertModule {
+    type Concert {
+        @pk id: Int = autoIncrement()
+        title: String
+        published: Boolean
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-field/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-field/old/src/index.exo
@@ -1,0 +1,7 @@
+@postgres
+module ConcertModule {
+    type Concert {
+        @pk id: Int = autoIncrement()
+        title: String
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-field/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-field/scope-all-schemas/down.sql
@@ -1,0 +1,1 @@
+-- ALTER TABLE "concerts" DROP COLUMN "published";

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-field/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-field/scope-all-schemas/new.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "concerts" (
+    "id" SERIAL PRIMARY KEY,
+    "title" TEXT NOT NULL,
+    "published" BOOLEAN NOT NULL
+);

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-field/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-field/scope-all-schemas/old.sql
@@ -1,0 +1,4 @@
+CREATE TABLE "concerts" (
+    "id" SERIAL PRIMARY KEY,
+    "title" TEXT NOT NULL
+);

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-field/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-field/scope-all-schemas/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "concerts" ADD "published" BOOLEAN NOT NULL;

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices-non-public-schemas/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices-non-public-schemas/new/src/index.exo
@@ -1,0 +1,16 @@
+@postgres
+module ConcertModule {
+    @table(schema="c")
+    type Concert {
+        @pk id: Int = autoIncrement()
+        @index title: String
+        @index venue: Venue
+    }
+
+    @table(schema="v")
+    type Venue {
+        @pk id: Int = autoIncrement()
+        @index name: String
+        concerts: Set<Concert>?
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices-non-public-schemas/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices-non-public-schemas/old/src/index.exo
@@ -1,0 +1,14 @@
+@postgres
+module ConcertModule {
+    type Concert {
+        @pk id: Int = autoIncrement()
+        title: String
+        venue: Venue
+    }
+
+    type Venue {
+        @pk id: Int = autoIncrement()
+        name: String
+        concerts: Set<Concert>?
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices-non-public-schemas/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices-non-public-schemas/scope-all-schemas/down.sql
@@ -1,0 +1,21 @@
+-- DROP TABLE "c"."concerts" CASCADE;
+
+-- DROP TABLE "v"."venues" CASCADE;
+
+CREATE TABLE "concerts" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL,
+	"venue_id" INT NOT NULL
+);
+
+CREATE TABLE "venues" (
+	"id" SERIAL PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+-- DROP SCHEMA "c" CASCADE;
+
+-- DROP SCHEMA "v" CASCADE;
+
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices-non-public-schemas/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices-non-public-schemas/scope-all-schemas/new.sql
@@ -1,0 +1,23 @@
+CREATE SCHEMA "c";
+
+CREATE SCHEMA "v";
+
+CREATE TABLE "c"."concerts" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL,
+	"venue_id" INT NOT NULL
+);
+
+CREATE TABLE "v"."venues" (
+	"id" SERIAL PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+ALTER TABLE "c"."concerts" ADD CONSTRAINT "c_concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "v"."venues";
+
+CREATE INDEX "concert_title_idx" ON "c"."concerts" ("title");
+
+CREATE INDEX "concert_venue_idx" ON "c"."concerts" ("venue_id");
+
+CREATE INDEX "venue_name_idx" ON "v"."venues" ("name");
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices-non-public-schemas/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices-non-public-schemas/scope-all-schemas/old.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "concerts" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL,
+	"venue_id" INT NOT NULL
+);
+
+CREATE TABLE "venues" (
+	"id" SERIAL PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices-non-public-schemas/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices-non-public-schemas/scope-all-schemas/up.sql
@@ -1,0 +1,27 @@
+CREATE SCHEMA "c";
+
+CREATE SCHEMA "v";
+
+-- DROP TABLE "concerts" CASCADE;
+
+-- DROP TABLE "venues" CASCADE;
+
+CREATE TABLE "c"."concerts" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL,
+	"venue_id" INT NOT NULL
+);
+
+CREATE TABLE "v"."venues" (
+	"id" SERIAL PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+ALTER TABLE "c"."concerts" ADD CONSTRAINT "c_concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "v"."venues";
+
+CREATE INDEX "concert_title_idx" ON "c"."concerts" ("title");
+
+CREATE INDEX "concert_venue_idx" ON "c"."concerts" ("venue_id");
+
+CREATE INDEX "venue_name_idx" ON "v"."venues" ("name");
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices/new/src/index.exo
@@ -1,0 +1,13 @@
+@postgres
+module ConcertModule {
+    type Concert {
+        @pk id: Int = autoIncrement()
+        @index title: String
+        @index venue: Venue
+    }
+    type Venue {
+        @pk id: Int = autoIncrement()
+        @index name: String
+        concerts: Set<Concert>?
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices/old/src/index.exo
@@ -1,0 +1,13 @@
+@postgres
+module ConcertModule {
+    type Concert {
+        @pk id: Int = autoIncrement()
+        title: String
+        venue: Venue
+    }
+    type Venue {
+        @pk id: Int = autoIncrement()
+        name: String
+        concerts: Set<Concert>?
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices/scope-all-schemas/down.sql
@@ -1,0 +1,6 @@
+DROP INDEX "concert_title_idx";
+
+DROP INDEX "concert_venue_idx";
+
+DROP INDEX "venue_name_idx";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices/scope-all-schemas/new.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "concerts" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL,
+	"venue_id" INT NOT NULL
+);
+
+CREATE TABLE "venues" (
+	"id" SERIAL PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+
+CREATE INDEX "concert_title_idx" ON "concerts" ("title");
+
+CREATE INDEX "concert_venue_idx" ON "concerts" ("venue_id");
+
+CREATE INDEX "venue_name_idx" ON "venues" ("name");
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices/scope-all-schemas/old.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "concerts" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL,
+	"venue_id" INT NOT NULL
+);
+
+CREATE TABLE "venues" (
+	"id" SERIAL PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices/scope-all-schemas/up.sql
@@ -1,0 +1,6 @@
+CREATE INDEX "concert_title_idx" ON "concerts" ("title");
+
+CREATE INDEX "concert_venue_idx" ON "concerts" ("venue_id");
+
+CREATE INDEX "venue_name_idx" ON "venues" ("name");
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-model/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-model/new/src/index.exo
@@ -1,0 +1,8 @@
+@postgres
+module ConcertModule {
+    type Concert {
+        @pk id: Int = autoIncrement()
+        title: String
+        published: Boolean
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-model/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-model/scope-all-schemas/down.sql
@@ -1,0 +1,1 @@
+-- DROP TABLE "concerts" CASCADE;

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-model/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-model/scope-all-schemas/new.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "concerts" (
+    "id" SERIAL PRIMARY KEY,
+    "title" TEXT NOT NULL,
+    "published" BOOLEAN NOT NULL
+);

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-model/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-model/scope-all-schemas/up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "concerts" (
+    "id" SERIAL PRIMARY KEY,
+    "title" TEXT NOT NULL,
+    "published" BOOLEAN NOT NULL
+);

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-and-related-model/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-and-related-model/new/src/index.exo
@@ -1,0 +1,14 @@
+
+@postgres
+module ConcertModule {
+    type Concert {
+        @pk id: Int = autoIncrement()
+        title: String
+        venue: Venue
+    }
+    type Venue {
+        @pk id: Int = autoIncrement()
+        name: String
+        concerts: Set<Concert>?
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-and-related-model/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-and-related-model/old/src/index.exo
@@ -1,0 +1,7 @@
+@postgres
+module ConcertModule {
+    type Concert {
+        @pk id: Int = autoIncrement()
+        title: String
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-and-related-model/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-and-related-model/scope-all-schemas/down.sql
@@ -1,0 +1,4 @@
+-- ALTER TABLE "concerts" DROP COLUMN "venue_id";
+
+-- DROP TABLE "venues" CASCADE;
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-and-related-model/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-and-related-model/scope-all-schemas/new.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "concerts" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL,
+	"venue_id" INT NOT NULL
+);
+
+CREATE TABLE "venues" (
+	"id" SERIAL PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-and-related-model/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-and-related-model/scope-all-schemas/old.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "concerts" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-and-related-model/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-and-related-model/scope-all-schemas/up.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "concerts" ADD "venue_id" INT NOT NULL;
+
+CREATE TABLE "venues" (
+	"id" SERIAL PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-field/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-field/new/src/index.exo
@@ -1,0 +1,13 @@
+@postgres
+module ConcertModule {
+    type Concert {
+        @pk id: Int = autoIncrement()
+        title: String
+        venue: Venue
+    }
+    type Venue {
+        @pk id: Int = autoIncrement()
+        name: String
+        concerts: Set<Concert>?
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-field/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-field/old/src/index.exo
@@ -1,0 +1,11 @@
+@postgres
+module ConcertModule {
+    type Concert {
+        @pk id: Int = autoIncrement()
+        title: String
+    }
+    type Venue {
+        @pk id: Int = autoIncrement()
+        name: String
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-field/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-field/scope-all-schemas/down.sql
@@ -1,0 +1,2 @@
+-- ALTER TABLE "concerts" DROP COLUMN "venue_id";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-field/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-field/scope-all-schemas/new.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "concerts" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL,
+	"venue_id" INT NOT NULL
+);
+
+CREATE TABLE "venues" (
+	"id" SERIAL PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-field/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-field/scope-all-schemas/old.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "concerts" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL
+);
+
+CREATE TABLE "venues" (
+	"id" SERIAL PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-field/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-field/scope-all-schemas/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "concerts" ADD "venue_id" INT NOT NULL;
+
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-annotation/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-annotation/new/src/index.exo
@@ -1,0 +1,8 @@
+@postgres
+module ConcertModule {
+    type Concert {
+        @pk id: Int = autoIncrement()
+        title: String
+        @update updatedAt: Instant = now()
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-annotation/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-annotation/old/src/index.exo
@@ -1,0 +1,8 @@
+@postgres
+module ConcertModule {
+    type Concert {
+        @pk id: Int = autoIncrement()
+        title: String
+        updatedAt: Instant = now()
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-annotation/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-annotation/scope-all-schemas/down.sql
@@ -1,0 +1,4 @@
+DROP TRIGGER exograph_on_update_concerts on "concerts";
+
+DROP FUNCTION exograph_update_concerts;
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-annotation/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-annotation/scope-all-schemas/new.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "concerts" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL,
+	"updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE FUNCTION exograph_update_concerts() RETURNS TRIGGER AS $$ BEGIN NEW.updated_at = now(); RETURN NEW; END; $$ language 'plpgsql';
+
+CREATE TRIGGER exograph_on_update_concerts BEFORE UPDATE ON concerts FOR EACH ROW EXECUTE FUNCTION exograph_update_concerts();
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-annotation/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-annotation/scope-all-schemas/old.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "concerts" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL,
+	"updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-annotation/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-annotation/scope-all-schemas/up.sql
@@ -1,0 +1,4 @@
+CREATE FUNCTION exograph_update_concerts() RETURNS TRIGGER AS $$ BEGIN NEW.updated_at = now(); RETURN NEW; END; $$ language 'plpgsql';
+
+CREATE TRIGGER exograph_on_update_concerts BEFORE UPDATE ON concerts FOR EACH ROW EXECUTE FUNCTION exograph_update_concerts();
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-sync-field/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-sync-field/new/src/index.exo
@@ -1,0 +1,9 @@
+@postgres
+module ConcertModule {
+    type Concert {
+        @pk id: Int = autoIncrement()
+        title: String
+        @update updatedAt: Instant = now()
+        @update modificationId: Uuid = generate_uuid()
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-sync-field/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-sync-field/old/src/index.exo
@@ -1,0 +1,7 @@
+@postgres
+module ConcertModule {
+    type Concert {
+        @pk id: Int = autoIncrement()
+        title: String
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-sync-field/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-sync-field/scope-all-schemas/down.sql
@@ -1,0 +1,10 @@
+-- ALTER TABLE "concerts" DROP COLUMN "updated_at";
+
+-- ALTER TABLE "concerts" DROP COLUMN "modification_id";
+
+DROP TRIGGER exograph_on_update_concerts on "concerts";
+
+DROP FUNCTION exograph_update_concerts;
+
+-- DROP EXTENSION "pgcrypto";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-sync-field/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-sync-field/scope-all-schemas/new.sql
@@ -1,0 +1,13 @@
+CREATE EXTENSION "pgcrypto";
+
+CREATE TABLE "concerts" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL,
+	"updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+	"modification_id" uuid NOT NULL DEFAULT gen_random_uuid()
+);
+
+CREATE FUNCTION exograph_update_concerts() RETURNS TRIGGER AS $$ BEGIN NEW.updated_at = now(); NEW.modification_id = gen_random_uuid(); RETURN NEW; END; $$ language 'plpgsql';
+
+CREATE TRIGGER exograph_on_update_concerts BEFORE UPDATE ON concerts FOR EACH ROW EXECUTE FUNCTION exograph_update_concerts();
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-sync-field/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-sync-field/scope-all-schemas/old.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "concerts" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-sync-field/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-sync-field/scope-all-schemas/up.sql
@@ -1,0 +1,10 @@
+CREATE EXTENSION "pgcrypto";
+
+ALTER TABLE "concerts" ADD "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now();
+
+ALTER TABLE "concerts" ADD "modification_id" uuid NOT NULL DEFAULT gen_random_uuid();
+
+CREATE FUNCTION exograph_update_concerts() RETURNS TRIGGER AS $$ BEGIN NEW.updated_at = now(); NEW.modification_id = gen_random_uuid(); RETURN NEW; END; $$ language 'plpgsql';
+
+CREATE TRIGGER exograph_on_update_concerts BEFORE UPDATE ON concerts FOR EACH ROW EXECUTE FUNCTION exograph_update_concerts();
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/default-value-change/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/default-value-change/new/src/index.exo
@@ -1,0 +1,9 @@
+@postgres
+module UserModule {
+    type User {
+        @pk id: Int = autoIncrement()
+        role: String = "USER" // Set default value
+        verified: Boolean = true // Change default value
+        enabled: Boolean // Drop default value
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/default-value-change/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/default-value-change/old/src/index.exo
@@ -1,0 +1,9 @@
+@postgres
+module UserModule {
+    type User {
+        @pk id: Int = autoIncrement()
+        role: String
+        verified: Boolean = false
+        enabled: Boolean = true
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/default-value-change/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/default-value-change/scope-all-schemas/down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "users" ALTER COLUMN "role" DROP DEFAULT;
+
+ALTER TABLE "users" ALTER COLUMN "verified" SET DEFAULT false;
+
+ALTER TABLE "users" ALTER COLUMN "enabled" SET DEFAULT true;
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/default-value-change/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/default-value-change/scope-all-schemas/new.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "users" (
+	"id" SERIAL PRIMARY KEY,
+	"role" TEXT NOT NULL DEFAULT 'USER'::text,
+	"verified" BOOLEAN NOT NULL DEFAULT true,
+	"enabled" BOOLEAN NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/default-value-change/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/default-value-change/scope-all-schemas/old.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "users" (
+	"id" SERIAL PRIMARY KEY,
+	"role" TEXT NOT NULL,
+	"verified" BOOLEAN NOT NULL DEFAULT false,
+	"enabled" BOOLEAN NOT NULL DEFAULT true
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/default-value-change/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/default-value-change/scope-all-schemas/up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "users" ALTER COLUMN "role" SET DEFAULT 'USER'::text;
+
+ALTER TABLE "users" ALTER COLUMN "verified" SET DEFAULT true;
+
+ALTER TABLE "users" ALTER COLUMN "enabled" DROP DEFAULT;
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/introduce-vector-field/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/introduce-vector-field/new/src/index.exo
@@ -1,0 +1,9 @@
+@postgres
+module DocumentDatabase {
+  @access(true)
+  type Document {
+    @pk id: Int = autoIncrement()
+    content: String
+    contentVector: Vector?
+  }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/introduce-vector-field/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/introduce-vector-field/old/src/index.exo
@@ -1,0 +1,8 @@
+@postgres
+module DocumentDatabase {
+  @access(true)
+  type Document {
+    @pk id: Int = autoIncrement()
+    content: String
+  }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/introduce-vector-field/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/introduce-vector-field/scope-all-schemas/down.sql
@@ -1,0 +1,4 @@
+-- ALTER TABLE "documents" DROP COLUMN "content_vector";
+
+-- DROP EXTENSION "vector";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/introduce-vector-field/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/introduce-vector-field/scope-all-schemas/new.sql
@@ -1,0 +1,8 @@
+CREATE EXTENSION "vector";
+
+CREATE TABLE "documents" (
+	"id" SERIAL PRIMARY KEY,
+	"content" TEXT NOT NULL,
+	"content_vector" Vector(1536)
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/introduce-vector-field/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/introduce-vector-field/scope-all-schemas/old.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "documents" (
+	"id" SERIAL PRIMARY KEY,
+	"content" TEXT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/introduce-vector-field/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/introduce-vector-field/scope-all-schemas/up.sql
@@ -1,0 +1,4 @@
+CREATE EXTENSION "vector";
+
+ALTER TABLE "documents" ADD "content_vector" Vector(1536);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/managed-to-unmanged-type-change/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/managed-to-unmanged-type-change/new/src/index.exo
@@ -1,0 +1,9 @@
+@postgres
+module LogModule {
+    @table(managed=false)
+    type User {
+        @pk id: Int
+        name: String
+        email: String
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/managed-to-unmanged-type-change/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/managed-to-unmanged-type-change/old/src/index.exo
@@ -1,0 +1,7 @@
+@postgres
+module LogModule {
+    type User {
+        @pk id: Int
+        name: String
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/managed-to-unmanged-type-change/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/managed-to-unmanged-type-change/scope-all-schemas/down.sql
@@ -1,0 +1,2 @@
+-- ALTER TABLE "users" DROP COLUMN "email";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/managed-to-unmanged-type-change/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/managed-to-unmanged-type-change/scope-all-schemas/old.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/modify-multi-column-indices/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/modify-multi-column-indices/new/src/index.exo
@@ -1,0 +1,13 @@
+@postgres
+module ConcertModule {
+    type Concert {
+        @pk id: Int = autoIncrement()
+        @index("title", "title-venue") title: String
+        @index("venue", "title-venue") venue: Venue
+    }
+    type Venue {
+        @pk id: Int = autoIncrement()
+        @index("name") name: String
+        concerts: Set<Concert>?
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/modify-multi-column-indices/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/modify-multi-column-indices/old/src/index.exo
@@ -1,0 +1,13 @@
+@postgres
+module ConcertModule {
+    type Concert {
+        @pk id: Int = autoIncrement()
+        @index title: String
+        @index venue: Venue
+    }
+    type Venue {
+        @pk id: Int = autoIncrement()
+        @index name: String
+        concerts: Set<Concert>?
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/modify-multi-column-indices/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/modify-multi-column-indices/scope-all-schemas/down.sql
@@ -1,0 +1,14 @@
+DROP INDEX "title";
+
+DROP INDEX "title-venue";
+
+DROP INDEX "venue";
+
+CREATE INDEX "concert_title_idx" ON "concerts" ("title");
+
+CREATE INDEX "concert_venue_idx" ON "concerts" ("venue_id");
+
+DROP INDEX "name";
+
+CREATE INDEX "venue_name_idx" ON "venues" ("name");
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/modify-multi-column-indices/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/modify-multi-column-indices/scope-all-schemas/new.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "concerts" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL,
+	"venue_id" INT NOT NULL
+);
+
+CREATE TABLE "venues" (
+	"id" SERIAL PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+
+CREATE INDEX "title" ON "concerts" ("title");
+
+CREATE INDEX "title-venue" ON "concerts" ("title", "venue_id");
+
+CREATE INDEX "venue" ON "concerts" ("venue_id");
+
+CREATE INDEX "name" ON "venues" ("name");
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/modify-multi-column-indices/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/modify-multi-column-indices/scope-all-schemas/old.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "concerts" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL,
+	"venue_id" INT NOT NULL
+);
+
+CREATE TABLE "venues" (
+	"id" SERIAL PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+
+CREATE INDEX "concert_title_idx" ON "concerts" ("title");
+
+CREATE INDEX "concert_venue_idx" ON "concerts" ("venue_id");
+
+CREATE INDEX "venue_name_idx" ON "venues" ("name");
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/modify-multi-column-indices/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/modify-multi-column-indices/scope-all-schemas/up.sql
@@ -1,0 +1,14 @@
+DROP INDEX "concert_title_idx";
+
+DROP INDEX "concert_venue_idx";
+
+CREATE INDEX "title" ON "concerts" ("title");
+
+CREATE INDEX "title-venue" ON "concerts" ("title", "venue_id");
+
+CREATE INDEX "venue" ON "concerts" ("venue_id");
+
+DROP INDEX "venue_name_idx";
+
+CREATE INDEX "name" ON "venues" ("name");
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint-participation-change/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint-participation-change/new/src/index.exo
@@ -1,0 +1,8 @@
+@postgres
+module RsvpModule {
+    type Rsvp {
+        @pk id: Int = autoIncrement()
+        @unique("email_event_id") email: String
+        @unique("email_event_id") event_id: Int
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint-participation-change/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint-participation-change/old/src/index.exo
@@ -1,0 +1,8 @@
+@postgres
+module RsvpModule {
+    type Rsvp {
+        @pk id: Int = autoIncrement()
+        @unique("email_event_id") email: String
+        event_id: Int
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint-participation-change/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint-participation-change/scope-all-schemas/down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "rsvps" DROP CONSTRAINT "unique_constraint_rsvp_email_event_id";
+
+ALTER TABLE "rsvps" ADD CONSTRAINT "unique_constraint_rsvp_email_event_id" UNIQUE ("email");
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint-participation-change/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint-participation-change/scope-all-schemas/new.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "rsvps" (
+	"id" SERIAL PRIMARY KEY,
+	"email" TEXT NOT NULL,
+	"event_id" INT NOT NULL
+);
+
+ALTER TABLE "rsvps" ADD CONSTRAINT "unique_constraint_rsvp_email_event_id" UNIQUE ("email", "event_id");
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint-participation-change/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint-participation-change/scope-all-schemas/old.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "rsvps" (
+	"id" SERIAL PRIMARY KEY,
+	"email" TEXT NOT NULL,
+	"event_id" INT NOT NULL
+);
+
+ALTER TABLE "rsvps" ADD CONSTRAINT "unique_constraint_rsvp_email_event_id" UNIQUE ("email");
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint-participation-change/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint-participation-change/scope-all-schemas/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "rsvps" DROP CONSTRAINT "unique_constraint_rsvp_email_event_id";
+
+ALTER TABLE "rsvps" ADD CONSTRAINT "unique_constraint_rsvp_email_event_id" UNIQUE ("email", "event_id");
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint/new/src/index.exo
@@ -1,0 +1,8 @@
+@postgres
+module RsvpModule {
+    type Rsvp {
+        @pk id: Int = autoIncrement()
+        @unique("email_event_id") email: String
+        @unique("email_event_id") event_id: Int
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint/old/src/index.exo
@@ -1,0 +1,8 @@
+@postgres
+module RsvpModule {
+    type Rsvp {
+        @pk id: Int = autoIncrement()
+        email: String
+        event_id: Int
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint/scope-all-schemas/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "rsvps" DROP CONSTRAINT "unique_constraint_rsvp_email_event_id";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint/scope-all-schemas/new.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "rsvps" (
+	"id" SERIAL PRIMARY KEY,
+	"email" TEXT NOT NULL,
+	"event_id" INT NOT NULL
+);
+
+ALTER TABLE "rsvps" ADD CONSTRAINT "unique_constraint_rsvp_email_event_id" UNIQUE ("email", "event_id");
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint/scope-all-schemas/old.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "rsvps" (
+	"id" SERIAL PRIMARY KEY,
+	"email" TEXT NOT NULL,
+	"event_id" INT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/multi-column-unique-constraint/scope-all-schemas/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "rsvps" ADD CONSTRAINT "unique_constraint_rsvp_email_event_id" UNIQUE ("email", "event_id");
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-module-level-schema/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-module-level-schema/new/src/index.exo
@@ -1,0 +1,15 @@
+@postgres(schema="info")
+module LogModule {
+    type Log {
+        @pk id: Int
+        level: String?
+        message: String
+        owner: User
+    }
+
+    type User {
+        @pk id: Int
+        name: String
+        logs: Set<Log>?
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-module-level-schema/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-module-level-schema/old/src/index.exo
@@ -1,0 +1,15 @@
+@postgres
+module LogModule {
+    type Log {
+        @pk id: Int
+        level: String?
+        message: String
+        owner: User
+    }
+
+    type User {
+        @pk id: Int
+        name: String
+        logs: Set<Log>?
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-module-level-schema/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-module-level-schema/scope-all-schemas/down.sql
@@ -1,0 +1,20 @@
+-- DROP TABLE "info"."logs" CASCADE;
+
+-- DROP TABLE "info"."users" CASCADE;
+
+CREATE TABLE "logs" (
+	"id" INT PRIMARY KEY,
+	"level" TEXT,
+	"message" TEXT NOT NULL,
+	"owner_id" INT NOT NULL
+);
+
+CREATE TABLE "users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+-- DROP SCHEMA "info" CASCADE;
+
+ALTER TABLE "logs" ADD CONSTRAINT "logs_owner_id_fk" FOREIGN KEY ("owner_id") REFERENCES "users";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-module-level-schema/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-module-level-schema/scope-all-schemas/new.sql
@@ -1,0 +1,16 @@
+CREATE SCHEMA "info";
+
+CREATE TABLE "info"."logs" (
+	"id" INT PRIMARY KEY,
+	"level" TEXT,
+	"message" TEXT NOT NULL,
+	"owner_id" INT NOT NULL
+);
+
+CREATE TABLE "info"."users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+ALTER TABLE "info"."logs" ADD CONSTRAINT "info_logs_owner_id_fk" FOREIGN KEY ("owner_id") REFERENCES "info"."users";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-module-level-schema/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-module-level-schema/scope-all-schemas/old.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "logs" (
+	"id" INT PRIMARY KEY,
+	"level" TEXT,
+	"message" TEXT NOT NULL,
+	"owner_id" INT NOT NULL
+);
+
+CREATE TABLE "users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+ALTER TABLE "logs" ADD CONSTRAINT "logs_owner_id_fk" FOREIGN KEY ("owner_id") REFERENCES "users";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-module-level-schema/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-module-level-schema/scope-all-schemas/up.sql
@@ -1,0 +1,20 @@
+CREATE SCHEMA "info";
+
+-- DROP TABLE "logs" CASCADE;
+
+-- DROP TABLE "users" CASCADE;
+
+CREATE TABLE "info"."logs" (
+	"id" INT PRIMARY KEY,
+	"level" TEXT,
+	"message" TEXT NOT NULL,
+	"owner_id" INT NOT NULL
+);
+
+CREATE TABLE "info"."users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+ALTER TABLE "info"."logs" ADD CONSTRAINT "info_logs_owner_id_fk" FOREIGN KEY ("owner_id") REFERENCES "info"."users";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-schema/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-schema/new/src/index.exo
@@ -1,0 +1,16 @@
+@postgres
+module LogModule {
+    type Log {
+        @pk id: Int
+        level: String?
+        message: String
+        owner: User
+    }
+
+    @table(schema="auth")
+    type User {
+        @pk id: Int
+        name: String
+        logs: Set<Log>?
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-schema/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-schema/old/src/index.exo
@@ -1,0 +1,15 @@
+@postgres
+module LogModule {
+    type Log {
+        @pk id: Int
+        level: String?
+        message: String
+        owner: User
+    }
+
+    type User {
+        @pk id: Int
+        name: String
+        logs: Set<Log>?
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-schema/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-schema/scope-all-schemas/down.sql
@@ -1,0 +1,9 @@
+-- DROP TABLE "auth"."users" CASCADE;
+
+CREATE TABLE "users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+-- DROP SCHEMA "auth" CASCADE;
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-schema/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-schema/scope-all-schemas/new.sql
@@ -1,0 +1,16 @@
+CREATE SCHEMA "auth";
+
+CREATE TABLE "logs" (
+	"id" INT PRIMARY KEY,
+	"level" TEXT,
+	"message" TEXT NOT NULL,
+	"owner_id" INT NOT NULL
+);
+
+CREATE TABLE "auth"."users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+ALTER TABLE "logs" ADD CONSTRAINT "logs_owner_id_fk" FOREIGN KEY ("owner_id") REFERENCES "auth"."users";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-schema/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-schema/scope-all-schemas/old.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "logs" (
+	"id" INT PRIMARY KEY,
+	"level" TEXT,
+	"message" TEXT NOT NULL,
+	"owner_id" INT NOT NULL
+);
+
+CREATE TABLE "users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+ALTER TABLE "logs" ADD CONSTRAINT "logs_owner_id_fk" FOREIGN KEY ("owner_id") REFERENCES "users";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-schema/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-schema/scope-all-schemas/up.sql
@@ -1,0 +1,9 @@
+CREATE SCHEMA "auth";
+
+-- DROP TABLE "users" CASCADE;
+
+CREATE TABLE "auth"."users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/not-null/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/not-null/new/src/index.exo
@@ -1,0 +1,8 @@
+@postgres
+module LogModule {
+    type Log {
+        @pk id: Int
+        level: String
+        message: String
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/not-null/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/not-null/old/src/index.exo
@@ -1,0 +1,8 @@
+@postgres
+module LogModule {
+    type Log {
+        @pk id: Int
+        level: String?
+        message: String
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/not-null/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/not-null/scope-all-schemas/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "logs" ALTER COLUMN "level" DROP NOT NULL;
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/not-null/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/not-null/scope-all-schemas/new.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "logs" (
+	"id" INT PRIMARY KEY,
+	"level" TEXT NOT NULL,
+	"message" TEXT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/not-null/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/not-null/scope-all-schemas/old.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "logs" (
+	"id" INT PRIMARY KEY,
+	"level" TEXT,
+	"message" TEXT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/not-null/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/not-null/scope-all-schemas/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "logs" ALTER COLUMN "level" SET NOT NULL;
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/one-to-one-constraints/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/one-to-one-constraints/new/src/index.exo
@@ -1,0 +1,12 @@
+@postgres
+module MembershipModule {
+    type Membership {
+        @pk id: Int = autoIncrement()
+        user: User
+    }
+    type User {
+        @pk id: Int = autoIncrement()
+        name: String
+        membership: Membership?
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/one-to-one-constraints/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/one-to-one-constraints/old/src/index.exo
@@ -1,0 +1,11 @@
+@postgres
+module MembershipModule {
+    type Membership {
+        @pk id: Int = autoIncrement()
+    }
+    
+    type User {
+        @pk id: Int = autoIncrement()
+        name: String
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/one-to-one-constraints/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/one-to-one-constraints/scope-all-schemas/down.sql
@@ -1,0 +1,4 @@
+-- ALTER TABLE "memberships" DROP COLUMN "user_id";
+
+ALTER TABLE "memberships" DROP CONSTRAINT "unique_constraint_membership_user";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/one-to-one-constraints/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/one-to-one-constraints/scope-all-schemas/new.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "memberships" (
+	"id" SERIAL PRIMARY KEY,
+	"user_id" INT NOT NULL
+);
+
+CREATE TABLE "users" (
+	"id" SERIAL PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+ALTER TABLE "memberships" ADD CONSTRAINT "memberships_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "users";
+
+ALTER TABLE "memberships" ADD CONSTRAINT "unique_constraint_membership_user" UNIQUE ("user_id");
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/one-to-one-constraints/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/one-to-one-constraints/scope-all-schemas/old.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "memberships" (
+	"id" SERIAL PRIMARY KEY
+);
+
+CREATE TABLE "users" (
+	"id" SERIAL PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/one-to-one-constraints/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/one-to-one-constraints/scope-all-schemas/up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "memberships" ADD "user_id" INT NOT NULL;
+
+ALTER TABLE "memberships" ADD CONSTRAINT "unique_constraint_membership_user" UNIQUE ("user_id");
+
+ALTER TABLE "memberships" ADD CONSTRAINT "memberships_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "users";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/public-to-named-schema/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/public-to-named-schema/new/src/index.exo
@@ -1,0 +1,8 @@
+@postgres
+module LogModule {
+    @table(schema="auth")
+    type User {
+        @pk id: Int
+        name: String
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/public-to-named-schema/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/public-to-named-schema/old/src/index.exo
@@ -1,0 +1,7 @@
+@postgres
+module LogModule {
+    type User {
+        @pk id: Int
+        name: String
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/public-to-named-schema/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/public-to-named-schema/scope-all-schemas/down.sql
@@ -1,0 +1,9 @@
+-- DROP TABLE "auth"."users" CASCADE;
+
+CREATE TABLE "users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+-- DROP SCHEMA "auth" CASCADE;
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/public-to-named-schema/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/public-to-named-schema/scope-all-schemas/new.sql
@@ -1,0 +1,7 @@
+CREATE SCHEMA "auth";
+
+CREATE TABLE "auth"."users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/public-to-named-schema/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/public-to-named-schema/scope-all-schemas/old.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/public-to-named-schema/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/public-to-named-schema/scope-all-schemas/up.sql
@@ -1,0 +1,9 @@
+CREATE SCHEMA "auth";
+
+-- DROP TABLE "users" CASCADE;
+
+CREATE TABLE "auth"."users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/public-to-named-schema/scope-new-spec/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/public-to-named-schema/scope-new-spec/down.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/public-to-named-schema/scope-new-spec/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/public-to-named-schema/scope-new-spec/new.sql
@@ -1,0 +1,7 @@
+CREATE SCHEMA "auth";
+
+CREATE TABLE "auth"."users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/public-to-named-schema/scope-new-spec/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/public-to-named-schema/scope-new-spec/old.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/public-to-named-schema/scope-new-spec/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/public-to-named-schema/scope-new-spec/up.sql
@@ -1,0 +1,7 @@
+CREATE SCHEMA "auth";
+
+CREATE TABLE "auth"."users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/two-named-schema-change/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/two-named-schema-change/new/src/index.exo
@@ -1,0 +1,8 @@
+@postgres
+module LogModule {
+    @table(schema="auth")
+    type User {
+        @pk id: Int
+        name: String
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/two-named-schema-change/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/two-named-schema-change/old/src/index.exo
@@ -1,0 +1,7 @@
+@postgres(schema="log")
+module LogModule {
+    type User {
+        @pk id: Int
+        name: String
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/two-named-schema-change/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/two-named-schema-change/scope-all-schemas/down.sql
@@ -1,0 +1,11 @@
+CREATE SCHEMA "log";
+
+-- DROP TABLE "auth"."users" CASCADE;
+
+CREATE TABLE "log"."users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+-- DROP SCHEMA "auth" CASCADE;
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/two-named-schema-change/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/two-named-schema-change/scope-all-schemas/new.sql
@@ -1,0 +1,7 @@
+CREATE SCHEMA "auth";
+
+CREATE TABLE "auth"."users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/two-named-schema-change/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/two-named-schema-change/scope-all-schemas/old.sql
@@ -1,0 +1,7 @@
+CREATE SCHEMA "log";
+
+CREATE TABLE "log"."users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/two-named-schema-change/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/two-named-schema-change/scope-all-schemas/up.sql
@@ -1,0 +1,11 @@
+CREATE SCHEMA "auth";
+
+-- DROP TABLE "log"."users" CASCADE;
+
+CREATE TABLE "auth"."users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+-- DROP SCHEMA "log" CASCADE;
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/two-named-schema-change/scope-new-spec/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/two-named-schema-change/scope-new-spec/down.sql
@@ -1,0 +1,7 @@
+CREATE SCHEMA "log";
+
+CREATE TABLE "log"."users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/two-named-schema-change/scope-new-spec/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/two-named-schema-change/scope-new-spec/new.sql
@@ -1,0 +1,7 @@
+CREATE SCHEMA "auth";
+
+CREATE TABLE "auth"."users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/two-named-schema-change/scope-new-spec/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/two-named-schema-change/scope-new-spec/old.sql
@@ -1,0 +1,7 @@
+CREATE SCHEMA "log";
+
+CREATE TABLE "log"."users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/two-named-schema-change/scope-new-spec/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/two-named-schema-change/scope-new-spec/up.sql
@@ -1,0 +1,7 @@
+CREATE SCHEMA "auth";
+
+CREATE TABLE "auth"."users" (
+	"id" INT PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/unmanaged-type-change/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/unmanaged-type-change/new/src/index.exo
@@ -1,0 +1,9 @@
+@postgres
+module LogModule {
+    @table(managed=false)
+    type User {
+        @pk id: Int
+        name: String
+        email: String
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/unmanaged-type-change/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/unmanaged-type-change/old/src/index.exo
@@ -1,0 +1,8 @@
+@postgres
+module LogModule {
+    @table(managed=false)
+    type User {
+        @pk id: Int
+        name: String
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/update-relation-optionality/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/update-relation-optionality/new/src/index.exo
@@ -1,0 +1,13 @@
+@postgres
+module ConcertModule {
+    type Concert {
+        @pk id: Int = autoIncrement()
+        title: String
+        venue: Venue?
+    }
+    type Venue {
+        @pk id: Int = autoIncrement()
+        name: String
+        concerts: Set<Concert>?
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/update-relation-optionality/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/update-relation-optionality/old/src/index.exo
@@ -1,0 +1,13 @@
+@postgres
+module ConcertModule {
+    type Concert {
+        @pk id: Int = autoIncrement()
+        title: String
+        venue: Venue
+    }
+    type Venue {
+        @pk id: Int = autoIncrement()
+        name: String
+        concerts: Set<Concert>?
+    }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/update-relation-optionality/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/update-relation-optionality/scope-all-schemas/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "concerts" ALTER COLUMN "venue_id" SET NOT NULL;
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/update-relation-optionality/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/update-relation-optionality/scope-all-schemas/new.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "concerts" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL,
+	"venue_id" INT
+);
+
+CREATE TABLE "venues" (
+	"id" SERIAL PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/update-relation-optionality/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/update-relation-optionality/scope-all-schemas/old.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "concerts" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL,
+	"venue_id" INT NOT NULL
+);
+
+CREATE TABLE "venues" (
+	"id" SERIAL PRIMARY KEY,
+	"name" TEXT NOT NULL
+);
+
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/update-relation-optionality/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/update-relation-optionality/scope-all-schemas/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "concerts" ALTER COLUMN "venue_id" DROP NOT NULL;
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-default-distance-function/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-default-distance-function/new/src/index.exo
@@ -1,0 +1,10 @@
+@postgres
+module DocumentDatabase {
+  @access(true)
+  type Document {
+    @pk id: Int = autoIncrement()
+    title: String
+    content: String
+    @index @size(3) contentVector: Vector?
+  }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-default-distance-function/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-default-distance-function/old/src/index.exo
@@ -1,0 +1,10 @@
+@postgres
+module DocumentDatabase {
+  @access(true)
+  type Document {
+    @pk id: Int = autoIncrement()
+    title: String
+    content: String
+    @size(3) contentVector: Vector?
+  }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-default-distance-function/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-default-distance-function/scope-all-schemas/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX "document_contentvector_idx";
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-default-distance-function/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-default-distance-function/scope-all-schemas/new.sql
@@ -1,0 +1,11 @@
+CREATE EXTENSION "vector";
+
+CREATE TABLE "documents" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL,
+	"content" TEXT NOT NULL,
+	"content_vector" Vector(3)
+);
+
+CREATE INDEX "document_contentvector_idx" ON "documents" USING hnsw ("content_vector" vector_cosine_ops);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-default-distance-function/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-default-distance-function/scope-all-schemas/old.sql
@@ -1,0 +1,9 @@
+CREATE EXTENSION "vector";
+
+CREATE TABLE "documents" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL,
+	"content" TEXT NOT NULL,
+	"content_vector" Vector(3)
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-default-distance-function/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-default-distance-function/scope-all-schemas/up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX "document_contentvector_idx" ON "documents" USING hnsw ("content_vector" vector_cosine_ops);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-distance-function-change/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-distance-function-change/new/src/index.exo
@@ -1,0 +1,10 @@
+@postgres
+module DocumentDatabase {
+  @access(true)
+  type Document {
+    @pk id: Int = autoIncrement()
+    title: String
+    content: String
+    @distanceFunction("l2") @index @size(3) contentVector: Vector?
+  }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-distance-function-change/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-distance-function-change/old/src/index.exo
@@ -1,0 +1,10 @@
+@postgres
+module DocumentDatabase {
+  @access(true)
+  type Document {
+    @pk id: Int = autoIncrement()
+    title: String
+    content: String
+    @size(3) @index contentVector: Vector?
+  }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-distance-function-change/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-distance-function-change/scope-all-schemas/down.sql
@@ -1,0 +1,4 @@
+DROP INDEX "document_contentvector_idx";
+
+CREATE INDEX "document_contentvector_idx" ON "documents" USING hnsw ("content_vector" vector_cosine_ops);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-distance-function-change/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-distance-function-change/scope-all-schemas/new.sql
@@ -1,0 +1,11 @@
+CREATE EXTENSION "vector";
+
+CREATE TABLE "documents" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL,
+	"content" TEXT NOT NULL,
+	"content_vector" Vector(3)
+);
+
+CREATE INDEX "document_contentvector_idx" ON "documents" USING hnsw ("content_vector" vector_l2_ops);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-distance-function-change/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-distance-function-change/scope-all-schemas/old.sql
@@ -1,0 +1,11 @@
+CREATE EXTENSION "vector";
+
+CREATE TABLE "documents" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL,
+	"content" TEXT NOT NULL,
+	"content_vector" Vector(3)
+);
+
+CREATE INDEX "document_contentvector_idx" ON "documents" USING hnsw ("content_vector" vector_cosine_ops);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-distance-function-change/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-indices-distance-function-change/scope-all-schemas/up.sql
@@ -1,0 +1,4 @@
+DROP INDEX "document_contentvector_idx";
+
+CREATE INDEX "document_contentvector_idx" ON "documents" USING hnsw ("content_vector" vector_l2_ops);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-size-change/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-size-change/new/src/index.exo
@@ -1,0 +1,10 @@
+@postgres
+module DocumentDatabase {
+  @access(true)
+  type Document {
+    @pk id: Int = autoIncrement()
+    title: String
+    content: String
+    @size(4) contentVector: Vector?
+  }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-size-change/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-size-change/old/src/index.exo
@@ -1,0 +1,10 @@
+@postgres
+module DocumentDatabase {
+  @access(true)
+  type Document {
+    @pk id: Int = autoIncrement()
+    title: String
+    content: String
+    @size(3) contentVector: Vector?
+  }
+}

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-size-change/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-size-change/scope-all-schemas/down.sql
@@ -1,0 +1,4 @@
+-- ALTER TABLE "documents" DROP COLUMN "content_vector";
+
+ALTER TABLE "documents" ADD "content_vector" Vector(3);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-size-change/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-size-change/scope-all-schemas/new.sql
@@ -1,0 +1,9 @@
+CREATE EXTENSION "vector";
+
+CREATE TABLE "documents" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL,
+	"content" TEXT NOT NULL,
+	"content_vector" Vector(4)
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-size-change/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-size-change/scope-all-schemas/old.sql
@@ -1,0 +1,9 @@
+CREATE EXTENSION "vector";
+
+CREATE TABLE "documents" (
+	"id" SERIAL PRIMARY KEY,
+	"title" TEXT NOT NULL,
+	"content" TEXT NOT NULL,
+	"content_vector" Vector(3)
+);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-size-change/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/vector-size-change/scope-all-schemas/up.sql
@@ -1,0 +1,4 @@
+-- ALTER TABLE "documents" DROP COLUMN "content_vector";
+
+ALTER TABLE "documents" ADD "content_vector" Vector(4);
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration.rs
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration.rs
@@ -596,6 +596,10 @@ mod tests {
         if actual == expected {
             return Ok(());
         }
+        // Line-ending insensitive comparison (for Windows compatibility)
+        if (actual.lines().zip(expected.lines())).all(|(a, e)| a.trim() == e.trim()) {
+            return Ok(());
+        }
 
         let dialect = PostgreSqlDialect {};
         let actual_sql = Parser::parse_sql(&dialect, actual)

--- a/crates/postgres-subsystem/postgres-core-model/src/migration.rs
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration.rs
@@ -343,7 +343,7 @@ mod tests {
 
             let scope_folder = format!("{}/{}", folder, scope_dir_name);
 
-            println!("\tTesting scope {}", scope_spec_name);
+            println!("\tscope {}:", scope_spec_name);
 
             if let Err(e) = assert_for_scope(&old_system, &new_system, &scope_folder, &scope).await
             {
@@ -403,7 +403,7 @@ mod tests {
             println!("Old creation failed: {}", e);
             failed = true;
         } else {
-            println!("\told-creation: {}", "passed".green());
+            println!("\t\told-creation: {}", "pass".green());
         }
 
         if let Err(e) = assert_creation_and_self_migration(
@@ -416,7 +416,7 @@ mod tests {
             println!("New creation failed: {}", e);
             failed = true;
         } else {
-            println!("\t\tnew-creation: {}", "passed".green());
+            println!("\t\tnew-creation: {}", "pass".green());
         }
 
         if let Err(e) = assert_migration(
@@ -430,7 +430,7 @@ mod tests {
             println!("Up failed: {}", e);
             failed = true;
         } else {
-            println!("\t\tup: {}", "passed".green());
+            println!("\t\tup: {}", "pass".green());
         }
 
         if let Err(e) = assert_migration(
@@ -444,7 +444,7 @@ mod tests {
             println!("Down failed: {}", e);
             failed = true;
         } else {
-            println!("\t\tdown: {}", "passed".green());
+            println!("\t\tdown: {}", "pass".green());
         }
 
         if failed {
@@ -540,7 +540,7 @@ mod tests {
         };
 
         let (expected_sql, expected_destructive_indices) = {
-            let expected_sql = expected.split(";").map(|s| s.trim()).collect::<Vec<_>>();
+            let expected_sql = expected.split(";\n").map(|s| s.trim()).collect::<Vec<_>>();
             let expected_sql_destructive_indices = expected_sql
                 .iter()
                 .enumerate()

--- a/crates/postgres-subsystem/postgres-core-model/src/migration.rs
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration.rs
@@ -285,7 +285,7 @@ mod tests {
     #[cfg_attr(not(target_family = "wasm"), tokio::test)]
     #[cfg_attr(target_family = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
     async fn all_tests() {
-        let filter = std::env::var("MIGRATION_TEST_FILTER").unwrap_or("*".to_string());
+        let filter = std::env::var("_EXO_DEV_MIGRATION_TEST_FILTER").unwrap_or("*".to_string());
         let wildcard = WildMatch::new(&filter);
 
         let test_configs_dir = relative_path("", "");
@@ -501,7 +501,7 @@ mod tests {
             actual.write(&mut buffer, false).unwrap();
             let actual_sql = String::from_utf8(buffer.into_inner()).unwrap();
 
-            if actual_sql == expected {
+            if (actual_sql.lines().zip(expected.lines())).all(|(a, e)| a.trim() == e.trim()) {
                 return Ok(());
             }
         }
@@ -526,7 +526,7 @@ mod tests {
                     .iter()
                     .map(|stmt| MigrationStatement {
                         statement: stmt.statement.clone(),
-                        is_destructive: true,
+                        is_destructive: false,
                     })
                     .collect::<Vec<_>>(),
             };
@@ -593,9 +593,6 @@ mod tests {
     }
 
     fn assert_sql_str_eq(actual: &str, expected: &str, message: &str) -> Result<(), String> {
-        if actual == expected {
-            return Ok(());
-        }
         // Line-ending insensitive comparison (for Windows compatibility)
         if (actual.lines().zip(expected.lines())).all(|(a, e)| a.trim() == e.trim()) {
             return Ok(());


### PR DESCRIPTION
Our migration tests used strings in Rust files (for exo and SQL), which required string escaping, prefix stripping, and other modifications. This made reading the test code difficult. Also, we relied on exact string matches, which required paying too much attention to the precise format.

This refactoring:
1. Move .exo and .sql files outside of rust code
2. Uses `sqlparser` to match without considering the format

Note that in some cases, `sqlparser` doesn't parse valid syntax, so we rely on exact string comparison as a fallback/optimization. We will contribute fixes to `sqlparser` and then remove this reliance.