### PR TITLE
Support composite primary keys of scalar fields

### DIFF
--- a/crates/cli/src/commands/schema/import.rs
+++ b/crates/cli/src/commands/schema/import.rs
@@ -10,7 +10,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use clap::Command;
-use exo_sql::schema::column_spec::{ColumnSpec, ColumnTypeSpec};
+use exo_sql::schema::column_spec::{ColumnReferenceSpec, ColumnSpec, ColumnTypeSpec};
 use exo_sql::schema::database_spec::DatabaseSpec;
 use exo_sql::schema::issue::WithIssues;
 use exo_sql::schema::spec::{MigrationScope, MigrationScopeMatches};
@@ -155,9 +155,9 @@ impl ToModel for ColumnSpec {
         };
 
         let (mut data_type, annots) = self.typ.to_model();
-        if let ColumnTypeSpec::ColumnReference {
+        if let ColumnTypeSpec::ColumnReference(ColumnReferenceSpec {
             foreign_table_name, ..
-        } = &self.typ
+        }) = &self.typ
         {
             data_type = to_model_name(&data_type);
 

--- a/crates/postgres-subsystem/postgres-core-builder/src/access_utils.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/access_utils.rs
@@ -1097,7 +1097,7 @@ fn reduce_nested_primitive_expr(
 
             match head {
                 ColumnPathLink::Relation(r)
-                    if r.foreign_column_id.table_id == parent_entity.table_id =>
+                    if r.column_pairs[0].foreign_column_id.table_id == parent_entity.table_id =>
                 {
                     // Eliminate the head link. For example if the expression is self.user.id, then
                     // we can reduce it to just id (assuming that the parent entity is user)
@@ -1114,7 +1114,7 @@ fn reduce_nested_primitive_expr(
 
             match head {
                 ColumnPathLink::Relation(r)
-                    if r.foreign_column_id.table_id == parent_entity.table_id =>
+                    if r.column_pairs[0].foreign_column_id.table_id == parent_entity.table_id =>
                 {
                     // Eliminate the head link. For example if the expression is self.user.id, then
                     // we can reduce it to just id (assuming that the parent entity is user)

--- a/crates/postgres-subsystem/postgres-core-builder/src/access_utils.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/access_utils.rs
@@ -1096,9 +1096,7 @@ fn reduce_nested_primitive_expr(
             let (head, tail) = pc.split_head();
 
             match head {
-                ColumnPathLink::Relation(r)
-                    if r.column_pairs[0].foreign_column_id.table_id == parent_entity.table_id =>
-                {
+                ColumnPathLink::Relation(r) if r.linked_table_id() == parent_entity.table_id => {
                     // Eliminate the head link. For example if the expression is self.user.id, then
                     // we can reduce it to just id (assuming that the parent entity is user)
                     NestedPredicatePart::Parent(DatabaseAccessPrimitiveExpression::Column(
@@ -1113,9 +1111,7 @@ fn reduce_nested_primitive_expr(
             let (head, tail) = pc.split_head();
 
             match head {
-                ColumnPathLink::Relation(r)
-                    if r.column_pairs[0].foreign_column_id.table_id == parent_entity.table_id =>
-                {
+                ColumnPathLink::Relation(r) if r.linked_table_id() == parent_entity.table_id => {
                     // Eliminate the head link. For example if the expression is self.user.id, then
                     // we can reduce it to just id (assuming that the parent entity is user)
                     NestedPredicatePart::Parent(DatabaseAccessPrimitiveExpression::Column(

--- a/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
@@ -181,11 +181,9 @@ fn expand_type_relations(
         }
 
         if field.self_column {
-            let self_column_ids: Vec<ColumnId> = field
-                .column_names
-                .iter()
-                .map(|name| building.database.get_column_id(table_id, name).unwrap())
-                .collect();
+            let self_column_ids = building
+                .database
+                .get_column_ids_from_names(table_id, &field.column_names);
             if let Some(relation) =
                 compute_many_to_one_relation(field, self_column_ids.clone(), resolved_env, building)
             {

--- a/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
@@ -277,37 +277,6 @@ fn create_columns(
                     // Many-to-one:
                     // Column from the current table (but of the type of the pk column of the other table)
                     // and it refers to the pk column in the other table.
-                    // Ok(composite
-                    //     .fields
-                    //     .iter()
-                    //     .filter(|field| field.is_pk)
-                    //     .map(|field| {
-                    //         println!("creating column: {:?} in {}", field, &composite.name);
-                    //         PhysicalColumn {
-                    //             table_id,
-                    //             // name: format!("{}_{}", composite.name, field.column_name),
-                    //             name: field.column_name.to_string(),
-                    //             typ: if composite.representation == EntityRepresentation::Json {
-                    //                 PhysicalColumnType::Json
-                    //             } else {
-                    //                 // A placeholder value. Will be resolved in the next phase (see expand_type_relations)
-                    //                 PhysicalColumnType::Boolean
-                    //             },
-                    //             is_pk: false,
-                    //             is_auto_increment: false,
-                    //             is_nullable: optional,
-                    //             unique_constraints: unique_constraint_name.clone(),
-                    //             default_value: default_value.clone(),
-                    //             update_sync,
-                    //         }
-                    //     })
-                    //     .collect())
-
-                    println!(
-                        "creating column: {:?} in {}",
-                        field.column_name, &composite.name
-                    );
-
                     Ok(vec![PhysicalColumn {
                         table_id,
                         name: field.column_name.to_string(),

--- a/crates/postgres-subsystem/postgres-core-builder/src/resolved_type.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/resolved_type.rs
@@ -70,7 +70,7 @@ impl ToPlural for ResolvedCompositeType {
 pub struct ResolvedField {
     pub name: String,
     pub typ: FieldType<ResolvedFieldType>,
-    pub column_name: String,
+    pub column_names: Vec<String>,
     pub self_column: bool, // is the column name in the same table or does it point to a column in a different table?
     pub is_pk: bool,
     pub access: ResolvedAccess,
@@ -155,8 +155,8 @@ impl ResolvedCompositeType {
         self.fields.iter().find(|f| f.is_pk)
     }
 
-    pub fn field_by_column_name(&self, column_name: &str) -> Option<&ResolvedField> {
-        self.fields.iter().find(|f| f.column_name == column_name)
+    pub fn field_by_column_names(&self, column_names: &[String]) -> Option<&ResolvedField> {
+        self.fields.iter().find(|f| f.column_names == column_names)
     }
 
     pub fn unique_constraints(&self) -> HashMap<String, Vec<&ResolvedField>> {

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/column_names_for_non_standard_relational_field_names.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/column_names_for_non_standard_relational_field_names.snap
@@ -47,7 +47,8 @@ values:
               Plain:
                 type_name: Int
                 is_primitive: true
-            column_name: id
+            column_names:
+              - id
             self_column: true
             is_pk: true
             access:
@@ -70,7 +71,8 @@ values:
               Plain:
                 type_name: String
                 is_primitive: true
-            column_name: title
+            column_names:
+              - title
             self_column: true
             is_pk: false
             access:
@@ -93,7 +95,8 @@ values:
               Plain:
                 type_name: Venue
                 is_primitive: false
-            column_name: venuex_id
+            column_names:
+              - venuex_id
             self_column: true
             is_pk: false
             access:
@@ -116,7 +119,8 @@ values:
               Plain:
                 type_name: Boolean
                 is_primitive: true
-            column_name: published
+            column_names:
+              - published
             self_column: true
             is_pk: false
             access:
@@ -155,7 +159,8 @@ values:
               Plain:
                 type_name: Int
                 is_primitive: true
-            column_name: id
+            column_names:
+              - id
             self_column: true
             is_pk: true
             access:
@@ -178,7 +183,8 @@ values:
               Plain:
                 type_name: String
                 is_primitive: true
-            column_name: name
+            column_names:
+              - name
             self_column: true
             is_pk: false
             access:
@@ -202,7 +208,8 @@ values:
                 Plain:
                   type_name: Concert
                   is_primitive: false
-            column_name: venuex_id
+            column_names:
+              - venuex_id
             self_column: false
             is_pk: false
             access:
@@ -225,7 +232,8 @@ values:
               Plain:
                 type_name: Boolean
                 is_primitive: true
-            column_name: published
+            column_names:
+              - published
             self_column: true
             is_pk: false
             access:

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/field_name_variations.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/field_name_variations.snap
@@ -47,7 +47,8 @@ values:
               Plain:
                 type_name: Int
                 is_primitive: true
-            column_name: id
+            column_names:
+              - id
             self_column: true
             is_pk: true
             access:
@@ -70,7 +71,8 @@ values:
               Plain:
                 type_name: String
                 is_primitive: true
-            column_name: title_main
+            column_names:
+              - title_main
             self_column: true
             is_pk: false
             access:
@@ -93,7 +95,8 @@ values:
               Plain:
                 type_name: String
                 is_primitive: true
-            column_name: title_main1
+            column_names:
+              - title_main1
             self_column: true
             is_pk: false
             access:
@@ -116,7 +119,8 @@ values:
               Plain:
                 type_name: Boolean
                 is_primitive: true
-            column_name: public1
+            column_names:
+              - public1
             self_column: true
             is_pk: false
             access:
@@ -139,7 +143,8 @@ values:
               Plain:
                 type_name: Boolean
                 is_primitive: true
-            column_name: public2
+            column_names:
+              - public2
             self_column: true
             is_pk: false
             access:
@@ -162,7 +167,8 @@ values:
               Plain:
                 type_name: Int
                 is_primitive: true
-            column_name: foo123
+            column_names:
+              - foo123
             self_column: true
             is_pk: false
             access:

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/non_public_schema.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/non_public_schema.snap
@@ -47,7 +47,8 @@ values:
               Plain:
                 type_name: Int
                 is_primitive: true
-            column_name: id
+            column_names:
+              - id
             self_column: true
             is_pk: true
             access:
@@ -70,7 +71,8 @@ values:
               Plain:
                 type_name: String
                 is_primitive: true
-            column_name: name
+            column_names:
+              - name
             self_column: true
             is_pk: false
             access:
@@ -109,7 +111,8 @@ values:
               Plain:
                 type_name: Int
                 is_primitive: true
-            column_name: id
+            column_names:
+              - id
             self_column: true
             is_pk: true
             access:
@@ -132,7 +135,8 @@ values:
               Plain:
                 type_name: String
                 is_primitive: true
-            column_name: name
+            column_names:
+              - name
             self_column: true
             is_pk: false
             access:

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_access.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_access.snap
@@ -47,7 +47,8 @@ values:
               Plain:
                 type_name: Int
                 is_primitive: true
-            column_name: id
+            column_names:
+              - id
             self_column: true
             is_pk: true
             access:
@@ -70,7 +71,8 @@ values:
               Plain:
                 type_name: String
                 is_primitive: true
-            column_name: title
+            column_names:
+              - title
             self_column: true
             is_pk: false
             access:
@@ -93,7 +95,8 @@ values:
               Plain:
                 type_name: Boolean
                 is_primitive: true
-            column_name: public
+            column_names:
+              - public
             self_column: true
             is_pk: false
             access:
@@ -174,7 +177,8 @@ values:
               Plain:
                 type_name: Int
                 is_primitive: true
-            column_name: id
+            column_names:
+              - id
             self_column: true
             is_pk: true
             access:
@@ -197,7 +201,8 @@ values:
               Plain:
                 type_name: String
                 is_primitive: true
-            column_name: name
+            column_names:
+              - name
             self_column: true
             is_pk: false
             access:
@@ -238,7 +243,8 @@ values:
               Plain:
                 type_name: Int
                 is_primitive: true
-            column_name: id
+            column_names:
+              - id
             self_column: true
             is_pk: true
             access:
@@ -261,7 +267,8 @@ values:
               Plain:
                 type_name: String
                 is_primitive: true
-            column_name: name
+            column_names:
+              - name
             self_column: true
             is_pk: false
             access:

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_access_default_values.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_access_default_values.snap
@@ -47,7 +47,8 @@ values:
               Plain:
                 type_name: Int
                 is_primitive: true
-            column_name: id
+            column_names:
+              - id
             self_column: true
             is_pk: true
             access:
@@ -70,7 +71,8 @@ values:
               Plain:
                 type_name: String
                 is_primitive: true
-            column_name: title
+            column_names:
+              - title
             self_column: true
             is_pk: false
             access:
@@ -93,7 +95,8 @@ values:
               Plain:
                 type_name: Boolean
                 is_primitive: true
-            column_name: public
+            column_names:
+              - public
             self_column: true
             is_pk: false
             access:

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_annotations.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_annotations.snap
@@ -47,7 +47,8 @@ values:
               Plain:
                 type_name: Int
                 is_primitive: true
-            column_name: custom_id
+            column_names:
+              - custom_id
             self_column: true
             is_pk: true
             access:
@@ -72,7 +73,8 @@ values:
               Plain:
                 type_name: String
                 is_primitive: true
-            column_name: custom_title
+            column_names:
+              - custom_title
             self_column: true
             is_pk: false
             access:
@@ -97,7 +99,8 @@ values:
               Plain:
                 type_name: Venue
                 is_primitive: false
-            column_name: custom_venue_id
+            column_names:
+              - custom_venue_id
             self_column: true
             is_pk: false
             access:
@@ -120,7 +123,8 @@ values:
               Plain:
                 type_name: Int
                 is_primitive: true
-            column_name: reserved
+            column_names:
+              - reserved
             self_column: true
             is_pk: false
             access:
@@ -148,7 +152,8 @@ values:
               Plain:
                 type_name: Instant
                 is_primitive: true
-            column_name: time
+            column_names:
+              - time
             self_column: true
             is_pk: false
             access:
@@ -173,7 +178,8 @@ values:
               Plain:
                 type_name: Decimal
                 is_primitive: true
-            column_name: price
+            column_names:
+              - price
             self_column: true
             is_pk: false
             access:
@@ -215,7 +221,8 @@ values:
               Plain:
                 type_name: Int
                 is_primitive: true
-            column_name: custom_id
+            column_names:
+              - custom_id
             self_column: true
             is_pk: true
             access:
@@ -238,7 +245,8 @@ values:
               Plain:
                 type_name: String
                 is_primitive: true
-            column_name: custom_name
+            column_names:
+              - custom_name
             self_column: true
             is_pk: false
             access:
@@ -262,7 +270,8 @@ values:
                 Plain:
                   type_name: Concert
                   is_primitive: false
-            column_name: custom_venue_id
+            column_names:
+              - custom_venue_id
             self_column: false
             is_pk: false
             access:
@@ -285,7 +294,8 @@ values:
               Plain:
                 type_name: Int
                 is_primitive: true
-            column_name: capacity
+            column_names:
+              - capacity
             self_column: true
             is_pk: false
             access:
@@ -311,7 +321,8 @@ values:
               Plain:
                 type_name: Float
                 is_primitive: true
-            column_name: latitude
+            column_names:
+              - latitude
             self_column: true
             is_pk: false
             access:

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_camel_case_model_and_fields.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_camel_case_model_and_fields.snap
@@ -47,7 +47,8 @@ values:
               Plain:
                 type_name: Int
                 is_primitive: true
-            column_name: concert_id
+            column_names:
+              - concert_id
             self_column: true
             is_pk: true
             access:
@@ -70,7 +71,8 @@ values:
               Plain:
                 type_name: String
                 is_primitive: true
-            column_name: main_title
+            column_names:
+              - main_title
             self_column: true
             is_pk: false
             access:

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_defaults.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_defaults.snap
@@ -47,7 +47,8 @@ values:
               Plain:
                 type_name: Int
                 is_primitive: true
-            column_name: id
+            column_names:
+              - id
             self_column: true
             is_pk: true
             access:
@@ -72,7 +73,8 @@ values:
               Plain:
                 type_name: String
                 is_primitive: true
-            column_name: title
+            column_names:
+              - title
             self_column: true
             is_pk: false
             access:
@@ -95,7 +97,8 @@ values:
               Plain:
                 type_name: Venue
                 is_primitive: false
-            column_name: venue_id
+            column_names:
+              - venue_id
             self_column: true
             is_pk: false
             access:
@@ -120,7 +123,8 @@ values:
                 Plain:
                   type_name: String
                   is_primitive: true
-            column_name: attending
+            column_names:
+              - attending
             self_column: true
             is_pk: false
             access:
@@ -145,7 +149,8 @@ values:
                   Plain:
                     type_name: Boolean
                     is_primitive: true
-            column_name: seating
+            column_names:
+              - seating
             self_column: true
             is_pk: false
             access:
@@ -184,7 +189,8 @@ values:
               Plain:
                 type_name: Int
                 is_primitive: true
-            column_name: id
+            column_names:
+              - id
             self_column: true
             is_pk: true
             access:
@@ -209,7 +215,8 @@ values:
               Plain:
                 type_name: String
                 is_primitive: true
-            column_name: name
+            column_names:
+              - name
             self_column: true
             is_pk: false
             access:
@@ -233,7 +240,8 @@ values:
                 Plain:
                   type_name: Concert
                   is_primitive: false
-            column_name: venue_id
+            column_names:
+              - venue_id
             self_column: false
             is_pk: false
             access:

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_multiple_matching_field_with_column_annotation.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_multiple_matching_field_with_column_annotation.snap
@@ -47,7 +47,8 @@ values:
               Plain:
                 type_name: Int
                 is_primitive: true
-            column_name: id
+            column_names:
+              - id
             self_column: true
             is_pk: true
             access:
@@ -70,7 +71,8 @@ values:
               Plain:
                 type_name: String
                 is_primitive: true
-            column_name: title
+            column_names:
+              - title
             self_column: true
             is_pk: false
             access:
@@ -93,7 +95,8 @@ values:
               Plain:
                 type_name: Venue
                 is_primitive: false
-            column_name: ticket_office
+            column_names:
+              - ticket_office
             self_column: true
             is_pk: false
             access:
@@ -116,7 +119,8 @@ values:
               Plain:
                 type_name: Venue
                 is_primitive: false
-            column_name: main
+            column_names:
+              - main
             self_column: true
             is_pk: false
             access:
@@ -155,7 +159,8 @@ values:
               Plain:
                 type_name: Int
                 is_primitive: true
-            column_name: id
+            column_names:
+              - id
             self_column: true
             is_pk: true
             access:
@@ -178,7 +183,8 @@ values:
               Plain:
                 type_name: String
                 is_primitive: true
-            column_name: name
+            column_names:
+              - name
             self_column: true
             is_pk: false
             access:
@@ -202,7 +208,8 @@ values:
                 Plain:
                   type_name: Concert
                   is_primitive: false
-            column_name: ticket_office
+            column_names:
+              - ticket_office
             self_column: false
             is_pk: false
             access:
@@ -226,7 +233,8 @@ values:
                 Plain:
                   type_name: Concert
                   is_primitive: false
-            column_name: main
+            column_names:
+              - main
             self_column: false
             is_pk: false
             access:

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_optional_fields.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_optional_fields.snap
@@ -47,7 +47,8 @@ values:
               Plain:
                 type_name: Int
                 is_primitive: true
-            column_name: id
+            column_names:
+              - id
             self_column: true
             is_pk: true
             access:
@@ -70,7 +71,8 @@ values:
               Plain:
                 type_name: String
                 is_primitive: true
-            column_name: title
+            column_names:
+              - title
             self_column: true
             is_pk: false
             access:
@@ -94,7 +96,8 @@ values:
                 Plain:
                   type_name: Venue
                   is_primitive: false
-            column_name: venue_id
+            column_names:
+              - venue_id
             self_column: true
             is_pk: false
             access:
@@ -118,7 +121,8 @@ values:
                 Plain:
                   type_name: Blob
                   is_primitive: true
-            column_name: icon
+            column_names:
+              - icon
             self_column: true
             is_pk: false
             access:
@@ -157,7 +161,8 @@ values:
               Plain:
                 type_name: Int
                 is_primitive: true
-            column_name: id
+            column_names:
+              - id
             self_column: true
             is_pk: true
             access:
@@ -180,7 +185,8 @@ values:
               Plain:
                 type_name: String
                 is_primitive: true
-            column_name: name
+            column_names:
+              - name
             self_column: true
             is_pk: false
             access:
@@ -204,7 +210,8 @@ values:
                 Plain:
                   type_name: String
                   is_primitive: true
-            column_name: custom_address
+            column_names:
+              - custom_address
             self_column: true
             is_pk: false
             access:
@@ -229,7 +236,8 @@ values:
                   Plain:
                     type_name: Concert
                     is_primitive: false
-            column_name: venue_id
+            column_names:
+              - venue_id
             self_column: false
             is_pk: false
             access:

--- a/crates/postgres-subsystem/postgres-core-builder/src/type_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/type_builder.rs
@@ -600,11 +600,8 @@ fn create_relation(
     let self_table_id = &self_type.table_id;
 
     if field.is_pk {
-        let column_id = building
-            .database
-            .get_column_id(*self_table_id, &field.column_names[0])
-            .unwrap();
-        PostgresRelation::Pk { column_id }
+        let column_ids = building.database.get_pk_column_ids(*self_table_id);
+        PostgresRelation::Pk { column_ids }
     } else {
         // we can treat Optional fields as their inner type for the purposes of computing relations
         let field_base_typ = &field.typ.base_type();

--- a/crates/postgres-subsystem/postgres-core-builder/src/type_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/type_builder.rs
@@ -562,7 +562,7 @@ fn create_vector_distance_field(
             let self_table_id = &self_type.table_id;
             let column_id = building
                 .database
-                .get_column_id(*self_table_id, &field.column_name)
+                .get_column_id(*self_table_id, &field.column_names[0])
                 .unwrap();
 
             let access = compute_access(&field.access, *type_id, env, building).unwrap();
@@ -602,7 +602,7 @@ fn create_relation(
     if field.is_pk {
         let column_id = building
             .database
-            .get_column_id(*self_table_id, &field.column_name)
+            .get_column_id(*self_table_id, &field.column_names[0])
             .unwrap();
         PostgresRelation::Pk { column_id }
     } else {
@@ -621,7 +621,7 @@ fn create_relation(
                         ResolvedType::Primitive(_) => PostgresRelation::Scalar {
                             column_id: building
                                 .database
-                                .get_column_id(*self_table_id, &field.column_name)
+                                .get_column_id(*self_table_id, &field.column_names[0])
                                 .unwrap(),
                         },
                         ResolvedType::Composite(foreign_field_type) => {
@@ -629,7 +629,7 @@ fn create_relation(
                                 PostgresRelation::Scalar {
                                     column_id: building
                                         .database
-                                        .get_column_id(*self_table_id, &field.column_name)
+                                        .get_column_id(*self_table_id, &field.column_names[0])
                                         .unwrap(),
                                 }
                             } else if expand_foreign_relations {
@@ -657,7 +657,7 @@ fn create_relation(
                         } else {
                             let column_id = building
                                 .database
-                                .get_column_id(*self_table_id, &field.column_name)
+                                .get_column_id(*self_table_id, &field.column_names[0])
                                 .unwrap();
                             PostgresRelation::Scalar { column_id }
                         }
@@ -667,7 +667,7 @@ fn create_relation(
                             PostgresRelation::Scalar {
                                 column_id: building
                                     .database
-                                    .get_column_id(*self_table_id, &field.column_name)
+                                    .get_column_id(*self_table_id, &field.column_names[0])
                                     .unwrap(),
                             }
                         } else {
@@ -675,7 +675,7 @@ fn create_relation(
                             // but we can't be sure if this is a ManyToOne or OneToMany unless we examine the other side's type.
                             let foreign_type_field_typ = &foreign_resolved_type
                                 .as_composite()
-                                .field_by_column_name(&field.column_name)
+                                .field_by_column_names(&field.column_names)
                                 .unwrap()
                                 .typ;
 
@@ -755,13 +755,13 @@ fn compute_many_to_one(
 
     let foreign_column_id = building
         .database
-        .get_column_id(foreign_table_id, &field.column_name)
+        .get_column_id(foreign_table_id, &field.column_names[0])
         .unwrap();
 
     let foreign_resolved_field = foreign_field_type
         .fields
         .iter()
-        .find(|f| f.column_name == field.column_name)
+        .find(|f| f.column_names == field.column_names)
         .unwrap();
 
     let foreign_field_id = get_field_id(
@@ -798,7 +798,7 @@ fn compute_one_to_many_relation(
 
     let self_column_id = building
         .database
-        .get_column_id(*self_table_id, &field.column_name)
+        .get_column_id(*self_table_id, &field.column_names[0])
         .unwrap();
     let foreign_pk_field_id = foreign_type.pk_field_id(foreign_type_id).unwrap();
 

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices-non-public-schemas/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices-non-public-schemas/scope-all-schemas/down.sql
@@ -17,5 +17,5 @@ CREATE TABLE "venues" (
 
 -- DROP SCHEMA "v" CASCADE;
 
-ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
 

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices-non-public-schemas/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices-non-public-schemas/scope-all-schemas/new.sql
@@ -13,7 +13,7 @@ CREATE TABLE "v"."venues" (
 	"name" TEXT NOT NULL
 );
 
-ALTER TABLE "c"."concerts" ADD CONSTRAINT "c_concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "v"."venues";
+ALTER TABLE "c"."concerts" ADD CONSTRAINT "c_concerts_venue_fk" FOREIGN KEY ("venue_id") REFERENCES "v"."venues";
 
 CREATE INDEX "concert_title_idx" ON "c"."concerts" ("title");
 

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices-non-public-schemas/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices-non-public-schemas/scope-all-schemas/old.sql
@@ -9,5 +9,5 @@ CREATE TABLE "venues" (
 	"name" TEXT NOT NULL
 );
 
-ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
 

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices-non-public-schemas/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices-non-public-schemas/scope-all-schemas/up.sql
@@ -17,7 +17,7 @@ CREATE TABLE "v"."venues" (
 	"name" TEXT NOT NULL
 );
 
-ALTER TABLE "c"."concerts" ADD CONSTRAINT "c_concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "v"."venues";
+ALTER TABLE "c"."concerts" ADD CONSTRAINT "c_concerts_venue_fk" FOREIGN KEY ("venue_id") REFERENCES "v"."venues";
 
 CREATE INDEX "concert_title_idx" ON "c"."concerts" ("title");
 

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices/scope-all-schemas/new.sql
@@ -9,7 +9,7 @@ CREATE TABLE "venues" (
 	"name" TEXT NOT NULL
 );
 
-ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
 
 CREATE INDEX "concert_title_idx" ON "concerts" ("title");
 

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-indices/scope-all-schemas/old.sql
@@ -9,5 +9,5 @@ CREATE TABLE "venues" (
 	"name" TEXT NOT NULL
 );
 
-ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
 

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-and-related-model/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-and-related-model/scope-all-schemas/new.sql
@@ -9,5 +9,5 @@ CREATE TABLE "venues" (
 	"name" TEXT NOT NULL
 );
 
-ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
 

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-and-related-model/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-and-related-model/scope-all-schemas/up.sql
@@ -5,5 +5,5 @@ CREATE TABLE "venues" (
 	"name" TEXT NOT NULL
 );
 
-ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
 

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-field/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-field/scope-all-schemas/new.sql
@@ -9,5 +9,5 @@ CREATE TABLE "venues" (
 	"name" TEXT NOT NULL
 );
 
-ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
 

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-field/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-relation-field/scope-all-schemas/up.sql
@@ -1,4 +1,4 @@
 ALTER TABLE "concerts" ADD "venue_id" INT NOT NULL;
 
-ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
 

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/composite-pk-reorder-fields/new/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/composite-pk-reorder-fields/new/src/index.exo
@@ -2,8 +2,7 @@
 module PeopleDatabase {
   @access(true)
   type Person {
-    @pk firstName: String
-    @pk lastName: String
+    @pk name: String
     age: Int
     address: Address?
   }

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/composite-pk-reorder-fields/old/src/index.exo
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/composite-pk-reorder-fields/old/src/index.exo
@@ -2,17 +2,16 @@
 module PeopleDatabase {
   @access(true)
   type Person {
-    @pk firstName: String
-    @pk lastName: String
+    @pk name: String
     age: Int
     address: Address?
   }
 
   type Address {
     @pk street: String
-    @pk city: String
-    @pk state: String
     @pk zip: Int
+    @pk state: String
+    @pk city: String
     people: Set<Person>?
   }
 }

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/composite-pk-reorder-fields/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/composite-pk-reorder-fields/scope-all-schemas/new.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "persons" (
+	"name" TEXT PRIMARY KEY,
+	"age" INT NOT NULL,
+	"address_street" TEXT,
+	"address_city" TEXT,
+	"address_state" TEXT,
+	"address_zip" INT
+);
+
+CREATE TABLE "addresss" (
+	"street" TEXT,
+	"city" TEXT,
+	"state" TEXT,
+	"zip" INT,
+	PRIMARY KEY ("street", "city", "state", "zip")
+);
+
+ALTER TABLE "persons" ADD CONSTRAINT "persons_address_fk" FOREIGN KEY ("address_city", "address_state", "address_street", "address_zip") REFERENCES "addresss" ("city", "state", "street", "zip");
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/composite-pk-reorder-fields/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/composite-pk-reorder-fields/scope-all-schemas/old.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "persons" (
+	"name" TEXT PRIMARY KEY,
+	"age" INT NOT NULL,
+	"address_street" TEXT,
+	"address_zip" INT,
+	"address_state" TEXT,
+	"address_city" TEXT
+);
+
+CREATE TABLE "addresss" (
+	"street" TEXT,
+	"zip" INT,
+	"state" TEXT,
+	"city" TEXT,
+	PRIMARY KEY ("street", "zip", "state", "city")
+);
+
+ALTER TABLE "persons" ADD CONSTRAINT "persons_address_fk" FOREIGN KEY ("address_city", "address_state", "address_street", "address_zip") REFERENCES "addresss" ("city", "state", "street", "zip");
+

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/modify-multi-column-indices/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/modify-multi-column-indices/scope-all-schemas/new.sql
@@ -9,7 +9,7 @@ CREATE TABLE "venues" (
 	"name" TEXT NOT NULL
 );
 
-ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
 
 CREATE INDEX "title" ON "concerts" ("title");
 

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/modify-multi-column-indices/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/modify-multi-column-indices/scope-all-schemas/old.sql
@@ -9,7 +9,7 @@ CREATE TABLE "venues" (
 	"name" TEXT NOT NULL
 );
 
-ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
 
 CREATE INDEX "concert_title_idx" ON "concerts" ("title");
 

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-module-level-schema/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-module-level-schema/scope-all-schemas/down.sql
@@ -16,5 +16,5 @@ CREATE TABLE "users" (
 
 -- DROP SCHEMA "info" CASCADE;
 
-ALTER TABLE "logs" ADD CONSTRAINT "logs_owner_id_fk" FOREIGN KEY ("owner_id") REFERENCES "users";
+ALTER TABLE "logs" ADD CONSTRAINT "logs_owner_fk" FOREIGN KEY ("owner_id") REFERENCES "users";
 

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-module-level-schema/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-module-level-schema/scope-all-schemas/new.sql
@@ -12,5 +12,5 @@ CREATE TABLE "info"."users" (
 	"name" TEXT NOT NULL
 );
 
-ALTER TABLE "info"."logs" ADD CONSTRAINT "info_logs_owner_id_fk" FOREIGN KEY ("owner_id") REFERENCES "info"."users";
+ALTER TABLE "info"."logs" ADD CONSTRAINT "info_logs_owner_fk" FOREIGN KEY ("owner_id") REFERENCES "info"."users";
 

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-module-level-schema/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-module-level-schema/scope-all-schemas/old.sql
@@ -10,5 +10,5 @@ CREATE TABLE "users" (
 	"name" TEXT NOT NULL
 );
 
-ALTER TABLE "logs" ADD CONSTRAINT "logs_owner_id_fk" FOREIGN KEY ("owner_id") REFERENCES "users";
+ALTER TABLE "logs" ADD CONSTRAINT "logs_owner_fk" FOREIGN KEY ("owner_id") REFERENCES "users";
 

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-module-level-schema/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-module-level-schema/scope-all-schemas/up.sql
@@ -16,5 +16,5 @@ CREATE TABLE "info"."users" (
 	"name" TEXT NOT NULL
 );
 
-ALTER TABLE "info"."logs" ADD CONSTRAINT "info_logs_owner_id_fk" FOREIGN KEY ("owner_id") REFERENCES "info"."users";
+ALTER TABLE "info"."logs" ADD CONSTRAINT "info_logs_owner_fk" FOREIGN KEY ("owner_id") REFERENCES "info"."users";
 

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-schema/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-schema/scope-all-schemas/new.sql
@@ -12,5 +12,5 @@ CREATE TABLE "auth"."users" (
 	"name" TEXT NOT NULL
 );
 
-ALTER TABLE "logs" ADD CONSTRAINT "logs_owner_id_fk" FOREIGN KEY ("owner_id") REFERENCES "auth"."users";
+ALTER TABLE "logs" ADD CONSTRAINT "logs_owner_fk" FOREIGN KEY ("owner_id") REFERENCES "auth"."users";
 

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-schema/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/non-public-schema/scope-all-schemas/old.sql
@@ -10,5 +10,5 @@ CREATE TABLE "users" (
 	"name" TEXT NOT NULL
 );
 
-ALTER TABLE "logs" ADD CONSTRAINT "logs_owner_id_fk" FOREIGN KEY ("owner_id") REFERENCES "users";
+ALTER TABLE "logs" ADD CONSTRAINT "logs_owner_fk" FOREIGN KEY ("owner_id") REFERENCES "users";
 

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/one-to-one-constraints/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/one-to-one-constraints/scope-all-schemas/new.sql
@@ -8,7 +8,7 @@ CREATE TABLE "users" (
 	"name" TEXT NOT NULL
 );
 
-ALTER TABLE "memberships" ADD CONSTRAINT "memberships_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "users";
-
 ALTER TABLE "memberships" ADD CONSTRAINT "unique_constraint_membership_user" UNIQUE ("user_id");
+
+ALTER TABLE "memberships" ADD CONSTRAINT "memberships_user_fk" FOREIGN KEY ("user_id") REFERENCES "users";
 

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/one-to-one-constraints/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/one-to-one-constraints/scope-all-schemas/up.sql
@@ -2,5 +2,5 @@ ALTER TABLE "memberships" ADD "user_id" INT NOT NULL;
 
 ALTER TABLE "memberships" ADD CONSTRAINT "unique_constraint_membership_user" UNIQUE ("user_id");
 
-ALTER TABLE "memberships" ADD CONSTRAINT "memberships_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "users";
+ALTER TABLE "memberships" ADD CONSTRAINT "memberships_user_fk" FOREIGN KEY ("user_id") REFERENCES "users";
 

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/update-relation-optionality/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/update-relation-optionality/scope-all-schemas/new.sql
@@ -9,5 +9,5 @@ CREATE TABLE "venues" (
 	"name" TEXT NOT NULL
 );
 
-ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
 

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/update-relation-optionality/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/update-relation-optionality/scope-all-schemas/old.sql
@@ -9,5 +9,5 @@ CREATE TABLE "venues" (
 	"name" TEXT NOT NULL
 );
 
-ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_id_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
+ALTER TABLE "concerts" ADD CONSTRAINT "concerts_venue_fk" FOREIGN KEY ("venue_id") REFERENCES "venues";
 

--- a/crates/postgres-subsystem/postgres-core-model/src/relation.rs
+++ b/crates/postgres-subsystem/postgres-core-model/src/relation.rs
@@ -34,11 +34,11 @@ pub enum PostgresRelation {
 pub struct ManyToOneRelation {
     // For the `Concert.venue` field (assuming [Concert] -> Venue), we will have:
     // - cardinality: Unbounded
-    // - foreign_pk_field_id: Venue.id
+    // - foreign_pk_field_ids: [Venue.id]
     // - relation_id.self_column_id: concerts.venue_id
     // - relation_id.foreign_pk_column_id: venues.id
     pub cardinality: RelationCardinality,
-    pub foreign_pk_field_id: EntityFieldId,
+    pub foreign_pk_field_ids: Vec<EntityFieldId>,
     pub relation_id: ManyToOneId,
 }
 

--- a/crates/postgres-subsystem/postgres-core-model/src/relation.rs
+++ b/crates/postgres-subsystem/postgres-core-model/src/relation.rs
@@ -23,7 +23,7 @@ pub enum RelationCardinality {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum PostgresRelation {
-    Pk { column_id: ColumnId },
+    Pk { column_ids: Vec<ColumnId> },
     Scalar { column_id: ColumnId },
     ManyToOne(ManyToOneRelation),
     OneToMany(OneToManyRelation),
@@ -72,9 +72,8 @@ impl OneToManyRelation {
 impl PostgresRelation {
     pub fn column_path_link(&self, database: &Database) -> ColumnPathLink {
         match &self {
-            PostgresRelation::Pk { column_id, .. } | PostgresRelation::Scalar { column_id, .. } => {
-                ColumnPathLink::Leaf(*column_id)
-            }
+            PostgresRelation::Pk { column_ids, .. } => ColumnPathLink::Leaf(column_ids[0]),
+            PostgresRelation::Scalar { column_id, .. } => ColumnPathLink::Leaf(*column_id),
             PostgresRelation::ManyToOne(relation) => relation.column_path_link(database),
             PostgresRelation::OneToMany(relation) => relation.column_path_link(database),
             PostgresRelation::Embedded => {

--- a/crates/postgres-subsystem/postgres-core-model/src/types.rs
+++ b/crates/postgres-subsystem/postgres-core-model/src/types.rs
@@ -125,20 +125,20 @@ impl EntityType {
         self.fields.iter().find(|field| field.name == name)
     }
 
-    pub fn pk_field(&self) -> Option<&PostgresField<EntityType>> {
+    pub fn pk_fields(&self) -> Vec<&PostgresField<EntityType>> {
         self.fields
             .iter()
-            .find(|field| matches!(&field.relation, PostgresRelation::Pk { .. }))
+            .filter(|field| matches!(&field.relation, PostgresRelation::Pk { .. }))
+            .collect()
     }
 
-    pub fn pk_field_id(
-        &self,
-        entity_id: SerializableSlabIndex<EntityType>,
-    ) -> Option<EntityFieldId> {
+    pub fn pk_field_ids(&self, entity_id: SerializableSlabIndex<EntityType>) -> Vec<EntityFieldId> {
         self.fields
             .iter()
-            .position(|field| matches!(&field.relation, PostgresRelation::Pk { .. }))
-            .map(|field_index| EntityFieldId(field_index, entity_id))
+            .enumerate()
+            .filter(|(_, field)| matches!(&field.relation, PostgresRelation::Pk { .. }))
+            .map(|(field_index, _)| EntityFieldId(field_index, entity_id))
+            .collect()
     }
 
     pub fn aggregate_field_by_name(&self, name: &str) -> Option<&AggregateField> {

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/delete_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/delete_mutation_builder.rs
@@ -79,7 +79,7 @@ impl MutationBuilder for DeleteMutationBuilder {
         entity_type: &EntityType,
         building: &SystemContextBuilding,
     ) -> PostgresMutationParameters {
-        PostgresMutationParameters::Delete(query_builder::pk_predicate_param(
+        PostgresMutationParameters::Delete(query_builder::pk_predicate_params(
             entity_type,
             &building.predicate_types,
             &building.core_subsystem.database,
@@ -101,9 +101,9 @@ impl MutationBuilder for DeleteMutationBuilder {
         entity_type: &EntityType,
         building: &SystemContextBuilding,
     ) -> PostgresMutationParameters {
-        PostgresMutationParameters::Delete(query_builder::collection_predicate_param(
+        PostgresMutationParameters::Delete(vec![query_builder::collection_predicate_param(
             entity_type,
             &building.predicate_types,
-        ))
+        )])
     }
 }

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/mutation_builder.rs
@@ -560,7 +560,7 @@ fn get_matching_field<'a>(
         let matching_fields: Vec<_> = field_typ
             .fields
             .iter()
-            .filter(|f| field.column_name == f.column_name)
+            .filter(|f| field.column_names == f.column_names)
             .collect();
 
         match &matching_fields[..] {

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/mutation_builder.rs
@@ -260,7 +260,7 @@ pub trait DataParamBuilder<D> {
         };
 
         match &field.relation {
-            PostgresRelation::Pk { column_id } => {
+            PostgresRelation::Pk { column_ids } => {
                 if Self::data_param_role() == DataParamRole::Update {
                     // A typical way clients use update mutation is to get the data along with the id,
                     // modify the data and send it back to the server. So we accept the id
@@ -283,7 +283,7 @@ pub trait DataParamBuilder<D> {
                     //
                     // We should revisit this after we support "readonly" fields (see
                     // https://github.com/exograph/exograph/issues/926)
-                    let column = column_id.get_column(&building.core_subsystem.database);
+                    let column = column_ids[0].get_column(&building.core_subsystem.database);
 
                     if column.is_auto_increment {
                         None

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/mutation_builder.rs
@@ -107,14 +107,20 @@ pub trait MutationBuilder {
             return vec![];
         }
 
-        let single_mutation = entity_type.pk_field().map(|_| PostgresMutation {
-            name: Self::single_mutation_name(entity_type),
-            parameters: Self::single_mutation_parameters(entity_type, building),
-            return_type: Self::single_mutation_modified_type(BaseOperationReturnType {
-                associated_type_id: entity_type_id,
-                type_name: entity_type.name.clone(),
-            }),
-        });
+        let pk_fields = entity_type.pk_fields();
+
+        let single_mutation = if pk_fields.is_empty() {
+            None
+        } else {
+            Some(PostgresMutation {
+                name: Self::single_mutation_name(entity_type),
+                parameters: Self::single_mutation_parameters(entity_type, building),
+                return_type: Self::single_mutation_modified_type(BaseOperationReturnType {
+                    associated_type_id: entity_type_id,
+                    type_name: entity_type.name.clone(),
+                }),
+            })
+        };
 
         let multi_mutation = PostgresMutation {
             name: Self::multi_mutation_name(entity_type),

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/query_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/query_builder.rs
@@ -161,17 +161,20 @@ fn expand_pk_query(
 
     if let Some(existing_query) = existing_query {
         existing_query.parameters.predicate_params =
-            vec![pk_predicate_param(entity_type, predicate_types, database)];
+            pk_predicate_params(entity_type, predicate_types, database);
     }
 }
 
-pub fn pk_predicate_param(
+pub fn pk_predicate_params(
     entity_type: &EntityType,
     predicate_types: &MappedArena<PredicateParameterType>,
     database: &Database,
-) -> PredicateParameter {
-    let pk_field = entity_type.pk_field().unwrap();
-    implicit_equals_predicate_param(pk_field, predicate_types, database)
+) -> Vec<PredicateParameter> {
+    let pk_fields = entity_type.pk_fields();
+    pk_fields
+        .iter()
+        .map(|field| implicit_equals_predicate_param(field, predicate_types, database))
+        .collect()
 }
 
 fn implicit_equals_predicate_param(

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/query_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/query_builder.rs
@@ -19,7 +19,7 @@ use postgres_graphql_model::{
     predicate::{PredicateParameter, PredicateParameterType, PredicateParameterTypeWrapper},
     query::{
         AggregateQuery, AggregateQueryParameters, CollectionQuery, CollectionQueryParameters,
-        PkQuery, PkQueryParameters, UniqueQuery, UniqueQueryParameters,
+        UniqueQuery, UniqueQueryParameters,
     },
 };
 
@@ -107,37 +107,61 @@ pub fn build_expanded(resolved_env: &ResolvedTypeEnv, building: &mut SystemConte
     }
 }
 
-fn shallow_pk_query(
+fn shallow_unique_query(
+    name: String,
     entity_type_id: SerializableSlabIndex<EntityType>,
-    typ: &ResolvedCompositeType,
-) -> PkQuery {
-    let operation_name = typ.pk_query();
-    PkQuery {
-        name: operation_name,
-        parameters: PkQueryParameters {
-            predicate_param: PredicateParameter::shallow(),
+    return_type: &ResolvedCompositeType,
+) -> UniqueQuery {
+    UniqueQuery {
+        name,
+        parameters: UniqueQueryParameters {
+            predicate_params: vec![],
         },
         return_type: OperationReturnType::Optional(Box::new(OperationReturnType::Plain(
             BaseOperationReturnType {
                 associated_type_id: entity_type_id,
-                type_name: typ.name.clone(),
+                type_name: return_type.name.clone(),
             },
         ))),
     }
 }
 
+fn shallow_pk_query(
+    entity_type_id: SerializableSlabIndex<EntityType>,
+    return_type: &ResolvedCompositeType,
+) -> UniqueQuery {
+    shallow_unique_query(return_type.pk_query(), entity_type_id, return_type)
+}
+
+fn shallow_unique_queries(
+    entity_type_id: SerializableSlabIndex<EntityType>,
+    resolved_entity_type: &ResolvedCompositeType,
+) -> Vec<UniqueQuery> {
+    resolved_entity_type
+        .unique_constraints()
+        .keys()
+        .map(|name| {
+            shallow_unique_query(
+                resolved_entity_type.unique_query(name),
+                entity_type_id,
+                resolved_entity_type,
+            )
+        })
+        .collect()
+}
+
 fn expand_pk_query(
     entity_type: &EntityType,
     predicate_types: &MappedArena<PredicateParameterType>,
-    pk_queries: &mut MappedArena<PkQuery>,
+    pk_queries: &mut MappedArena<UniqueQuery>,
     database: &Database,
 ) {
     let operation_name = entity_type.pk_query();
     let existing_query = &mut pk_queries.get_by_key_mut(&operation_name);
 
     if let Some(existing_query) = existing_query {
-        existing_query.parameters.predicate_param =
-            pk_predicate_param(entity_type, predicate_types, database);
+        existing_query.parameters.predicate_params =
+            vec![pk_predicate_param(entity_type, predicate_types, database)];
     }
 }
 
@@ -242,28 +266,6 @@ fn expand_aggregate_query(
 
     let existing_query = &mut aggregate_queries.get_by_key_mut(&operation_name).unwrap();
     existing_query.parameters.predicate_param = predicate_param;
-}
-
-fn shallow_unique_queries(
-    entity_type_id: SerializableSlabIndex<EntityType>,
-    resolved_entity_type: &ResolvedCompositeType,
-) -> Vec<UniqueQuery> {
-    resolved_entity_type
-        .unique_constraints()
-        .keys()
-        .map(|name| UniqueQuery {
-            name: resolved_entity_type.unique_query(name),
-            parameters: UniqueQueryParameters {
-                predicate_params: vec![],
-            },
-            return_type: OperationReturnType::Optional(Box::new(OperationReturnType::Plain(
-                BaseOperationReturnType {
-                    associated_type_id: entity_type_id,
-                    type_name: resolved_entity_type.name.clone(),
-                },
-            ))),
-        })
-        .collect()
 }
 
 pub fn expand_unique_queries(

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/system_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/system_builder.rs
@@ -18,7 +18,7 @@ use postgres_graphql_model::{
     mutation::PostgresMutation,
     order::OrderByParameterType,
     predicate::PredicateParameterType,
-    query::{AggregateQuery, CollectionQuery, PkQuery, UniqueQuery},
+    query::{AggregateQuery, CollectionQuery, UniqueQuery},
     subsystem::PostgresGraphQLSubsystem,
     types::MutationType,
 };
@@ -113,12 +113,13 @@ pub struct SystemContextBuilding {
     pub order_by_types: MappedArena<OrderByParameterType>,
     pub predicate_types: MappedArena<PredicateParameterType>,
 
-    pub pk_queries: MappedArena<PkQuery>,
+    pub pk_queries: MappedArena<UniqueQuery>,
     pub collection_queries: MappedArena<CollectionQuery>,
     pub aggregate_queries: MappedArena<AggregateQuery>,
     pub unique_queries: MappedArena<UniqueQuery>,
 
-    pub pk_queries_map: HashMap<SerializableSlabIndex<EntityType>, SerializableSlabIndex<PkQuery>>,
+    pub pk_queries_map:
+        HashMap<SerializableSlabIndex<EntityType>, SerializableSlabIndex<UniqueQuery>>,
     pub collection_queries_map:
         HashMap<SerializableSlabIndex<EntityType>, SerializableSlabIndex<CollectionQuery>>,
     pub aggregate_queries_map:

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/update_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/update_mutation_builder.rs
@@ -121,7 +121,7 @@ impl MutationBuilder for UpdateMutationBuilder {
     ) -> PostgresMutationParameters {
         PostgresMutationParameters::Update {
             data_param: Self::data_param(entity_type, building, false),
-            predicate_param: query_builder::pk_predicate_param(
+            predicate_params: query_builder::pk_predicate_params(
                 entity_type,
                 &building.predicate_types,
                 &building.core_subsystem.database,
@@ -146,10 +146,10 @@ impl MutationBuilder for UpdateMutationBuilder {
     ) -> PostgresMutationParameters {
         PostgresMutationParameters::Update {
             data_param: Self::data_param(entity_type, building, true),
-            predicate_param: query_builder::collection_predicate_param(
+            predicate_params: vec![query_builder::collection_predicate_param(
                 entity_type,
                 &building.predicate_types,
-            ),
+            )],
         }
     }
 }
@@ -313,7 +313,7 @@ impl DataParamBuilder<DataParameter> for UpdateMutationBuilder {
                         // For a non-nested type ("base type"), we already have the PK field, but it is optional. So here
                         // we make it required (by not wrapping the entity_pk_field it as optional)
                         if let Some(base_type_pk_field) = base_type_pk_field {
-                            let entity_pk_field = entity_type.pk_field().unwrap();
+                            let entity_pk_field = entity_type.pk_fields()[0];
                             base_type_pk_field.typ = to_mutation_type(
                                 &entity_pk_field.typ,
                                 MutationTypeKind::Update,

--- a/crates/postgres-subsystem/postgres-graphql-model/src/operation.rs
+++ b/crates/postgres-subsystem/postgres-graphql-model/src/operation.rs
@@ -41,7 +41,7 @@ use crate::types::Operation;
 /// An operation such as a query or mutation.
 ///
 /// * `P` - This parameter allows differentiating between, for example,
-///   [`PkQuery`](`super::query::PkQuery`), [`AggregateQuery`](super::query::AggregateQuery), and
+///   [`UniqueQuery`](`super::query::UniqueQuery`), [`AggregateQuery`](super::query::AggregateQuery), and
 ///   [`PostgresMutation`](super::mutation::PostgresMutation).
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PostgresOperation<P: OperationParameters> {

--- a/crates/postgres-subsystem/postgres-graphql-model/src/query.rs
+++ b/crates/postgres-subsystem/postgres-graphql-model/src/query.rs
@@ -19,21 +19,6 @@ use crate::{
 
 use super::operation::{OperationParameters, PostgresOperation};
 
-/// Query by primary key such as `todo(id: 1)`
-pub type PkQuery = PostgresOperation<PkQueryParameters>;
-
-/// Primary key query parameter such as `id: 1` in `todo(id: 1)`
-#[derive(Serialize, Deserialize, Debug)]
-pub struct PkQueryParameters {
-    pub predicate_param: PredicateParameter,
-}
-
-impl OperationParameters for PkQueryParameters {
-    fn introspect(&self) -> Vec<&dyn Parameter> {
-        vec![&self.predicate_param]
-    }
-}
-
 /// Query that return a collection such as `todos(where: { title: { eq: "Hello" } })`
 pub type CollectionQuery = PostgresOperation<CollectionQueryParameters>;
 
@@ -76,7 +61,9 @@ impl OperationParameters for AggregateQueryParameters {
     }
 }
 
-/// Query by unique constrained parameters such as `userByEmail(email: "hello@example.com")` or `userByFirstAndLastName(firstName: "John", lastName: "Doe")`
+/// Query that returns a single entity (due to the constraint)
+/// - Primary key: such as single `todo(id: 1)` or composite `user(firstName: "John", lastName: "Doe")`
+/// - Uniqueness: such as `userByEmail(email: "hello@example.com")` or `userByFirstAndLastName(firstName: "John", lastName: "Doe")`
 pub type UniqueQuery = PostgresOperation<UniqueQueryParameters>;
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/postgres-subsystem/postgres-graphql-model/src/subsystem.rs
+++ b/crates/postgres-subsystem/postgres-graphql-model/src/subsystem.rs
@@ -13,7 +13,6 @@ use async_graphql_parser::types::{FieldDefinition, TypeDefinition};
 
 use super::{
     mutation::PostgresMutation, order::OrderByParameterType, predicate::PredicateParameterType,
-    query::PkQuery,
 };
 use crate::{
     query::{AggregateQuery, CollectionQuery, UniqueQuery},
@@ -40,12 +39,13 @@ pub struct PostgresGraphQLSubsystem {
     pub order_by_types: SerializableSlab<OrderByParameterType>,
     pub predicate_types: SerializableSlab<PredicateParameterType>,
 
-    pub pk_queries: MappedArena<PkQuery>,
+    pub pk_queries: MappedArena<UniqueQuery>,
     pub collection_queries: MappedArena<CollectionQuery>,
     pub aggregate_queries: MappedArena<AggregateQuery>,
     pub unique_queries: MappedArena<UniqueQuery>,
 
-    pub pk_queries_map: HashMap<SerializableSlabIndex<EntityType>, SerializableSlabIndex<PkQuery>>,
+    pub pk_queries_map:
+        HashMap<SerializableSlabIndex<EntityType>, SerializableSlabIndex<UniqueQuery>>,
     pub collection_queries_map:
         HashMap<SerializableSlabIndex<EntityType>, SerializableSlabIndex<CollectionQuery>>,
     pub aggregate_queries_map:
@@ -128,7 +128,7 @@ impl PostgresGraphQLSubsystem {
         all_type_definitions
     }
 
-    pub fn get_pk_query(&self, entity_type_id: SerializableSlabIndex<EntityType>) -> &PkQuery {
+    pub fn get_pk_query(&self, entity_type_id: SerializableSlabIndex<EntityType>) -> &UniqueQuery {
         let pk_query_index = self.pk_queries_map[&entity_type_id];
         &self.pk_queries[pk_query_index]
     }

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/aggregate_query.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/aggregate_query.rs
@@ -44,7 +44,7 @@ impl OperationSelectionResolver for AggregateQuery {
         .await?;
 
         let query_predicate = super::predicate_mapper::compute_predicate(
-            &self.parameters.predicate_param,
+            &[&self.parameters.predicate_param],
             &field.arguments,
             subsystem,
             request_context,

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/aggregate_query.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/aggregate_query.rs
@@ -107,7 +107,26 @@ async fn map_field<'content>(
         let model_field_agg_type = format!("{model_field_type}Agg");
 
         match &model_field.relation {
-            PostgresRelation::Pk { column_id } | PostgresRelation::Scalar { column_id } => {
+            PostgresRelation::Pk { column_ids } => {
+                let elements = field
+                    .subfields
+                    .iter()
+                    .map(|subfield| {
+                        let selection_elem = if subfield.name == "__typename" {
+                            SelectionElement::Constant(model_field_agg_type.clone())
+                        } else {
+                            SelectionElement::Function(exo_sql::Function::Named {
+                                function_name: subfield.name.to_string(),
+                                column_id: column_ids[0],
+                            })
+                        };
+                        (subfield.output_name(), selection_elem)
+                    })
+                    .collect();
+                SelectionElement::Object(elements)
+            }
+
+            PostgresRelation::Scalar { column_id } => {
                 let elements = field
                     .subfields
                     .iter()
@@ -125,6 +144,7 @@ async fn map_field<'content>(
                     .collect();
                 SelectionElement::Object(elements)
             }
+
             _ => {
                 return Err(PostgresExecutionError::Generic(
                     "Invalid nested aggregation of a composite type".into(),

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/create_data_param_mapper.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/create_data_param_mapper.rs
@@ -127,9 +127,10 @@ async fn map_single<'a>(
                 }
 
                 PostgresRelation::ManyToOne(ManyToOneRelation { relation_id, .. }) => {
-                    let ManyToOne { self_column_id, .. } =
+                    let ManyToOne { column_pairs, .. } =
                         relation_id.deref(&subsystem.core_subsystem.database);
-                    map_self_column(self_column_id, field, field_arg, subsystem).await
+                    map_self_column(column_pairs[0].self_column_id, field, field_arg, subsystem)
+                        .await
                 }
 
                 PostgresRelation::OneToMany(one_to_many_relation) => {

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/create_data_param_mapper.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/create_data_param_mapper.rs
@@ -122,7 +122,11 @@ async fn map_single<'a>(
 
         field_arg.map(|field_arg| async move {
             match &field.relation {
-                PostgresRelation::Pk { column_id } | PostgresRelation::Scalar { column_id } => {
+                PostgresRelation::Pk { column_ids } => {
+                    map_self_column(column_ids[0], field, field_arg, subsystem).await
+                }
+
+                PostgresRelation::Scalar { column_id } => {
                     map_self_column(*column_id, field, field_arg, subsystem).await
                 }
 

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/postgres_mutation.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/postgres_mutation.rs
@@ -68,10 +68,10 @@ impl OperationResolver for PostgresMutation {
                 )
                 .await?,
             ),
-            PostgresMutationParameters::Delete(predicate_param) => AbstractOperation::Delete(
+            PostgresMutationParameters::Delete(predicate_params) => AbstractOperation::Delete(
                 delete_operation(
                     return_type,
-                    predicate_param,
+                    predicate_params,
                     field,
                     abstract_select,
                     subsystem,
@@ -81,12 +81,12 @@ impl OperationResolver for PostgresMutation {
             ),
             PostgresMutationParameters::Update {
                 data_param,
-                predicate_param,
+                predicate_params,
             } => AbstractOperation::Update(
                 update_operation(
                     return_type,
                     data_param,
-                    predicate_param,
+                    predicate_params,
                     field,
                     abstract_select,
                     subsystem,
@@ -121,7 +121,7 @@ async fn create_operation<'content>(
 
 async fn delete_operation<'content>(
     return_type: &'content OperationReturnType<EntityType>,
-    predicate_param: &'content PredicateParameter,
+    predicate_params: &'content [PredicateParameter],
     field: &'content ValidatedField,
     select: AbstractSelect,
     subsystem: &'content PostgresGraphQLSubsystem,
@@ -140,7 +140,7 @@ async fn delete_operation<'content>(
     .await?;
 
     let arg_predicate = compute_predicate(
-        predicate_param,
+        &predicate_params.iter().collect::<Vec<_>>(),
         &field.arguments,
         subsystem,
         request_context,
@@ -158,7 +158,7 @@ async fn delete_operation<'content>(
 async fn update_operation<'content>(
     return_type: &'content OperationReturnType<EntityType>,
     data_param: &'content DataParameter,
-    predicate_param: &'content PredicateParameter,
+    predicate_param: &'content [PredicateParameter],
     field: &'content ValidatedField,
     select: AbstractSelect,
     subsystem: &'content PostgresGraphQLSubsystem,
@@ -176,7 +176,7 @@ async fn update_operation<'content>(
     .await?;
 
     let arg_predicate = compute_predicate(
-        predicate_param,
+        &predicate_param.iter().collect::<Vec<_>>(),
         &field.arguments,
         subsystem,
         request_context,

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/predicate_mapper.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/predicate_mapper.rs
@@ -79,8 +79,8 @@ impl<'a> SQLMapper<'a, AbstractPredicate> for PredicateParamInput<'a> {
                                     .column_path_link
                                     .as_ref()
                                     .unwrap()
-                                    .self_column_id()
-                                    .clone();
+                                    .self_column_ids()
+                                    .clone()[0];
 
                                 let param_column_path = ColumnPath::Physical(
                                     PhysicalColumnPath::leaf(*param_column_id),
@@ -406,7 +406,7 @@ fn operands<'a>(
         .column_path_link
         .as_ref()
         .expect("Could not find column path link while forming operands")
-        .self_column_id();
+        .self_column_ids()[0];
     let op_physical_column = op_physical_column_id.get_column(&subsystem.core_subsystem.database);
 
     let op_value = literal_column_path(

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/predicate_mapper.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/predicate_mapper.rs
@@ -422,20 +422,28 @@ fn operands<'a>(
 }
 
 pub async fn compute_predicate<'a>(
-    param: &'a PredicateParameter,
+    params: &'a [&'a PredicateParameter],
     arguments: &'a Arguments,
     subsystem: &'a PostgresGraphQLSubsystem,
     request_context: &'a RequestContext<'a>,
 ) -> Result<AbstractPredicate, PostgresExecutionError> {
-    extract_and_map(
-        PredicateParamInput {
-            param,
-            parent_column_path: None,
-        },
-        arguments,
-        subsystem,
-        request_context,
-    )
-    .await
-    .map(|predicate| predicate.unwrap_or(AbstractPredicate::True))
+    let predicates = futures::future::try_join_all(params.iter().map(|param| async {
+        extract_and_map(
+            PredicateParamInput {
+                param,
+                parent_column_path: None,
+            },
+            arguments,
+            subsystem,
+            request_context,
+        )
+        .await
+    }))
+    .await?;
+
+    let predicates = predicates.into_iter().flatten();
+
+    Ok(predicates.fold(AbstractPredicate::True, |acc, predicate| {
+        AbstractPredicate::and(acc, predicate)
+    }))
 }

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/update_data_param_mapper.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/update_data_param_mapper.rs
@@ -101,7 +101,7 @@ fn compute_update_columns<'a>(
                 }),
 
             PostgresRelation::ManyToOne(ManyToOneRelation {
-                foreign_pk_field_id,
+                foreign_pk_field_ids,
                 relation_id,
                 ..
             }) => {
@@ -111,7 +111,7 @@ fn compute_update_columns<'a>(
                 let self_column_id = column_pairs[0].self_column_id;
 
                 let self_column = self_column_id.get_column(&subsystem.core_subsystem.database);
-                let foreign_type_pk_field_name = &foreign_pk_field_id
+                let foreign_type_pk_field_name = &foreign_pk_field_ids[0]
                     .resolve(&subsystem.core_subsystem.entity_types)
                     .name;
 

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/update_data_param_mapper.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/update_data_param_mapper.rs
@@ -98,8 +98,10 @@ fn compute_update_columns<'a>(
                 relation_id,
                 ..
             }) => {
-                let ManyToOne { self_column_id, .. } =
+                let ManyToOne { column_pairs, .. } =
                     relation_id.deref(&subsystem.core_subsystem.database);
+
+                let self_column_id = column_pairs[0].self_column_id;
 
                 let self_column = self_column_id.get_column(&subsystem.core_subsystem.database);
                 let foreign_type_pk_field_name = &foreign_pk_field_id
@@ -300,7 +302,7 @@ async fn compute_nested_update_object_arg<'a>(
     let predicate = AbstractPredicate::and(arg_predicate, access_predicate);
 
     Ok(NestedAbstractUpdate {
-        nesting_relation: *nesting_relation,
+        nesting_relation: nesting_relation.clone(),
         update: AbstractUpdate {
             table_id,
             predicate,
@@ -346,7 +348,7 @@ async fn compute_nested_inserts<'a>(
         .await?;
 
         Ok(NestedAbstractInsert {
-            relation_column_id: nesting_relation.foreign_column_id,
+            relation_column_id: nesting_relation.column_pairs[0].foreign_column_id,
             insert: AbstractInsert {
                 table_id,
                 rows,
@@ -510,7 +512,7 @@ async fn compute_nested_delete_object_arg<'a>(
     let table_id = subsystem.core_subsystem.entity_types[field_mutation_type.entity_id].table_id;
 
     Ok(NestedAbstractDelete {
-        nesting_relation: *nesting_relation,
+        nesting_relation: nesting_relation.clone(),
         delete: AbstractDelete {
             table_id,
             predicate,

--- a/docs/docs/postgres/customizing-types.md
+++ b/docs/docs/postgres/customizing-types.md
@@ -146,7 +146,7 @@ module TodoDatabase {
 
 Exograph will map the `ProductProfit` type to the `product_profits` view (it could also be a table, possibly a foreign table). However, Exograph will ignore the `ProductProfit` type during schema migration.
 
-Exograph will apply access control and infer queries for the `ProductProfit` type as usual, including [aggregated queries](operations/queries.md#aggregated-query). If you have an unmanaged type representing a view, you will typically want to set `mutation=false`, thus removing the mutation APIs for it. However, this is more of a convention than a restriction imposed by Exograph. Therefore, you may put any other access control rules if you want to modify the underlying data through the unmanaged type.
+Exograph will apply access control and infer queries for the `ProductProfit` type as usual, including [aggregated queries](operations/queries.md#aggregate-query). If you have an unmanaged type representing a view, you will typically want to set `mutation=false`, thus removing the mutation APIs for it. However, this is more of a convention than a restriction imposed by Exograph. Therefore, you may put any other access control rules if you want to modify the underlying data through the unmanaged type.
 
 If you allow mutation through a managed type for a view, you will want to make any derived fields read-only. For example, if you allow mutation through the `ProductProfit` type, you will want to make the `profit` field read-only.
 
@@ -229,7 +229,7 @@ module ConcertModule {
 
 ### Assigning primary key
 
-The `@pk` annotation designates the primary key of a type. The current implementation of Exograph only supports a single primary key (we will lift this restriction in the future):
+The `@pk` annotation designates the primary key of a type. Typically, you will mark one of the fields as the primary key, but Exograph supports composite primary keys as well.
 
 #### Auto-incrementing primary key
 
@@ -267,6 +267,34 @@ type Venue {
   ...
 }
 ```
+
+#### Composite primary key
+
+You can also specify a composite primary key by marking multiple fields with the `@pk` annotation. For example, if you want to make the combination of the `firstName` and `lastName` fields the primary key of the `Person` type and the combination of the `street`, `city`, `state`, and `zip` fields the primary key of the `Address` type, you can use the following definition:
+
+```exo
+@postgres
+module PeopleDatabase {
+  @access(true)
+  type Person {
+    @pk firstName: String
+    @pk lastName: String
+    age: Int
+    address: Address?
+  }
+
+  @access(true)
+  type Address {
+    @pk street: String
+    @pk city: String
+    @pk state: String
+    @pk zip: Int
+    people: Set<Person>?
+  }
+}
+```
+
+Other than marking multiple fields with `@pk`, all other aspects of the primary key are the same as for a single primary key.
 
 ### Specifying a default value
 

--- a/docs/docs/postgres/defining-modules.md
+++ b/docs/docs/postgres/defining-modules.md
@@ -15,8 +15,8 @@ module TodoDatabase {
 
 The `@postgres` annotation takes two optional parameters:
 
-- `schema`: The default schema for all tables in the module. See [specifying a schema](customizing-types.md#specifying-a-schema) for more details.
-- `managed`: The default managed state for all tables in the module. See [unmanaged views](customizing-types.md#unmanaged-views) for more details.
+- `schema`: The default schema for all tables in the module. See [specifying a schema](customizing-types.md#table-schema) for more details.
+- `managed`: The default managed state for all tables in the module. See [unmanaged views](customizing-types.md#using-unmanaged-tables) for more details.
 
 For example, the following module will associated the `Product` type with the `products` table in the `commerce` schema.
 

--- a/docs/docs/postgres/operations/mutations.md
+++ b/docs/docs/postgres/operations/mutations.md
@@ -137,6 +137,16 @@ mutation {
 }
 ```
 
+Like the [query to get a single entity](queries.md#primary-key-query), if the entity type has a composite primary key, you must supply all the fields of the primary key as arguments to the mutation. For example, if the `Person` type has a composite primary key of `firstName` and `lastName`, you must supply both `firstName` and `lastName` as arguments to the mutation.
+
+```graphql
+mutation {
+  updatePerson(firstName: "John", lastName: "Doe", data: {age: 30}) {
+    ...
+  }
+}
+```
+
 ### Updating multiple entities
 
 If you want to update multiple concerts, you can do so as follows. In the following, the goal is to move all concerts hosted in venue 3 to venue 2.
@@ -183,7 +193,7 @@ There is one more detail to note here. The `performances` added will automatical
 
 ## Deleting data
 
-To delete a single entity by its primary key, Exograph offers the `delete<EntityType>` mutation, which takes the primary key as an argument. To delete multiple entities, Exograph offers the `delete<PluralizedEntityName>` mutation, which takes a `where` argument to filter the entities to be deleted (it is the same `where` argument that is used to filter data in the queries in the [earlier section](queries.md#collection-query)).
+To delete a single entity by its primary key, Exograph offers the `delete<EntityType>` mutation, which takes the primary key as an argument. 
 
 Given this mutation, you can delete a concert as follows:
 
@@ -197,7 +207,19 @@ mutation {
 }
 ```
 
-If you want to delete all concerts hosted in venue 3, you could do so as follows:
+Like the [query to delete a single entity](queries.md#primary-key-query) and [update a single entity](mutations.md#updating-a-single-entity), if the entity type has a composite primary key, you must supply all the fields of the primary key as arguments to the mutation.
+
+```graphql
+mutation {
+  deletePerson(firstName: "John", lastName: "Doe") {
+    id
+    firstName
+    lastName
+  }
+}
+```
+
+To delete multiple entities, Exograph offers the `delete<PluralizedEntityName>` mutation, which takes a `where` argument to filter the entities to be deleted (it is the same `where` argument that is used to filter data in the queries in the [earlier section](queries.md#collection-query)). If you want to delete all concerts hosted in venue 3, you could do so as follows:
 
 ```graphql
 mutation {

--- a/docs/docs/postgres/operations/queries.md
+++ b/docs/docs/postgres/operations/queries.md
@@ -26,6 +26,16 @@ concert(id: 5) {
 }
 ```
 
+If a type has a composite primary key, Exograph enforces that you provide all the fields of the primary key as arguments to the query. For example, if the `Person` type has a composite primary key of `firstName` and `lastName`, you can use the following query to get a person by their first and last name:
+
+```graphql
+person(firstName: "John", lastName: "Doe") {
+  id
+  firstName
+  lastName
+}
+```
+
 ## Collection Query
 
 When you want to display a list of entities, for example, when displaying a list of concerts in a given year, you can use the query to get a list of entities. The query to get a list of entities is the "camelCased" version of the pluralized entity type. For example, if the entity type is `Concert`, the query name will be `concerts`, whereas if the entity type is `ShoppingCart`, the query name will be `shoppingCarts`.

--- a/integration-tests/composite-pk/scalars/no-auth/src/index.exo
+++ b/integration-tests/composite-pk/scalars/no-auth/src/index.exo
@@ -1,6 +1,7 @@
 @postgres
 module PeopleDatabase {
   @access(true)
+  @plural("People")
   type Person {
     @pk firstName: String
     @pk lastName: String
@@ -8,6 +9,8 @@ module PeopleDatabase {
     address: Address?
   }
 
+  @access(true)
+  @plural("Addresses")
   type Address {
     @pk street: String
     @pk city: String

--- a/integration-tests/composite-pk/scalars/no-auth/tests/init.gql
+++ b/integration-tests/composite-pk/scalars/no-auth/tests/init.gql
@@ -1,0 +1,95 @@
+operation: |
+    mutation {
+        address1: createAddress(data: {
+            street: "1 Main St",
+            city: "Albany",
+            state: "NY",
+            zip: 10001,
+            people: [
+                {
+                    firstName: "John",
+                    lastName: "DoeAlbany",
+                    age: 20
+                },
+                {
+                    firstName: "Jane",
+                    lastName: "SmithAlbany",
+                    age: 25
+                }
+            ]
+        }) {
+            street
+            city
+            state
+            zip
+        }
+        address2: createAddress(data: {
+            street: "2 Main St",
+            city: "Boston",
+            state: "MA",
+            zip: 22101,
+            people: [
+                {
+                    firstName: "John",
+                    lastName: "DoeBoston",
+                    age: 30
+                },
+                {
+                    firstName: "Jane",
+                    lastName: "SmithBoston",
+                    age: 35
+                }
+            ]
+        }) {
+            street
+            city
+            state
+            zip
+        },
+        address3: createAddress(data: {
+            street: "3 Main St",
+            city: "Chicago",
+            state: "IL",
+            zip: 60601,
+            people: [
+                {
+                    firstName: "John",
+                    lastName: "DoeChicago",
+                    age: 40
+                },
+                {
+                    firstName: "Jane",
+                    lastName: "SmithChicago",
+                    age: 45
+                }
+            ]
+        }) {
+            street
+            city
+            state
+            zip
+        },
+        address4: createAddress(data: {
+            street: "4 Main St",
+            city: "Plymouth",
+            state: "MA",
+            zip: 23600,
+            people: [
+                {
+                    firstName: "John",
+                    lastName: "DoePlymouth",
+                    age: 50
+                },
+                {
+                    firstName: "Jane",
+                    lastName: "SmithPlymouth",
+                    age: 55
+                }
+            ]
+        }) {
+            street
+            city
+            state
+            zip
+        }
+    }  

--- a/integration-tests/composite-pk/scalars/no-auth/tests/mutation/delete-people-by-address.exotest
+++ b/integration-tests/composite-pk/scalars/no-auth/tests/mutation/delete-people-by-address.exotest
@@ -1,0 +1,67 @@
+operation: |
+    fragment personInfo on Person {
+      firstName
+      lastName
+      address {
+        street
+        city
+        state
+        zip
+      }
+    }
+    mutation {
+      maPeople: deletePeople(where: { address: { state: {eq: "MA"} } }) @unordered {
+        ...personInfo
+      }
+      nonExisting: deletePeople(where: { address: { state: {eq: "CA"} } }) @unordered {
+        ...personInfo
+      }
+    }
+response: |
+    {
+      "data": {
+        "maPeople": [
+          {
+            "firstName": "John",
+            "lastName": "DoeBoston",
+            "address": {
+              "street": "2 Main St",
+              "city": "Boston",
+              "state": "MA",
+              "zip": 22101
+            }
+          },
+          {
+            "firstName": "Jane",
+            "lastName": "SmithBoston",
+            "address": {
+              "street": "2 Main St",
+              "city": "Boston",
+              "state": "MA",
+              "zip": 22101
+            }
+          },
+          {
+            "firstName": "John",
+            "lastName": "DoePlymouth",
+            "address": {
+              "street": "4 Main St",
+              "city": "Plymouth",
+              "state": "MA",
+              "zip": 23600
+            }
+          },
+          {
+            "firstName": "Jane",
+            "lastName": "SmithPlymouth",
+            "address": {
+              "street": "4 Main St",
+              "city": "Plymouth",
+              "state": "MA",
+              "zip": 23600
+            }
+          }
+        ],
+        "nonExisting": []
+      }
+    }

--- a/integration-tests/composite-pk/scalars/no-auth/tests/mutation/update-people-by-address.exotest
+++ b/integration-tests/composite-pk/scalars/no-auth/tests/mutation/update-people-by-address.exotest
@@ -1,0 +1,72 @@
+operation: |
+    fragment personInfo on Person {
+      firstName
+      lastName
+      age
+      address {
+        street
+        city
+        state
+        zip
+      }
+    }
+    mutation {
+      maPeople: updatePeople(where: { address: { state: {eq: "MA"} } }, data: { age: 20 }) @unordered {
+        ...personInfo
+      }
+      nonExisting: updatePeople(where: { address: { state: {eq: "CA"} } }, data: { age: 30 }) @unordered {
+        ...personInfo
+      }
+    }
+response: |
+    {
+      "data": {
+        "maPeople": [
+          {
+            "firstName": "John",
+            "lastName": "DoeBoston",
+            "age": 20,
+            "address": {
+              "street": "2 Main St",
+              "city": "Boston",
+              "state": "MA",
+              "zip": 22101
+            }
+          },
+          {
+            "firstName": "Jane",
+            "lastName": "SmithBoston",
+            "age": 20,
+            "address": {
+              "street": "2 Main St",
+              "city": "Boston",
+              "state": "MA",
+              "zip": 22101
+            }
+          },
+          {
+            "firstName": "John",
+            "lastName": "DoePlymouth",
+            "age": 20,
+            "address": {
+              "street": "4 Main St",
+              "city": "Plymouth",
+              "state": "MA",
+              "zip": 23600
+            }
+          },
+          {
+            "firstName": "Jane",
+            "lastName": "SmithPlymouth",
+            "age": 20,
+            "address": {
+              "street": "4 Main St",
+              "city": "Plymouth",
+              "state": "MA",
+              "zip": 23600
+            }
+          }
+        ],
+        "nonExisting": []
+      }
+    }

--- a/integration-tests/composite-pk/scalars/no-auth/tests/query/address-by-id.exotest
+++ b/integration-tests/composite-pk/scalars/no-auth/tests/query/address-by-id.exotest
@@ -1,0 +1,46 @@
+operation: |
+  fragment AddressFragment on Address {
+    street
+    city
+    state
+    zip
+  }
+
+  query {
+    address1: address(street: "1 Main St", city: "Albany", state: "NY", zip: 10001) {
+      ...AddressFragment
+    }
+    address2: address(street: "2 Main St", city: "Boston", state: "MA", zip: 22101) {
+      ...AddressFragment
+    }
+    address3: address(street: "3 Main St", city: "Chicago", state: "IL", zip: 60601) {
+      ...AddressFragment
+    }
+    nonExisting: address(street: "1 Main St", city: "Boston", state: "MA", zip: 60601) {
+      ...AddressFragment
+    }
+  }
+response: |
+  {
+    "data": {
+      "address1": {
+        "street": "1 Main St",
+        "city": "Albany",
+        "state": "NY",
+        "zip": 10001
+      },
+      "address2": {
+        "street": "2 Main St",
+        "city": "Boston",
+        "state": "MA",
+        "zip": 22101
+      },
+      "address3": {
+        "street": "3 Main St",
+        "city": "Chicago",
+        "state": "IL",
+        "zip": 60601
+      },
+      "nonExisting": null
+    }
+  }

--- a/integration-tests/composite-pk/scalars/no-auth/tests/query/addresses-by-people.exotest
+++ b/integration-tests/composite-pk/scalars/no-auth/tests/query/addresses-by-people.exotest
@@ -1,0 +1,198 @@
+operation: |
+    fragment address on Address {
+      street
+      city
+      state
+      zip
+      people {
+        firstName
+        lastName
+        age
+      }
+    }
+    
+    query {
+      johnAddresses: addresses(where: { people: { firstName: {eq: "John"} } }) @unordered {
+        ...address
+      }
+      janeAddresses: addresses(where: { people: { firstName: {eq: "Jane"} } }) @unordered {
+        ...address
+      }
+      olderThan50Addresses: addresses(where: { people: { age: {gt: 50} } }) @unordered {
+        ...address
+      }
+    }
+response: |
+    {
+      "data": {
+        "johnAddresses": [
+          {
+            "street": "1 Main St",
+            "city": "Albany",
+            "state": "NY",
+            "zip": 10001,
+            "people": [
+              {
+                "firstName": "John",
+                "lastName": "DoeAlbany",
+                "age": 20
+              },
+              {
+                "firstName": "Jane",
+                "lastName": "SmithAlbany",
+                "age": 25
+              }
+            ]
+          },
+          {
+            "street": "2 Main St",
+            "city": "Boston",
+            "state": "MA",
+            "zip": 22101,
+            "people": [
+              {
+                "firstName": "John",
+                "lastName": "DoeBoston",
+                "age": 30
+              },
+              {
+                "firstName": "Jane",
+                "lastName": "SmithBoston",
+                "age": 35
+              }
+            ]
+          },
+          {
+            "street": "3 Main St",
+            "city": "Chicago",
+            "state": "IL",
+            "zip": 60601,
+            "people": [
+              {
+                "firstName": "John",
+                "lastName": "DoeChicago",
+                "age": 40
+              },
+              {
+                "firstName": "Jane",
+                "lastName": "SmithChicago",
+                "age": 45
+              }
+            ]
+          },
+          {
+            "street": "4 Main St",
+            "city": "Plymouth",
+            "state": "MA",
+            "zip": 23600,
+            "people": [
+              {
+                "firstName": "John",
+                "lastName": "DoePlymouth",
+                "age": 50
+              },
+              {
+                "firstName": "Jane",
+                "lastName": "SmithPlymouth",
+                "age": 55
+              }
+            ]
+          }
+        ],
+        "janeAddresses": [
+          {
+            "street": "1 Main St",
+            "city": "Albany",
+            "state": "NY",
+            "zip": 10001,
+            "people": [
+              {
+                "firstName": "John",
+                "lastName": "DoeAlbany",
+                "age": 20
+              },
+              {
+                "firstName": "Jane",
+                "lastName": "SmithAlbany",
+                "age": 25
+              }
+            ]
+          },
+          {
+            "street": "2 Main St",
+            "city": "Boston",
+            "state": "MA",
+            "zip": 22101,
+            "people": [
+              {
+                "firstName": "John",
+                "lastName": "DoeBoston",
+                "age": 30
+              },
+              {
+                "firstName": "Jane",
+                "lastName": "SmithBoston",
+                "age": 35
+              }
+            ]
+          },
+          {
+            "street": "3 Main St",
+            "city": "Chicago",
+            "state": "IL",
+            "zip": 60601,
+            "people": [
+              {
+                "firstName": "John",
+                "lastName": "DoeChicago",
+                "age": 40
+              },
+              {
+                "firstName": "Jane",
+                "lastName": "SmithChicago",
+                "age": 45
+              }
+            ]
+          },
+          {
+            "street": "4 Main St",
+            "city": "Plymouth",
+            "state": "MA",
+            "zip": 23600,
+            "people": [
+              {
+                "firstName": "John",
+                "lastName": "DoePlymouth",
+                "age": 50
+              },
+              {
+                "firstName": "Jane",
+                "lastName": "SmithPlymouth",
+                "age": 55
+              }
+            ]
+          }
+        ],
+        "olderThan50Addresses": [
+          {
+            "street": "4 Main St",
+            "city": "Plymouth",
+            "state": "MA",
+            "zip": 23600,
+            "people": [
+              {
+                "firstName": "John",
+                "lastName": "DoePlymouth",
+                "age": 50
+              },
+              {
+                "firstName": "Jane",
+                "lastName": "SmithPlymouth",
+                "age": 55
+              }
+            ]
+          }
+        ]
+      }
+    }
+

--- a/integration-tests/composite-pk/scalars/no-auth/tests/query/addresses-where.exotest
+++ b/integration-tests/composite-pk/scalars/no-auth/tests/query/addresses-where.exotest
@@ -1,0 +1,60 @@
+operation: |
+    fragment addressInfo on Address {
+      street
+      city
+      state
+      zip
+    }
+    query {
+      all: addresses @unordered {
+        ...addressInfo
+      }
+      maCities: addresses(where: { state: {eq: "MA"} }) @unordered {
+        ...addressInfo
+      }
+    }
+response: |
+    {
+      "data": {
+        "all": [
+          {
+            "street": "1 Main St",
+            "city": "Albany",
+            "state": "NY",
+            "zip": 10001
+          },
+          {
+            "street": "2 Main St",
+            "city": "Boston",
+            "state": "MA",
+            "zip": 22101
+          },
+          {
+            "street": "3 Main St",
+            "city": "Chicago",
+            "state": "IL",
+            "zip": 60601
+          },
+          {
+            "street": "4 Main St",
+            "city": "Plymouth",
+            "state": "MA",
+            "zip": 23600
+          }
+        ],
+        "maCities": [
+          {
+            "street": "2 Main St",
+            "city": "Boston",
+            "state": "MA",
+            "zip": 22101
+          },
+          {
+            "street": "4 Main St",
+            "city": "Plymouth",
+            "state": "MA",
+            "zip": 23600
+          }
+        ]
+      }
+    }

--- a/integration-tests/composite-pk/scalars/no-auth/tests/query/people-by-address.exotest
+++ b/integration-tests/composite-pk/scalars/no-auth/tests/query/people-by-address.exotest
@@ -1,0 +1,148 @@
+operation: |
+    fragment personInfo on Person {
+      firstName
+      lastName
+      address {
+        street
+        city
+        state
+        zip
+      }
+    }
+    query {
+      all: people @unordered {
+        ...personInfo
+      }
+      maPeople: people(where: { address: { state: {eq: "MA"} } }) @unordered {
+        ...personInfo
+      }
+    }
+response: |
+    {
+      "data": {
+        "all": [
+          {
+            "firstName": "John",
+            "lastName": "DoeAlbany",
+            "address": {
+              "street": "1 Main St",
+              "city": "Albany",
+              "state": "NY",
+              "zip": 10001
+            }
+          },
+          {
+            "firstName": "Jane",
+            "lastName": "SmithAlbany",
+            "address": {
+              "street": "1 Main St",
+              "city": "Albany",
+              "state": "NY",
+              "zip": 10001
+            }
+          },
+          {
+            "firstName": "John",
+            "lastName": "DoeBoston",
+            "address": {
+              "street": "2 Main St",
+              "city": "Boston",
+              "state": "MA",
+              "zip": 22101
+            }
+          },
+          {
+            "firstName": "Jane",
+            "lastName": "SmithBoston",
+            "address": {
+              "street": "2 Main St",
+              "city": "Boston",
+              "state": "MA",
+              "zip": 22101
+            }
+          },
+          {
+            "firstName": "John",
+            "lastName": "DoeChicago",
+            "address": {
+              "street": "3 Main St",
+              "city": "Chicago",
+              "state": "IL",
+              "zip": 60601
+            }
+          },
+          {
+            "firstName": "Jane",
+            "lastName": "SmithChicago",
+            "address": {
+              "street": "3 Main St",
+              "city": "Chicago",
+              "state": "IL",
+              "zip": 60601
+            }
+          },
+          {
+            "firstName": "John",
+            "lastName": "DoePlymouth",
+            "address": {
+              "street": "4 Main St",
+              "city": "Plymouth",
+              "state": "MA",
+              "zip": 23600
+            }
+          },
+          {
+            "firstName": "Jane",
+            "lastName": "SmithPlymouth",
+            "address": {
+              "street": "4 Main St",
+              "city": "Plymouth",
+              "state": "MA",
+              "zip": 23600
+            }
+          }
+        ],
+        "maPeople": [
+          {
+            "firstName": "John",
+            "lastName": "DoeBoston",
+            "address": {
+              "street": "2 Main St",
+              "city": "Boston",
+              "state": "MA",
+              "zip": 22101
+            }
+          },
+          {
+            "firstName": "Jane",
+            "lastName": "SmithBoston",
+            "address": {
+              "street": "2 Main St",
+              "city": "Boston",
+              "state": "MA",
+              "zip": 22101
+            }
+          },
+          {
+            "firstName": "John",
+            "lastName": "DoePlymouth",
+            "address": {
+              "street": "4 Main St",
+              "city": "Plymouth",
+              "state": "MA",
+              "zip": 23600
+            }
+          },
+          {
+            "firstName": "Jane",
+            "lastName": "SmithPlymouth",
+            "address": {
+              "street": "4 Main St",
+              "city": "Plymouth",
+              "state": "MA",
+              "zip": 23600
+            }
+          }
+        ]
+      }
+    }

--- a/integration-tests/composite-pk/scalars/src/index.exo
+++ b/integration-tests/composite-pk/scalars/src/index.exo
@@ -1,0 +1,18 @@
+@postgres
+module TodoDatabase {
+  @access(true)
+  type Person {
+    @pk firstName: String
+    @pk lastName: String
+    age: Int
+    address: Address?
+  }
+
+  type Address {
+    @pk street: String
+    @pk city: String
+    @pk state: String
+    @pk zip: Int
+    people: Set<Person>?
+  }
+}

--- a/integration-tests/composite-pk/scalars/with-auth/src/index.exo
+++ b/integration-tests/composite-pk/scalars/with-auth/src/index.exo
@@ -1,0 +1,29 @@
+context AuthContext {
+  @jwt firstName: String
+  @jwt lastName: String
+  @jwt role: String
+}
+
+
+@postgres
+module PeopleDatabase {
+  @access(AuthContext.role == "admin" || (AuthContext.firstName == self.firstName && AuthContext.lastName == self.lastName))
+  @plural("People")
+  type Person {
+    @pk firstName: String
+    @pk lastName: String
+    age: Int
+    address: Address?
+  }
+
+  // Addresses are only accessible to admins or the person they belong to
+  @access(AuthContext.role == "admin" || (self.people.some(p => p.firstName == AuthContext.firstName && p.lastName == AuthContext.lastName)))
+  @plural("Addresses")
+  type Address {
+    @pk street: String
+    @pk city: String
+    @pk state: String
+    @pk zip: Int
+    people: Set<Person>?
+  }
+}

--- a/integration-tests/composite-pk/scalars/with-auth/tests/init.gql
+++ b/integration-tests/composite-pk/scalars/with-auth/tests/init.gql
@@ -1,0 +1,99 @@
+operation: |
+    mutation {
+        address1: createAddress(data: {
+            street: "1 Main St",
+            city: "Albany",
+            state: "NY",
+            zip: 10001,
+            people: [
+                {
+                    firstName: "John",
+                    lastName: "DoeAlbany",
+                    age: 20
+                },
+                {
+                    firstName: "Jane",
+                    lastName: "SmithAlbany",
+                    age: 25
+                }
+            ]
+        }) {
+            street
+            city
+            state
+            zip
+        }
+        address2: createAddress(data: {
+            street: "2 Main St",
+            city: "Boston",
+            state: "MA",
+            zip: 22101,
+            people: [
+                {
+                    firstName: "John",
+                    lastName: "DoeBoston",
+                    age: 30
+                },
+                {
+                    firstName: "Jane",
+                    lastName: "SmithBoston",
+                    age: 35
+                }
+            ]
+        }) {
+            street
+            city
+            state
+            zip
+        },
+        address3: createAddress(data: {
+            street: "3 Main St",
+            city: "Chicago",
+            state: "IL",
+            zip: 60601,
+            people: [
+                {
+                    firstName: "John",
+                    lastName: "DoeChicago",
+                    age: 40
+                },
+                {
+                    firstName: "Jane",
+                    lastName: "SmithChicago",
+                    age: 45
+                }
+            ]
+        }) {
+            street
+            city
+            state
+            zip
+        },
+        address4: createAddress(data: {
+            street: "4 Main St",
+            city: "Plymouth",
+            state: "MA",
+            zip: 23600,
+            people: [
+                {
+                    firstName: "John",
+                    lastName: "DoePlymouth",
+                    age: 50
+                },
+                {
+                    firstName: "Jane",
+                    lastName: "SmithPlymouth",
+                    age: 55
+                }
+            ]
+        }) {
+            street
+            city
+            state
+            zip
+        }
+    }
+auth: |
+    {
+        role: "admin"
+    }

--- a/integration-tests/composite-pk/scalars/with-auth/tests/mutation/delete-people-by-address.exotest
+++ b/integration-tests/composite-pk/scalars/with-auth/tests/mutation/delete-people-by-address.exotest
@@ -1,0 +1,42 @@
+operation: |
+    fragment personInfo on Person {
+      firstName
+      lastName
+      address {
+        street
+        city
+        state
+        zip
+      }
+    }
+    mutation {
+      maPeople: deletePeople(where: { address: { state: {eq: "MA"} } }) @unordered {
+        ...personInfo
+      }
+      nonExisting: deletePeople(where: { address: { state: {eq: "CA"} } }) @unordered {
+        ...personInfo
+      }
+    }
+auth: |
+    {
+      firstName: "Jane",
+      lastName: "SmithBoston"
+    }
+response: |
+    {
+      "data": {
+        "maPeople": [
+          {
+            "firstName": "Jane",
+            "lastName": "SmithBoston",
+            "address": {
+              "street": "2 Main St",
+              "city": "Boston",
+              "state": "MA",
+              "zip": 22101
+            }
+          }
+        ],
+        "nonExisting": []
+      }
+    }

--- a/integration-tests/composite-pk/scalars/with-auth/tests/mutation/update-people-by-address.exotest
+++ b/integration-tests/composite-pk/scalars/with-auth/tests/mutation/update-people-by-address.exotest
@@ -1,0 +1,44 @@
+operation: |
+    fragment personInfo on Person {
+      firstName
+      lastName
+      age
+      address {
+        street
+        city
+        state
+        zip
+      }
+    }
+    mutation {
+      maPeople: updatePeople(where: { address: { state: {eq: "MA"} } }, data: { age: 20 }) @unordered {
+        ...personInfo
+      }
+      nonExisting: updatePeople(where: { address: { state: {eq: "CA"} } }, data: { age: 30 }) @unordered {
+        ...personInfo
+      }
+    }
+auth: |
+    {
+      firstName: "Jane",
+      lastName: "SmithBoston"
+    }
+response: |
+    {
+      "data": {
+        "maPeople": [
+          {
+            "firstName": "Jane",
+            "lastName": "SmithBoston",
+            "age": 20,
+            "address": {
+              "street": "2 Main St",
+              "city": "Boston",
+              "state": "MA",
+              "zip": 22101
+            }
+          }
+        ],
+        "nonExisting": []
+      }
+    }

--- a/integration-tests/composite-pk/scalars/with-auth/tests/query/address-by-id.exotest
+++ b/integration-tests/composite-pk/scalars/with-auth/tests/query/address-by-id.exotest
@@ -1,0 +1,41 @@
+operation: |
+  fragment AddressFragment on Address {
+    street
+    city
+    state
+    zip
+  }
+
+  query {
+    address1: address(street: "1 Main St", city: "Albany", state: "NY", zip: 10001) {
+      ...AddressFragment
+    }
+    address2: address(street: "2 Main St", city: "Boston", state: "MA", zip: 22101) {
+      ...AddressFragment
+    }
+    address3: address(street: "3 Main St", city: "Chicago", state: "IL", zip: 60601) {
+      ...AddressFragment
+    }
+    nonExisting: address(street: "1 Main St", city: "Boston", state: "MA", zip: 60601) {
+      ...AddressFragment
+    }
+  }
+auth: |
+  {
+    firstName: "Jane",
+    lastName: "SmithBoston"
+  }  
+response: |
+  {
+    "data": {
+      "address1": null,
+      "address2": {
+        "street": "2 Main St",
+        "city": "Boston",
+        "state": "MA",
+        "zip": 22101
+      },
+      "address3": null,
+      "nonExisting": null
+    }
+  }

--- a/integration-tests/composite-pk/scalars/with-auth/tests/query/addresses-by-people.exotest
+++ b/integration-tests/composite-pk/scalars/with-auth/tests/query/addresses-by-people.exotest
@@ -1,0 +1,65 @@
+operation: |
+    fragment address on Address {
+      street
+      city
+      state
+      zip
+      people {
+        firstName
+        lastName
+        age
+      }
+    }
+    
+    query {
+      johnAddresses: addresses(where: { people: { firstName: {eq: "John"} } }) @unordered {
+        ...address
+      }
+      janeAddresses: addresses(where: { people: { firstName: {eq: "Jane"} } }) @unordered {
+        ...address
+      }
+      olderThan30Addresses: addresses(where: { people: { age: {gt: 30} } }) @unordered {
+        ...address
+      }
+    }
+auth: |
+    {
+      firstName: "Jane",
+      lastName: "SmithBoston"
+    }
+response: |
+    {
+      "data": {
+        "johnAddresses": [],
+        "janeAddresses": [
+          {
+            "street": "2 Main St",
+            "city": "Boston",
+            "state": "MA",
+            "zip": 22101,
+            "people": [
+              {
+                "firstName": "Jane",
+                "lastName": "SmithBoston",
+                "age": 35
+              }
+            ]
+          }
+        ],
+        "olderThan30Addresses": [
+          {
+            "street": "2 Main St",
+            "city": "Boston",
+            "state": "MA",
+            "zip": 22101,
+            "people": [
+              {
+                "firstName": "Jane",
+                "lastName": "SmithBoston",
+                "age": 35
+              }
+            ]
+          }
+        ]
+      }
+    }

--- a/integration-tests/composite-pk/scalars/with-auth/tests/query/addresses-where.exotest
+++ b/integration-tests/composite-pk/scalars/with-auth/tests/query/addresses-where.exotest
@@ -1,0 +1,172 @@
+stages:
+  - operation: |
+      fragment addressInfo on Address {
+        street
+        city
+        state
+        zip
+      }
+      query {
+        all: addresses @unordered {
+          ...addressInfo
+        }
+        maCities: addresses(where: { state: {eq: "MA"} }) @unordered {
+          ...addressInfo
+        }
+      }
+    response: |
+      {
+        "errors": [
+          {
+            "message": "Not authorized"
+          }
+        ]
+      }
+  - operation: |
+      fragment addressInfo on Address {
+        street
+        city
+        state
+        zip
+      }
+      query {
+        all: addresses @unordered {
+          ...addressInfo
+        }
+        maCities: addresses(where: { state: {eq: "MA"} }) @unordered {
+          ...addressInfo
+        }
+      }
+    auth: |
+      {
+        role: "admin"
+      }
+    response: |
+      {
+        "data": {
+          "all": [
+            {
+              "street": "1 Main St",
+              "city": "Albany",
+              "state": "NY",
+              "zip": 10001
+            },
+            {
+              "street": "2 Main St",
+              "city": "Boston",
+              "state": "MA",
+              "zip": 22101
+            },
+            {
+              "street": "3 Main St",
+              "city": "Chicago",
+              "state": "IL",
+              "zip": 60601
+            },
+            {
+              "street": "4 Main St",
+              "city": "Plymouth",
+              "state": "MA",
+              "zip": 23600
+            }
+          ],
+          "maCities": [
+            {
+              "street": "2 Main St",
+              "city": "Boston",
+              "state": "MA",
+              "zip": 22101
+            },
+            {
+              "street": "4 Main St",
+              "city": "Plymouth",
+              "state": "MA",
+              "zip": 23600
+            }
+          ]
+        }
+      }
+
+  - operation: |
+      fragment addressInfo on Address {
+        street
+        city
+        state
+        zip
+      }
+      query {
+        all: addresses @unordered {
+          ...addressInfo
+        }
+        maCities: addresses(where: { state: {eq: "MA"} }) @unordered {
+          ...addressInfo
+        }
+      }
+    auth: |
+      {
+        firstName: "John",
+        lastName: "DoeBoston"
+      }
+    response: |
+      {
+        "data": {
+          "all": [
+            {
+              "street": "2 Main St",
+              "city": "Boston",
+              "state": "MA",
+              "zip": 22101
+            }
+          ],
+          "maCities": [
+            {
+              "street": "2 Main St",
+              "city": "Boston",
+              "state": "MA",
+              "zip": 22101
+            }
+          ]
+        }
+      }
+
+  - operation: |
+      fragment addressInfo on Address {
+        street
+        city
+        state
+        zip
+      }
+      query {
+        all: addresses @unordered {
+          ...addressInfo
+        }
+        maCities: addresses(where: { state: {eq: "MA"} }) @unordered {
+          ...addressInfo
+        }
+      }
+    auth: |
+      {
+        firstName: "Jane",
+        lastName: "SmithBoston"
+      }
+    response: |
+      {
+        "data": {
+          "all": [
+            {
+              "street": "2 Main St",
+              "city": "Boston",
+              "state": "MA",
+              "zip": 22101
+            }
+          ],
+          "maCities": [
+            {
+              "street": "2 Main St",
+              "city": "Boston",
+              "state": "MA",
+              "zip": 22101
+            }
+          ]
+        }
+      }

--- a/integration-tests/composite-pk/scalars/with-auth/tests/query/people-by-address.exotest
+++ b/integration-tests/composite-pk/scalars/with-auth/tests/query/people-by-address.exotest
@@ -1,0 +1,54 @@
+operation: |
+    fragment personInfo on Person {
+      firstName
+      lastName
+      address {
+        street
+        city
+        state
+        zip
+      }
+    }
+    query {
+      all: people @unordered {
+        ...personInfo
+      }
+      maPeople: people(where: { address: { state: {eq: "MA"} } }) @unordered {
+        ...personInfo
+      }
+    }
+auth: |
+    {
+      firstName: "Jane",
+      lastName: "SmithBoston"
+    }
+response: |
+    {
+      "data": {
+        "all": [
+          {
+            "firstName": "Jane",
+            "lastName": "SmithBoston",
+            "address": {
+              "street": "2 Main St",
+              "city": "Boston",
+              "state": "MA",
+              "zip": 22101
+            }
+          }
+        ],
+        "maPeople": [
+          {
+            "firstName": "Jane",
+            "lastName": "SmithBoston",
+            "address": {
+              "street": "2 Main St",
+              "city": "Boston",
+              "state": "MA",
+              "zip": 22101
+            }
+          }
+        ]
+      }
+    }
+

--- a/libs/exo-sql/src/asql/column_path.rs
+++ b/libs/exo-sql/src/asql/column_path.rs
@@ -12,7 +12,7 @@ use std::cmp::Ordering;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    sql::{predicate::ParamEquality, SQLParamContainer},
+    sql::{predicate::ParamEquality, relation::RelationColumnPair, SQLParamContainer},
     ColumnId, Database, TableId,
 };
 
@@ -74,31 +74,31 @@ pub enum ColumnPathLink {
 
 impl ColumnPathLink {
     pub fn relation(
-        self_column_id: ColumnId,
-        linked_column_id: ColumnId,
+        column_pairs: Vec<RelationColumnPair>,
         linked_table_alias: Option<String>,
     ) -> Self {
         Self::Relation(RelationLink {
-            self_column_id,
-            foreign_column_id: linked_column_id,
+            column_pairs,
             linked_table_alias,
         })
     }
 
-    pub fn self_column_id(&self) -> ColumnId {
+    pub fn self_column_ids(&self) -> Vec<ColumnId> {
         match self {
-            ColumnPathLink::Relation(relation) => relation.self_column_id,
-            ColumnPathLink::Leaf(column_id) => *column_id,
+            ColumnPathLink::Relation(relation) => relation
+                .column_pairs
+                .iter()
+                .map(|pair| pair.self_column_id)
+                .collect(),
+            ColumnPathLink::Leaf(column_id) => vec![*column_id],
         }
     }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq)]
 pub struct RelationLink {
-    /// The column in the current table that is linked to the next table.
-    pub self_column_id: ColumnId,
-    /// The column in the next table that is linked to the current table.
-    pub foreign_column_id: ColumnId,
+    pub column_pairs: Vec<RelationColumnPair>,
+
     /// Alias that could be used when joining the table, etc. Useful when multiple columns in the self table refers to the same linked column
     /// For example, if "concerts" has "main_venue_id" and "alternative_venue_id" (both link to the venues.id column), we can set linked_table_alias
     /// to "main_venue_id_table" and "alternative_venue_id_table" respectively. Then we can join the venues table twice with different aliases.
@@ -114,8 +114,8 @@ impl PartialOrd for RelationLink {
 
 impl Ord for RelationLink {
     fn cmp(&self, other: &Self) -> Ordering {
-        (self.self_column_id, self.foreign_column_id)
-            .cmp(&(other.self_column_id, other.foreign_column_id))
+        (&self.column_pairs, &self.linked_table_alias)
+            .cmp(&(&other.column_pairs, &other.linked_table_alias))
     }
 }
 
@@ -127,9 +127,9 @@ impl ColumnPathLink {
     /// be the self column and `concert.venue_id` would be the linked column.
     pub fn is_one_to_many(&self, database: &Database) -> bool {
         match self {
-            ColumnPathLink::Relation(RelationLink { self_column_id, .. }) => {
-                self_column_id.get_column(database).is_pk
-            }
+            ColumnPathLink::Relation(RelationLink { column_pairs, .. }) => column_pairs
+                .iter()
+                .any(|pair| pair.self_column_id.get_column(database).is_pk),
             ColumnPathLink::Leaf(_) => false,
         }
     }
@@ -186,7 +186,7 @@ impl PhysicalColumnPath {
     }
 
     pub fn lead_table_id(&self) -> TableId {
-        self.0[0].self_column_id().table_id
+        self.0[0].self_column_ids()[0].table_id
     }
 
     pub fn push(mut self, link: ColumnPathLink) -> Self {
@@ -197,9 +197,9 @@ impl PhysicalColumnPath {
             matches!(
                 self.0.last().unwrap(),
                 ColumnPathLink::Relation(RelationLink {
-                    foreign_column_id,
+                    column_pairs,
                     ..
-                }) if foreign_column_id.table_id == link.self_column_id().table_id
+                }) if column_pairs[0].foreign_column_id.table_id == link.self_column_ids()[0].table_id
             ),
             "Expected link to point to next table"
         );
@@ -216,9 +216,9 @@ impl PhysicalColumnPath {
         assert!(matches!(
             self.0.last().unwrap(),
             ColumnPathLink::Relation(RelationLink {
-                foreign_column_id,
+                column_pairs,
                 ..
-            }) if foreign_column_id.table_id == tail.0[0].self_column_id().table_id
+            }) if column_pairs[0].foreign_column_id.table_id == tail.0[0].self_column_ids()[0].table_id
         ));
 
         self.0.extend(tail.0);

--- a/libs/exo-sql/src/asql/column_path.rs
+++ b/libs/exo-sql/src/asql/column_path.rs
@@ -77,6 +77,28 @@ impl ColumnPathLink {
         column_pairs: Vec<RelationColumnPair>,
         linked_table_alias: Option<String>,
     ) -> Self {
+        assert!(!column_pairs.is_empty(), "Column pairs must not be empty");
+
+        assert!(
+            column_pairs
+                .iter()
+                .all(|RelationColumnPair { self_column_id, .. }| {
+                    self_column_id.table_id == column_pairs[0].self_column_id.table_id
+                }),
+            "All self columns in the column pairs must refer to the same table"
+        );
+
+        assert!(
+            column_pairs.iter().all(
+                |RelationColumnPair {
+                     foreign_column_id, ..
+                 }| {
+                    foreign_column_id.table_id == column_pairs[0].foreign_column_id.table_id
+                }
+            ),
+            "All foreign columns in the column pairs must refer to the same table"
+        );
+
         Self::Relation(RelationLink {
             column_pairs,
             linked_table_alias,
@@ -104,6 +126,16 @@ pub struct RelationLink {
     /// to "main_venue_id_table" and "alternative_venue_id_table" respectively. Then we can join the venues table twice with different aliases.
     /// The alias name should not matter as long as it is unique within the self table
     pub linked_table_alias: Option<String>,
+}
+
+impl RelationLink {
+    pub fn self_table_id(&self) -> TableId {
+        self.column_pairs[0].self_column_id.table_id
+    }
+
+    pub fn linked_table_id(&self) -> TableId {
+        self.column_pairs[0].foreign_column_id.table_id
+    }
 }
 
 impl PartialOrd for RelationLink {

--- a/libs/exo-sql/src/lib.rs
+++ b/libs/exo-sql/src/lib.rs
@@ -74,7 +74,7 @@ pub use sql::{
     physical_column::{ColumnId, FloatBits, IntBits, PhysicalColumn, PhysicalColumnType},
     physical_table::{PhysicalIndex, PhysicalTable, PhysicalTableName},
     predicate::{CaseSensitivity, NumericComparator, ParamEquality, Predicate},
-    relation::{ManyToOne, ManyToOneId, OneToMany, OneToManyId, RelationId},
+    relation::{ManyToOne, ManyToOneId, OneToMany, OneToManyId, RelationColumnPair, RelationId},
     vector::{VectorDistanceFunction, DEFAULT_VECTOR_SIZE},
     SQLBytes, SQLParam, SQLParamContainer,
 };

--- a/libs/exo-sql/src/schema/column_spec.rs
+++ b/libs/exo-sql/src/schema/column_spec.rs
@@ -215,7 +215,11 @@ impl ColumnSpec {
     }
 
     /// Converts the column specification to SQL statements.
-    pub(super) fn to_sql(&self, table_spec: &TableSpec) -> SchemaStatement {
+    pub(super) fn to_sql(
+        &self,
+        table_spec: &TableSpec,
+        attach_pk_column_to_column_stmt: bool,
+    ) -> SchemaStatement {
         let SchemaStatement {
             statement,
             post_statements,
@@ -223,7 +227,11 @@ impl ColumnSpec {
         } = self
             .typ
             .to_sql(table_spec, &self.name, self.is_auto_increment);
-        let pk_str = if self.is_pk { " PRIMARY KEY" } else { "" };
+        let pk_str = if self.is_pk && attach_pk_column_to_column_stmt {
+            " PRIMARY KEY"
+        } else {
+            ""
+        };
         let not_null_str = if !self.is_nullable && !self.is_pk {
             // primary keys are implied to be not null
             " NOT NULL"

--- a/libs/exo-sql/src/schema/constraint.rs
+++ b/libs/exo-sql/src/schema/constraint.rs
@@ -22,7 +22,7 @@ pub(super) struct PrimaryKeyConstraint {
 }
 
 pub(super) struct ForeignKeyConstraint {
-    pub(super) _constraint_name: String,
+    pub(super) constraint_name: String,
     pub(super) self_columns: HashSet<String>,
     pub(super) foreign_table: PhysicalTableName,
     pub(super) foreign_columns: HashSet<String>,
@@ -101,7 +101,7 @@ impl Constraints {
                 let foreign_columns = Self::parse_column_list(&matches[3]); // name of the column in the referenced table
 
                 ForeignKeyConstraint {
-                    _constraint_name: conname.to_string(),
+                    constraint_name: conname.to_string(),
                     self_columns,
                     foreign_table: PhysicalTableName {
                         name: foreign_table,

--- a/libs/exo-sql/src/schema/op.rs
+++ b/libs/exo-sql/src/schema/op.rs
@@ -119,7 +119,7 @@ impl SchemaOp<'_> {
             SchemaOp::DeleteTable { table } => table.deletion_sql(),
 
             SchemaOp::CreateColumn { table, column } => {
-                let column_stmt = column.to_sql(table);
+                let column_stmt = column.to_sql(table, table.has_single_pk());
 
                 SchemaStatement {
                     statement: format!(

--- a/libs/exo-sql/src/schema/op.rs
+++ b/libs/exo-sql/src/schema/op.rs
@@ -12,8 +12,11 @@ use std::collections::HashSet;
 use crate::schema::{constraint::sorted_comma_list, index_spec::IndexSpec};
 
 use super::{
-    column_spec::ColumnSpec, function_spec::FunctionSpec, statement::SchemaStatement,
-    table_spec::TableSpec, trigger_spec::TriggerSpec,
+    column_spec::{ColumnReferenceSpec, ColumnSpec},
+    function_spec::FunctionSpec,
+    statement::SchemaStatement,
+    table_spec::TableSpec,
+    trigger_spec::TriggerSpec,
 };
 
 /// An execution unit of SQL, representing an operation that can create or destroy resources.
@@ -76,6 +79,16 @@ pub enum SchemaOp<'a> {
         constraint: String,
     },
 
+    CreateForeignKeyReference {
+        table: &'a TableSpec,
+        name: String,
+        reference_columns: Vec<(&'a ColumnSpec, &'a ColumnReferenceSpec)>,
+    },
+    DeleteForeignKeyReference {
+        table: &'a TableSpec,
+        name: String,
+    },
+
     SetNotNull {
         table: &'a TableSpec,
         column: &'a ColumnSpec,
@@ -119,7 +132,7 @@ impl SchemaOp<'_> {
             SchemaOp::DeleteTable { table } => table.deletion_sql(),
 
             SchemaOp::CreateColumn { table, column } => {
-                let column_stmt = column.to_sql(table, table.has_single_pk());
+                let column_stmt = column.to_sql(table.has_single_pk());
 
                 SchemaStatement {
                     statement: format!(
@@ -198,6 +211,66 @@ impl SchemaOp<'_> {
                     "ALTER TABLE {} DROP CONSTRAINT \"{}\";",
                     table.sql_name(),
                     constraint
+                ),
+                ..Default::default()
+            },
+
+            SchemaOp::CreateForeignKeyReference {
+                table,
+                name,
+                reference_columns,
+            } => {
+                let mut reference_columns = reference_columns.clone();
+                reference_columns
+                    .sort_by(|(column1, _), (column2, _)| column1.name.cmp(&column2.name));
+
+                let (self_columns, foreign_columns): (Vec<&ColumnSpec>, Vec<&ColumnReferenceSpec>) =
+                    reference_columns.into_iter().unzip();
+
+                let constraint_name = format!(
+                    "{}_{}_fk",
+                    table.name.fully_qualified_name_with_sep("_"),
+                    name
+                );
+
+                let foreign_reference_columns = if foreign_columns.len() == 1 {
+                    // If there is only one foreign column, we don't need to specify the columns in the foreign key constraint (assume it's the primary key)
+                    // TODO: We keep this behavior for now to avoid changing all migration tests, but we should do that in a future PR
+                    "".to_string()
+                } else {
+                    let names = foreign_columns
+                        .iter()
+                        .map(|column_reference| {
+                            format!("\"{}\"", column_reference.foreign_pk_column_name)
+                        })
+                        .collect::<Vec<_>>()
+                        .join(", ");
+
+                    format!(" ({names})")
+                };
+
+                let foreign_constraint = format!(
+                    r#"ALTER TABLE {} ADD CONSTRAINT "{constraint_name}" FOREIGN KEY ({}) REFERENCES {}{};"#,
+                    table.name.sql_name(),
+                    self_columns
+                        .iter()
+                        .map(|c| format!("\"{}\"", c.name.as_str()))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    foreign_columns[0].foreign_table_name.sql_name(),
+                    foreign_reference_columns
+                );
+
+                SchemaStatement {
+                    post_statements: vec![foreign_constraint],
+                    ..Default::default()
+                }
+            }
+            SchemaOp::DeleteForeignKeyReference { table, name } => SchemaStatement {
+                statement: format!(
+                    "ALTER TABLE {} DROP CONSTRAINT \"{}\";",
+                    table.sql_name(),
+                    name
                 ),
                 ..Default::default()
             },
@@ -281,6 +354,12 @@ impl SchemaOp<'_> {
             SchemaOp::RemoveUniqueConstraint { table, constraint } => {
                 // Extra uniqueness constraint may make inserts fail even if model allows it
                 Some(format!("Extra unique constaint `{}` in table `{}` found that is not require by the model.", constraint, table.sql_name()))
+            }
+            SchemaOp::CreateForeignKeyReference { table, reference_columns, .. } => {
+                Some(format!("The model requires a foreign key constraint in table `{}` for the following columns: {}", table.sql_name(), reference_columns.iter().map(|(c, _)| c.name.as_str()).collect::<Vec<_>>().join(", ")))
+            }
+            SchemaOp::DeleteForeignKeyReference { table, name } => {
+                Some(format!("Extra foreign key constraint `{}` in table `{}` found that is not require by the model.", name, table.sql_name()))
             }
 
             SchemaOp::SetNotNull { table, column } => {

--- a/libs/exo-sql/src/schema/test_helper.rs
+++ b/libs/exo-sql/src/schema/test_helper.rs
@@ -2,7 +2,7 @@
 
 use crate::PhysicalTableName;
 
-use super::column_spec::{ColumnSpec, ColumnTypeSpec};
+use super::column_spec::{ColumnReferenceSpec, ColumnSpec, ColumnTypeSpec};
 
 pub fn pk_column(name: impl Into<String>) -> ColumnSpec {
     ColumnSpec {
@@ -15,6 +15,7 @@ pub fn pk_column(name: impl Into<String>) -> ColumnSpec {
         is_nullable: false,
         unique_constraints: vec![],
         default_value: None,
+        group_name: None,
     }
 }
 
@@ -25,7 +26,7 @@ pub fn pk_reference_column(
 ) -> ColumnSpec {
     ColumnSpec {
         name: name.into(),
-        typ: ColumnTypeSpec::ColumnReference {
+        typ: ColumnTypeSpec::ColumnReference(ColumnReferenceSpec {
             foreign_table_name: PhysicalTableName::new(
                 foreign_table_name,
                 foreign_table_schema_name,
@@ -34,12 +35,13 @@ pub fn pk_reference_column(
             foreign_pk_type: Box::new(ColumnTypeSpec::Int {
                 bits: crate::IntBits::_16,
             }),
-        },
+        }),
         is_pk: false,
         is_auto_increment: false,
         is_nullable: false,
         unique_constraints: vec![],
         default_value: None,
+        group_name: None,
     }
 }
 
@@ -54,6 +56,7 @@ pub fn int_column(name: impl Into<String>) -> ColumnSpec {
         is_nullable: false,
         unique_constraints: vec![],
         default_value: None,
+        group_name: None,
     }
 }
 
@@ -66,6 +69,7 @@ pub fn string_column(name: impl Into<String>) -> ColumnSpec {
         is_nullable: false,
         unique_constraints: vec![],
         default_value: None,
+        group_name: None,
     }
 }
 
@@ -78,5 +82,6 @@ pub fn json_column(name: impl Into<String>) -> ColumnSpec {
         is_nullable: false,
         unique_constraints: vec![],
         default_value: None,
+        group_name: None,
     }
 }

--- a/libs/exo-sql/src/sql/database.rs
+++ b/libs/exo-sql/src/sql/database.rs
@@ -71,6 +71,17 @@ impl Database {
             .map(|column_index| new_column_id(table_id, column_index))
     }
 
+    pub fn get_column_ids_from_names(
+        &self,
+        table_id: TableId,
+        column_names: &[String],
+    ) -> Vec<ColumnId> {
+        column_names
+            .iter()
+            .map(|column_name| self.get_column_id(table_id, column_name).unwrap())
+            .collect()
+    }
+
     pub fn get_column_mut(&mut self, column_id: ColumnId) -> &mut PhysicalColumn {
         let table = self.get_table_mut(column_id.table_id);
         &mut table.columns[column_id.column_index]

--- a/libs/exo-sql/src/sql/database.rs
+++ b/libs/exo-sql/src/sql/database.rs
@@ -56,11 +56,13 @@ impl Database {
         })
     }
 
-    pub fn get_pk_column_id(&self, table_id: TableId) -> Option<ColumnId> {
+    pub fn get_pk_column_ids(&self, table_id: TableId) -> Vec<ColumnId> {
         let table = self.get_table(table_id);
         table
-            .get_pk_column_index()
+            .get_pk_column_indices()
+            .into_iter()
             .map(|column_index| new_column_id(table_id, column_index))
+            .collect()
     }
 
     pub fn get_column_id(&self, table_id: TableId, column_name: &str) -> Option<ColumnId> {

--- a/libs/exo-sql/src/sql/delete.rs
+++ b/libs/exo-sql/src/sql/delete.rs
@@ -91,7 +91,7 @@ impl<'a> TemplateDelete<'a> {
             .map(|row_index| {
                 let relation_predicate = ConcretePredicate::Eq(
                     Column::Physical {
-                        column_id: nesting_relation.foreign_column_id,
+                        column_id: nesting_relation.column_pairs[0].foreign_column_id,
                         table_alias: None,
                     },
                     Column::Param(SQLParamContainer::from_sql_value(

--- a/libs/exo-sql/src/sql/physical_column.rs
+++ b/libs/exo-sql/src/sql/physical_column.rs
@@ -38,6 +38,9 @@ pub struct PhysicalColumn {
     /// optional default value for this column
     pub default_value: Option<String>,
     pub update_sync: bool,
+
+    /// A name that can be used to group columns together (for example to generate a foreign key constraint name for composite primary keys)
+    pub group_name: Option<String>,
 }
 
 /// Simpler implementation of Debug for PhysicalColumn.
@@ -348,7 +351,12 @@ impl ColumnId {
         database
             .relations
             .iter()
-            .position(|relation| &relation.self_column_id == self)
+            .position(|relation| {
+                relation
+                    .column_pairs
+                    .iter()
+                    .any(|pair| &pair.self_column_id == self)
+            })
             .map(ManyToOneId)
     }
 

--- a/libs/exo-sql/src/sql/physical_table.rs
+++ b/libs/exo-sql/src/sql/physical_table.rs
@@ -102,8 +102,8 @@ impl std::fmt::Debug for PhysicalTable {
 }
 
 impl PhysicalTable {
-    pub fn get_pk_physical_column(&self) -> Option<&PhysicalColumn> {
-        self.columns.iter().find(|column| column.is_pk)
+    pub fn get_pk_physical_columns(&self) -> Vec<&PhysicalColumn> {
+        self.columns.iter().filter(|column| column.is_pk).collect()
     }
 
     pub fn insert<'a, C>(
@@ -160,8 +160,13 @@ impl PhysicalTable {
         self.columns.iter().position(|c| c.name == name)
     }
 
-    pub(crate) fn get_pk_column_index(&self) -> Option<usize> {
-        self.columns.iter().position(|c| c.is_pk)
+    pub(crate) fn get_pk_column_indices(&self) -> Vec<usize> {
+        self.columns
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| c.is_pk)
+            .map(|(i, _)| i)
+            .collect()
     }
 }
 

--- a/libs/exo-sql/src/sql/relation.rs
+++ b/libs/exo-sql/src/sql/relation.rs
@@ -2,16 +2,29 @@ use serde::{Deserialize, Serialize};
 
 use crate::{ColumnId, ColumnPathLink, Database};
 
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub struct OneToMany {
-    pub self_pk_column_id: ColumnId,
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct RelationColumnPair {
+    pub self_column_id: ColumnId,
     pub foreign_column_id: ColumnId,
+}
+
+impl RelationColumnPair {
+    pub fn flipped(&self) -> RelationColumnPair {
+        RelationColumnPair {
+            self_column_id: self.foreign_column_id,
+            foreign_column_id: self.self_column_id,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash, Debug)]
+pub struct OneToMany {
+    pub column_pairs: Vec<RelationColumnPair>,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash, Debug)]
 pub struct ManyToOne {
-    pub self_column_id: ColumnId,
-    pub foreign_pk_column_id: ColumnId,
+    pub column_pairs: Vec<RelationColumnPair>,
     /// A name that may be used to alias the foreign table. This is useful when
     /// multiple columns in a table refer to the same foreign table. For example,
     /// `concerts` may have a `main_venue_id` and a `alt_venue_id`.
@@ -20,24 +33,23 @@ pub struct ManyToOne {
 
 impl OneToMany {
     pub fn column_path_link(&self) -> ColumnPathLink {
-        ColumnPathLink::relation(self.self_pk_column_id, self.foreign_column_id, None)
+        ColumnPathLink::relation(self.column_pairs.clone(), None)
     }
 }
 
 impl ManyToOne {
     fn flipped(&self) -> OneToMany {
         OneToMany {
-            self_pk_column_id: self.foreign_pk_column_id,
-            foreign_column_id: self.self_column_id,
+            column_pairs: self
+                .column_pairs
+                .iter()
+                .map(|pair| pair.flipped())
+                .collect(),
         }
     }
 
     pub fn column_path_link(&self) -> ColumnPathLink {
-        ColumnPathLink::relation(
-            self.self_column_id,
-            self.foreign_pk_column_id,
-            self.foreign_table_alias.clone(),
-        )
+        ColumnPathLink::relation(self.column_pairs.clone(), self.foreign_table_alias.clone())
     }
 }
 

--- a/libs/exo-sql/src/sql/update.rs
+++ b/libs/exo-sql/src/sql/update.rs
@@ -113,7 +113,7 @@ impl<'a> TemplateUpdate<'a> {
 
                 let relation_predicate = ConcretePredicate::Eq(
                     Column::Physical {
-                        column_id: self.nesting_relation.foreign_column_id,
+                        column_id: self.nesting_relation.column_pairs[0].foreign_column_id,
                         table_alias: None,
                     },
                     Column::Param(SQLParamContainer::from_sql_value(

--- a/libs/exo-sql/src/transform/join_util.rs
+++ b/libs/exo-sql/src/transform/join_util.rs
@@ -9,7 +9,10 @@
 
 use crate::{
     asql::column_path::{ColumnPathLink, RelationLink},
-    sql::{column::Column, join::LeftJoin, predicate::ConcretePredicate, table::Table},
+    sql::{
+        column::Column, join::LeftJoin, predicate::ConcretePredicate, relation::RelationColumnPair,
+        table::Table,
+    },
     transform::table_dependency::{DependencyLink, TableDependency},
     Database, PhysicalColumnPath, TableId,
 };
@@ -48,10 +51,13 @@ pub fn compute_join(
             |acc, DependencyLink { link, dependency }| {
                 let (join_predicate, linked_table_alias) = match link {
                     ColumnPathLink::Relation(RelationLink {
-                        self_column_id,
-                        foreign_column_id: linked_column_id,
+                        column_pairs,
                         linked_table_alias,
                     }) => {
+                        let RelationColumnPair {
+                            self_column_id,
+                            foreign_column_id: linked_column_id,
+                        } = column_pairs[0];
                         let new_alias = selection_level
                             .alias((linked_column_id.table_id, linked_table_alias), database);
 

--- a/libs/exo-sql/src/transform/pg/predicate_transformer.rs
+++ b/libs/exo-sql/src/transform/pg/predicate_transformer.rs
@@ -9,7 +9,7 @@
 
 use crate::{
     asql::column_path::{ColumnPathLink, RelationLink},
-    sql::predicate::ConcretePredicate,
+    sql::{predicate::ConcretePredicate, relation::RelationColumnPair},
     transform::{pg::selection_level::SelectionLevel, transformer::PredicateTransformer},
     AbstractPredicate, AbstractSelect, AliasedSelectionElement, Column, ColumnPath, Database,
     NumericComparator, Selection, SelectionElement, VectorDistanceFunction,
@@ -180,11 +180,12 @@ fn form_subselect(
     database: &Database,
     select_transformer: &Postgres,
 ) -> ConcretePredicate {
-    let RelationLink {
+    let RelationLink { column_pairs, .. } = relation_link;
+
+    let RelationColumnPair {
         self_column_id,
         foreign_column_id,
-        ..
-    } = relation_link;
+    } = column_pairs[0];
 
     let foreign_column = foreign_column_id.get_column(database);
     let abstract_select = AbstractSelect {

--- a/libs/exo-sql/src/transform/pg/select/selection_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/select/selection_strategy.rs
@@ -153,20 +153,19 @@ pub(super) fn compute_relation_predicate(
         .map(|relation_id| {
             let (self_column_id, foreign_column_id) = match relation_id {
                 RelationId::OneToMany(relation_id) => {
-                    let OneToMany {
-                        self_pk_column_id,
-                        foreign_column_id,
-                    } = relation_id.deref(database);
+                    let OneToMany { column_pairs } = relation_id.deref(database);
 
-                    (self_pk_column_id, foreign_column_id)
+                    (
+                        column_pairs[0].self_column_id,
+                        column_pairs[0].foreign_column_id,
+                    )
                 }
                 RelationId::ManyToOne(relation_id) => {
-                    let ManyToOne {
-                        self_column_id,
-                        foreign_pk_column_id,
-                        ..
-                    } = relation_id.deref(database);
-                    (self_column_id, foreign_pk_column_id)
+                    let ManyToOne { column_pairs, .. } = relation_id.deref(database);
+                    (
+                        column_pairs[0].self_column_id,
+                        column_pairs[0].foreign_column_id,
+                    )
                 }
             };
 

--- a/libs/exo-sql/src/transform/pg/selection_level.rs
+++ b/libs/exo-sql/src/transform/pg/selection_level.rs
@@ -108,14 +108,16 @@ impl SelectionLevel {
                 let table_linking = relation_ids.iter().map(|relation_id| match relation_id {
                     RelationId::ManyToOne(r) => {
                         let many_to_one = r.deref(database);
+
                         (
-                            many_to_one.self_column_id.table_id,
+                            many_to_one.column_pairs[0].self_column_id.table_id,
                             many_to_one.foreign_table_alias.clone(),
                         )
                     }
                     RelationId::OneToMany(r) => {
                         let one_to_many = r.deref(database);
-                        (one_to_many.self_pk_column_id.table_id, None)
+
+                        (one_to_many.column_pairs[0].self_column_id.table_id, None)
                     }
                 });
 


### PR DESCRIPTION
This supports composite primary keys where each field is a scalar (non-scalar will come in a separate PR). For example, we now support the following model:

```exo
@postgres
module PeopleDatabase {
  @access(true)
  @plural("People")
  type Person {
    @pk firstName: String
    @pk lastName: String
    age: Int
    address: Address?
  }

  @access(true)
  @plural("Addresses")
  type Address {
    @pk street: String
    @pk city: String
    @pk state: String
    @pk zip: Int
    people: Set<Person>?
  }
}
```