### PR TITLE
Introduce the @relation annotation

### DIFF
--- a/crates/postgres-subsystem/postgres-builder/src/plugin.rs
+++ b/crates/postgres-subsystem/postgres-builder/src/plugin.rs
@@ -69,6 +69,15 @@ impl SubsystemBuilder for PostgresSubsystemBuilder {
                 },
             ),
             (
+                "relation",
+                AnnotationSpec {
+                    targets: &[AnnotationTarget::Field],
+                    no_params: false,
+                    single_params: true,
+                    mapped_params: None,
+                },
+            ),
+            (
                 "dbtype",
                 AnnotationSpec {
                     targets: &[AnnotationTarget::Field],

--- a/docs/docs/postgres/customizing-types.md
+++ b/docs/docs/postgres/customizing-types.md
@@ -210,7 +210,7 @@ module ConcertModule {
 }
 ```
 
-If you want to customize the name of the foreign key column, you can use the `@column` annotation. For example, to map the `venue` field to the `venue_pk_` column instead of `venue_id`, you can use the following setup:
+If you want to customize the name of the foreign key column, you can use the `@column` annotation. For example, to map the `venue` field to the `venue_pk` column instead of `venue_id`, you can use the following setup:
 
 ```exo
 @postgres
@@ -222,12 +222,10 @@ module ConcertModule {
 
   type Venue {
     ...
-    @column("venue_pk") concerts: Set<Concert>?
+    concerts: Set<Concert>?
   }
 }
 ```
-
-If you change the name of the foreign key column in the `Venue` type, you must also change the name of the foreign key column in the `Concert` type. This way, the column names guide Exograph to infer the relationship between the two types.
 
 ### Assigning primary key
 

--- a/error-report-testing/relation-matching/multiple-fields/error.txt
+++ b/error-report-testing/relation-matching/multiple-fields/error.txt
@@ -1,0 +1,8 @@
+error[C000]: Found multiple matching fields ('mainVenue', 'secondaryVenue') of the 'Venue' type when determining the matching column for 'concerts'. Consider using the `@relation` annotation to resolve this ambiguity.
+  --> src/index.exo:16:5
+   |
+16 |     concerts: Set<Concert>? 
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+
+Error: Parser error: Could not process input exo files
+

--- a/error-report-testing/relation-matching/multiple-fields/src/index.exo
+++ b/error-report-testing/relation-matching/multiple-fields/src/index.exo
@@ -1,0 +1,18 @@
+@postgres
+module ConcertModule {
+  @access(true)
+  type Concert {
+    @pk
+    id: Int = autoIncrement();
+    title: String
+    mainVenue: Venue 
+    secondaryVenue: Venue 
+  }
+
+  @access(true)
+  type Venue {
+    @pk id: Int = autoIncrement() 
+    name: String
+    concerts: Set<Concert>? 
+  }
+}

--- a/error-report-testing/relation-matching/relation-non-existing/error.txt
+++ b/error-report-testing/relation-matching/relation-non-existing/error.txt
@@ -1,0 +1,13 @@
+error[C000]: Could not find the matching field of the 'Concert' type 'mainVenue'. Ensure that there is only one field of that type or the '@relation' annotation specifies the matching field name.
+  --> src/index.exo:8:5
+   |
+8  |     mainVenue: Venue 
+   |     ^^^^^^^^^^^^^^^^
+error[C000]: Could not find the matching field of the 'Venue' type 'concerts'. Ensure that there is only one field of that type or the '@relation' annotation specifies the matching field name.
+  --> src/index.exo:15:5
+   |
+15 |     @relation("concerts") concerts: Set<Concert>? 
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Error: Parser error: Could not process input exo files
+

--- a/error-report-testing/relation-matching/relation-non-existing/src/index.exo
+++ b/error-report-testing/relation-matching/relation-non-existing/src/index.exo
@@ -1,0 +1,17 @@
+@postgres
+module ConcertModule {
+  @access(true)
+  type Concert {
+    @pk
+    id: Int = autoIncrement();
+    title: String
+    mainVenue: Venue 
+  }
+
+  @access(true)
+  type Venue {
+    @pk id: Int = autoIncrement() 
+    name: String
+    @relation("concerts") concerts: Set<Concert>? 
+  }
+}

--- a/integration-tests/one-to-one/no-auth-user-specified-column/src/index.exo
+++ b/integration-tests/one-to-one/no-auth-user-specified-column/src/index.exo
@@ -1,0 +1,19 @@
+// Tests are the same as in no-auth, but with a user-specified column name (thus soft-linked tests folder)
+@postgres
+module MembershipModule {
+  // A user may have an optional membership, but a membership must have an associated user
+  @access(true)
+  type User {
+    @pk id: Int = autoIncrement()
+    name: String
+    membership: Membership?
+  }
+
+  @access(true)
+  type Membership {
+    @pk id: Int = autoIncrement()
+    kind: String
+    // To test that we deal with user-specified column names correctly
+    @column("user___id") user: User
+  }
+}

--- a/integration-tests/one-to-one/no-auth-user-specified-column/tests
+++ b/integration-tests/one-to-one/no-auth-user-specified-column/tests
@@ -1,0 +1,1 @@
+../no-auth/tests

--- a/integration-tests/relation/multi-types/src/index.exo
+++ b/integration-tests/relation/multi-types/src/index.exo
@@ -4,15 +4,15 @@ module ConcertDatabase {
   type Concert {
     @pk id: Int = autoIncrement()
     title: String
-    @column("main_venue_id") mainVenue: Venue
-    @column("alt_venue_id") altVenue: Venue?
+    mainVenue: Venue
+    altVenue: Venue?
   }
 
   @access(true)
   type Venue {
     @pk id: Int = autoIncrement()
     name: String
-    @column("main_venue_id") mainConcerts: Set<Concert>?
-    @column("alt_venue_id") altConcerts: Set<Concert>?
+    @relation("mainVenue") mainConcerts: Set<Concert>?
+    @relation("altVenue") altConcerts: Set<Concert>?
   }
 }


### PR DESCRIPTION
This removes the overloaded (and confusing) semantics of the `@column` annotation. Instead of using `@column` on the collection side (the primary source of confusion since such annotation is meant to denote the column in the referred type), a dedicated `@relation` annotation is available. This change, along with the earlier change (to make @column not needed in many cases), requires the use of `@relation` only for multiple fields of the same type.

```exo
@postgres
module ConcertDatabase {
  @access(true)
  type Concert {
    @pk id: Int = autoIncrement()
    title: String
    mainVenue: Venue
    altVenue: Venue?
  }

  @access(true)
  type Venue {
    @pk id: Int = autoIncrement()
    name: String
    @relation("mainVenue") mainConcerts: Set<Concert>?
    @relation("altVenue") altConcerts: Set<Concert>?
  }
}
```