### PR TITLE
Allow skipping @column in a few cases

### DIFF
--- a/integration-tests/basic-model-no-auth/src/index.exo
+++ b/integration-tests/basic-model-no-auth/src/index.exo
@@ -16,7 +16,7 @@ module ConcertModule {
   type Venue {
     @pk id: Int = autoIncrement() 
     name: String
-    @column("venueid") concerts: Set<Concert>? 
+    concerts: Set<Concert>? 
     published: Boolean
     @singlePrecision latitude: Float
   }

--- a/integration-tests/basic-model-with-auth/src/index.exo
+++ b/integration-tests/basic-model-with-auth/src/index.exo
@@ -22,7 +22,7 @@ module ConcertModule {
   type Venue {
     @pk id: Int = autoIncrement()
     name: String
-    @column("venueid") concerts: Set<Concert>? 
+    concerts: Set<Concert>? 
     published: Boolean
     @singlePrecision latitude: Float
   }

--- a/integration-tests/field-merging/src/index.exo
+++ b/integration-tests/field-merging/src/index.exo
@@ -16,7 +16,7 @@ module ConcertModule {
   type Venue {
     @pk id: Int = autoIncrement() 
     name: String
-    @column("venueid") concerts: Set<Concert>? 
+    concerts: Set<Concert>? 
     published: Boolean
     @singlePrecision latitude: Float
   }

--- a/integration-tests/imports/src/mailing_list.exo
+++ b/integration-tests/imports/src/mailing_list.exo
@@ -6,6 +6,6 @@ module MailingListModule {
     type MailingList {
         @pk id: Int = autoIncrement()
         email_address: String
-        @column("subscribed_mailing_list")  subscriptions: Set<UserSubscription>? 
+        subscriptions: Set<UserSubscription>? 
     }
 }

--- a/integration-tests/imports/src/users/users.exo
+++ b/integration-tests/imports/src/users/users.exo
@@ -6,7 +6,7 @@ module UserModule {
     type User {
         @pk id: Int = autoIncrement()
         username: String
-        @column("subscribed_user_id") subscribed_lists: Set<UserSubscription>? 
+        subscribed_lists: Set<UserSubscription>? 
     }
     
     @access(true)

--- a/integration-tests/interceptor/ordering/src/index.exo
+++ b/integration-tests/interceptor/ordering/src/index.exo
@@ -13,7 +13,7 @@ module ConcertVenues {
   type Venue {
     @pk id: Int = autoIncrement()
     name: String
-    @column("venueid") concerts: Set<Concert>? 
+    concerts: Set<Concert>? 
     published: Boolean
     @singlePrecision latitude: Float
   }

--- a/integration-tests/many-to-many/indirect/custom-names/src/index.exo
+++ b/integration-tests/many-to-many/indirect/custom-names/src/index.exo
@@ -5,7 +5,7 @@ module ConcertsModule {
   type Concert {
     @pk id: Int = autoIncrement()
     title: String
-    @column("concert_id") concertArtists: Set<ConcertArtist> 
+    concertArtists: Set<ConcertArtist> 
     @column("venue_id") venue: Venue? 
   }
 
@@ -24,12 +24,12 @@ module ConcertsModule {
   type Artist {
     @pk id: Int = autoIncrement()
     name: String
-    @column("artist_id")  aristsConcerts: Set<ConcertArtist>? // An artist may yet to participate in a concert, hence optional
+    aristsConcerts: Set<ConcertArtist>? // An artist may yet to participate in a concert, hence optional
   }
 
   @access(true)
   type Venue {
     @pk id: Int = autoIncrement()
-    @column("venue_id") concerts: Set<Concert>? 
+    concerts: Set<Concert>? 
   }
 }

--- a/integration-tests/non-public-schema/basic-model-no-auth-module-level-schema/src/index.exo
+++ b/integration-tests/non-public-schema/basic-model-no-auth-module-level-schema/src/index.exo
@@ -14,7 +14,7 @@ module ConcertModule {
   type Venue {
     @pk id: Int = autoIncrement() 
     name: String
-    @column("venueid") concerts: Set<Concert>? 
+    concerts: Set<Concert>? 
     published: Boolean
     @singlePrecision latitude: Float
   }

--- a/integration-tests/non-public-schema/basic-model-no-auth-same-table-name/src/index.exo
+++ b/integration-tests/non-public-schema/basic-model-no-auth-same-table-name/src/index.exo
@@ -18,7 +18,7 @@ module ConcertModule {
   type Venue {
     @pk id: Int = autoIncrement() 
     name: String
-    @column("venueid") concerts: Set<Concert>? 
+    concerts: Set<Concert>? 
     published: Boolean
     @singlePrecision latitude: Float
   }

--- a/integration-tests/non-public-schema/basic-model-no-auth-unique-table-names/src/index.exo
+++ b/integration-tests/non-public-schema/basic-model-no-auth-unique-table-names/src/index.exo
@@ -16,7 +16,7 @@ module ConcertModule {
   type Venue {
     @pk id: Int = autoIncrement() 
     name: String
-    @column("venueid") concerts: Set<Concert>? 
+    concerts: Set<Concert>? 
     published: Boolean
     @singlePrecision latitude: Float
   }


### PR DESCRIPTION
If the type-based match is unambiguous, we can skip the requirement to attach `@column` on the collection side of the relation.

```exo
@postgres
module ConcertModule {
  @access(true)
  type Concert {
    @pk
    id: Int = autoIncrement();
    title: String
    @column("venueid") venue: Venue
  }

  @access(true)
  type Venue {
    @pk id: Int = autoIncrement()
    name: String
    concerts: Set<Concert>?
  }
}
```

Earlier, we needed `@column("venueid") concerts: Set<Concert>?`.

This is a step towards replacing `@column` on collection fields with `@relation` (or equivalent) and supporting composite primary key.