### PR TITLE
Support composite primary keys with non-scalar fields

### DIFF
--- a/crates/postgres-subsystem/postgres-core-builder/src/access_utils.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/access_utils.rs
@@ -1096,7 +1096,7 @@ fn reduce_nested_primitive_expr(
             let (head, tail) = pc.split_head();
 
             match head {
-                ColumnPathLink::Relation(r) if r.linked_table_id() == parent_entity.table_id => {
+                ColumnPathLink::Relation(r) if r.linked_table_id == parent_entity.table_id => {
                     // Eliminate the head link. For example if the expression is self.user.id, then
                     // we can reduce it to just id (assuming that the parent entity is user)
                     NestedPredicatePart::Parent(DatabaseAccessPrimitiveExpression::Column(
@@ -1111,7 +1111,7 @@ fn reduce_nested_primitive_expr(
             let (head, tail) = pc.split_head();
 
             match head {
-                ColumnPathLink::Relation(r) if r.linked_table_id() == parent_entity.table_id => {
+                ColumnPathLink::Relation(r) if r.linked_table_id == parent_entity.table_id => {
                     // Eliminate the head link. For example if the expression is self.user.id, then
                     // we can reduce it to just id (assuming that the parent entity is user)
                     NestedPredicatePart::Parent(DatabaseAccessPrimitiveExpression::Column(

--- a/crates/postgres-subsystem/postgres-core-builder/src/aggregate_type_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/aggregate_type_builder.rs
@@ -150,7 +150,7 @@ fn expand_type(resolved_type: &ResolvedType, building: &mut SystemContextBuildin
                 //   }
                 // }
                 // ```
-                if field.typ.innermost().is_primitive {
+                if field.typ.innermost().is_primitive || field.is_pk {
                     let type_name = aggregate_type_name(field.typ.name());
 
                     let type_id = building.aggregate_types.get_id(&type_name).unwrap();

--- a/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
@@ -398,8 +398,8 @@ fn compute_many_to_one_relation(
 
                     let field_alias = field.name.to_snake_case().to_plural();
 
-                    Some(ManyToOne {
-                        column_pairs: self_column_ids
+                    Some(ManyToOne::new(
+                        self_column_ids
                             .into_iter()
                             .zip(foreign_pk_column_ids)
                             .map(|(self_column_id, foreign_column_id)| RelationColumnPair {
@@ -407,8 +407,8 @@ fn compute_many_to_one_relation(
                                 foreign_column_id,
                             })
                             .collect(),
-                        foreign_table_alias: Some(field_alias),
-                    })
+                        Some(field_alias),
+                    ))
                 }
                 _ => None,
             }

--- a/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
@@ -301,7 +301,7 @@ fn create_columns(
                                     // A placeholder value. Will be resolved in the next phase (see expand_type_relations)
                                     PhysicalColumnType::Boolean
                                 },
-                                is_pk: false,
+                                is_pk: field.is_pk,
                                 is_auto_increment: false,
                                 is_nullable: optional,
                                 unique_constraints: unique_constraint_name.clone(),

--- a/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
@@ -44,7 +44,7 @@ pub fn build(resolved_env: &ResolvedTypeEnv) -> Result<Database, ModelBuildingEr
     // Ensure that all types have a primary key (skip JSON and unmanaged types)
     for (_, resolved_type) in resolved_env.resolved_types.iter() {
         if let ResolvedType::Composite(c) = &resolved_type {
-            if c.representation == EntityRepresentation::Managed && c.pk_field().is_none() {
+            if c.representation == EntityRepresentation::Managed && c.pk_fields().is_empty() {
                 let diagnostic = Diagnostic {
                     level: Level::Error,
                     message: format!(

--- a/crates/postgres-subsystem/postgres-core-builder/src/resolved_type.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/resolved_type.rs
@@ -151,8 +151,8 @@ impl TypeValidationProvider for ResolvedTypeHint {
 }
 
 impl ResolvedCompositeType {
-    pub fn pk_field(&self) -> Option<&ResolvedField> {
-        self.fields.iter().find(|f| f.is_pk)
+    pub fn pk_fields(&self) -> Vec<&ResolvedField> {
+        self.fields.iter().filter(|f| f.is_pk).collect()
     }
 
     pub fn field_by_column_names(&self, column_names: &[String]) -> Option<&ResolvedField> {

--- a/crates/postgres-subsystem/postgres-core-builder/src/resolved_type.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/resolved_type.rs
@@ -95,6 +95,14 @@ impl ResolvedField {
             Some(ResolvedFieldDefault::AutoIncrement)
         )
     }
+
+    // In many cases, the field has a single column name, so provide a way to get it while asserting that it has only one column name
+    pub fn column_name(&self) -> &str {
+        match &self.column_names[..] {
+            [name] => name,
+            _ => panic!("Expected a single column name for field {self:?}"),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/crates/postgres-subsystem/postgres-core-builder/src/resolved_type.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/resolved_type.rs
@@ -70,7 +70,7 @@ impl ToPlural for ResolvedCompositeType {
 pub struct ResolvedField {
     pub name: String,
     pub typ: FieldType<ResolvedFieldType>,
-    pub column_names: Vec<String>,
+    pub column_names: Vec<String>, // column names for this field (will be multiple of the field is composite and that composite type has multiple pks)
     pub self_column: bool, // is the column name in the same table or does it point to a column in a different table?
     pub is_pk: bool,
     pub access: ResolvedAccess,

--- a/crates/postgres-subsystem/postgres-core-builder/src/type_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/type_builder.rs
@@ -566,7 +566,7 @@ fn create_vector_distance_field(
             let self_table_id = &self_type.table_id;
             let column_id = building
                 .database
-                .get_column_id(*self_table_id, &field.column_names[0])
+                .get_column_id(*self_table_id, field.column_name())
                 .unwrap();
 
             let access = compute_access(&field.access, *type_id, env, building).unwrap();
@@ -619,7 +619,7 @@ fn create_relation(
                     ResolvedType::Primitive(_) => PostgresRelation::Scalar {
                         column_id: building
                             .database
-                            .get_column_id(*self_table_id, &field.column_names[0])
+                            .get_column_id(*self_table_id, field.column_name())
                             .unwrap(),
                         is_pk: false,
                     },
@@ -628,7 +628,7 @@ fn create_relation(
                             PostgresRelation::Scalar {
                                 column_id: building
                                     .database
-                                    .get_column_id(*self_table_id, &field.column_names[0])
+                                    .get_column_id(*self_table_id, field.column_name())
                                     .unwrap(),
                                 is_pk: false,
                             }
@@ -657,7 +657,7 @@ fn create_relation(
                     } else {
                         let column_id = building
                             .database
-                            .get_column_id(*self_table_id, &field.column_names[0])
+                            .get_column_id(*self_table_id, field.column_name())
                             .unwrap();
                         PostgresRelation::Scalar {
                             column_id,
@@ -670,7 +670,7 @@ fn create_relation(
                         PostgresRelation::Scalar {
                             column_id: building
                                 .database
-                                .get_column_id(*self_table_id, &field.column_names[0])
+                                .get_column_id(*self_table_id, field.column_name())
                                 .unwrap(),
                             is_pk: field.is_pk,
                         }

--- a/crates/postgres-subsystem/postgres-core-model/src/relation.rs
+++ b/crates/postgres-subsystem/postgres-core-model/src/relation.rs
@@ -7,8 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::types::EntityFieldId;
+use crate::types::{EntityFieldId, EntityType};
 
+use core_plugin_interface::core_model::mapped_arena::SerializableSlabIndex;
 use exo_sql::{ColumnId, ColumnPathLink, Database, ManyToOneId, OneToManyId};
 use serde::{Deserialize, Serialize};
 
@@ -53,6 +54,7 @@ pub struct ManyToOneRelation {
     // - relation_id.self_column_id: concerts.venue_id
     // - relation_id.foreign_pk_column_id: venues.id
     pub cardinality: RelationCardinality,
+    pub foreign_entity_id: SerializableSlabIndex<EntityType>,
     pub foreign_pk_field_ids: Vec<EntityFieldId>,
     pub relation_id: ManyToOneId,
 }
@@ -73,7 +75,7 @@ pub struct OneToManyRelation {
     // - relation_id.self_pk_column_id: venues.id
     // - relation_id.foreign_column_id: concerts.venue_id
     pub cardinality: RelationCardinality,
-    pub foreign_field_id: EntityFieldId,
+    pub foreign_entity_id: SerializableSlabIndex<EntityType>,
     pub relation_id: OneToManyId,
 }
 

--- a/crates/postgres-subsystem/postgres-core-model/src/types.rs
+++ b/crates/postgres-subsystem/postgres-core-model/src/types.rs
@@ -83,19 +83,6 @@ pub struct EntityType {
     pub access: Access,
 }
 
-pub fn get_field_id(
-    types: &SerializableSlab<EntityType>,
-    entity_id: SerializableSlabIndex<EntityType>,
-    field_name: &str,
-) -> Option<EntityFieldId> {
-    let entity = &types[entity_id];
-    entity
-        .fields
-        .iter()
-        .position(|field| field.name == field_name)
-        .map(|field_index| EntityFieldId(field_index, entity_id))
-}
-
 /// Encapsulates a field on an entity type (mirros how `ColumnId` is structured)
 #[derive(Serialize, Deserialize, Clone, Copy, Debug)]
 pub struct EntityFieldId(usize, SerializableSlabIndex<EntityType>);

--- a/crates/postgres-subsystem/postgres-core-model/src/types.rs
+++ b/crates/postgres-subsystem/postgres-core-model/src/types.rs
@@ -128,7 +128,7 @@ impl EntityType {
     pub fn pk_fields(&self) -> Vec<&PostgresField<EntityType>> {
         self.fields
             .iter()
-            .filter(|field| matches!(&field.relation, PostgresRelation::Pk { .. }))
+            .filter(|field| field.relation.is_pk())
             .collect()
     }
 
@@ -136,7 +136,7 @@ impl EntityType {
         self.fields
             .iter()
             .enumerate()
-            .filter(|(_, field)| matches!(&field.relation, PostgresRelation::Pk { .. }))
+            .filter(|(_, field)| field.relation.is_pk())
             .map(|(field_index, _)| EntityFieldId(field_index, entity_id))
             .collect()
     }

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/predicate_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/predicate_builder.rs
@@ -11,6 +11,7 @@ use core_plugin_interface::core_model::{
     mapped_arena::{MappedArena, SerializableSlabIndex},
     types::{FieldType, Named},
 };
+use exo_sql::ColumnPathLink;
 use postgres_graphql_model::predicate::PredicateParameterTypeWrapper;
 
 use postgres_core_model::types::{EntityType, PostgresField, PostgresPrimitiveType, TypeIndex};
@@ -283,7 +284,10 @@ fn expand_unique_type(
         .fields
         .iter()
         .flat_map(|field| match &field.relation {
-            PostgresRelation::Scalar { is_pk: true, .. } => {
+            PostgresRelation::Scalar {
+                is_pk: true,
+                column_id,
+            } => {
                 let field_type_name = field.typ.name();
                 let param_type_id = building
                     .predicate_types
@@ -299,7 +303,7 @@ fn expand_unique_type(
                     name: field.name.clone(),
                     typ: param_type,
                     access: Some(field.access.clone()),
-                    column_path_link: None,
+                    column_path_link: Some(ColumnPathLink::Leaf(*column_id)),
                     vector_distance_function: None,
                 })
             }

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/predicate_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/predicate_builder.rs
@@ -100,6 +100,16 @@ pub fn build_shallow(types: &MappedArena<ResolvedType>, building: &mut SystemCon
                         .predicate_types
                         .add(&shallow_type.name.clone(), shallow_type);
                 }
+                // Filter for the pk fields
+                {
+                    let shallow_type = PredicateParameterType {
+                        name: get_pk_filter_type_name(&c.name),
+                        kind: PredicateParameterTypeKind::ImplicitEqual, // Will be set to the correct value in expand_type
+                    };
+                    building
+                        .predicate_types
+                        .add(&shallow_type.name.clone(), shallow_type);
+                }
             }
         }
     }
@@ -145,6 +155,13 @@ pub fn build_expanded(resolved_env: &ResolvedTypeEnv, building: &mut SystemConte
             let new_kind = expand_unique_type(entity_type, building);
             building.predicate_types[existing_param_id.unwrap()].kind = new_kind;
         }
+
+        {
+            let param_type_name = get_pk_filter_type_name(&entity_type.name);
+            let existing_param_id = building.predicate_types.get_id(&param_type_name);
+            let new_kind = expand_pk_type(entity_type, building);
+            building.predicate_types[existing_param_id.unwrap()].kind = new_kind;
+        }
     }
 }
 
@@ -154,6 +171,10 @@ pub fn get_filter_type_name(type_name: &str) -> String {
 
 pub fn get_unique_filter_type_name(type_name: &str) -> String {
     format!("{type_name}UniqueFilter")
+}
+
+pub fn get_pk_filter_type_name(type_name: &str) -> String {
+    format!("{type_name}PkFilter")
 }
 
 fn expand_primitive_type(
@@ -283,11 +304,66 @@ fn expand_unique_type(
         .fields
         .iter()
         .flat_map(|field| match &field.relation {
-            PostgresRelation::Pk { .. } => {
+            PostgresRelation::Scalar { is_pk: true, .. } => {
                 let field_type_name = field.typ.name();
                 let param_type_id = building
                     .predicate_types
                     .get_id(field_type_name)
+                    .unwrap_or_else(|| panic!("Could not find predicate type '{field_type_name}'"));
+
+                let param_type = FieldType::Plain(PredicateParameterTypeWrapper {
+                    name: field_type_name.to_owned(),
+                    type_id: param_type_id,
+                });
+
+                Some(PredicateParameter {
+                    name: field.name.clone(),
+                    typ: param_type,
+                    access: Some(field.access.clone()),
+                    column_path_link: None,
+                    vector_distance_function: None,
+                })
+            }
+            _ => None,
+        })
+        .collect();
+
+    PredicateParameterTypeKind::Reference(field_predicates)
+}
+
+fn expand_pk_type(
+    entity_type: &EntityType,
+    building: &SystemContextBuilding,
+) -> PredicateParameterTypeKind {
+    let field_predicates = entity_type
+        .fields
+        .iter()
+        .flat_map(|field| match &field.relation {
+            PostgresRelation::Scalar { is_pk: true, .. } => {
+                let field_type_name = field.typ.name();
+                let param_type_id = building
+                    .predicate_types
+                    .get_id(field_type_name)
+                    .unwrap_or_else(|| panic!("Could not find predicate type '{field_type_name}'"));
+
+                let param_type = FieldType::Plain(PredicateParameterTypeWrapper {
+                    name: field_type_name.to_owned(),
+                    type_id: param_type_id,
+                });
+
+                Some(PredicateParameter {
+                    name: field.name.clone(),
+                    typ: param_type,
+                    access: Some(field.access.clone()),
+                    column_path_link: None,
+                    vector_distance_function: None,
+                })
+            }
+            PostgresRelation::ManyToOne { is_pk: true, .. } => {
+                let field_type_name = field.typ.name();
+                let param_type_id = building
+                    .predicate_types
+                    .get_id(&get_pk_filter_type_name(field_type_name))
                     .unwrap_or_else(|| panic!("Could not find predicate type '{field_type_name}'"));
 
                 let param_type = FieldType::Plain(PredicateParameterTypeWrapper {

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/reference_input_type_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/reference_input_type_builder.rs
@@ -68,7 +68,7 @@ fn expanded_reference_types(
         .fields
         .iter()
         .flat_map(|field| match &field.relation {
-            PostgresRelation::Pk { .. } => Some(PostgresField {
+            PostgresRelation::Scalar { is_pk: true, .. } => Some(PostgresField {
                 name: field.name.clone(),
                 typ: to_mutation_type(&field.typ, MutationTypeKind::Reference, building),
                 access: field.access.clone(),

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/reference_input_type_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/reference_input_type_builder.rs
@@ -78,6 +78,16 @@ fn expanded_reference_types(
                 readonly: field.readonly,
                 type_validation: None,
             }),
+            PostgresRelation::ManyToOne { is_pk: true, .. } => Some(PostgresField {
+                name: field.name.clone(),
+                typ: to_mutation_type(&field.typ, MutationTypeKind::Reference, building),
+                access: field.access.clone(),
+                relation: field.relation.clone(),
+                has_default_value: field.has_default_value,
+                dynamic_default_value: None,
+                readonly: field.readonly,
+                type_validation: None,
+            }),
             _ => None,
         })
         .collect();

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/update_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/update_mutation_builder.rs
@@ -22,10 +22,7 @@ use postgres_graphql_model::{
     types::MutationType,
 };
 
-use postgres_core_model::{
-    relation::PostgresRelation,
-    types::{EntityType, PostgresField, PostgresFieldType, TypeIndex},
-};
+use postgres_core_model::types::{EntityType, PostgresField, PostgresFieldType, TypeIndex};
 
 use crate::{
     mutation_builder::DataParamRole,
@@ -306,9 +303,8 @@ impl DataParamBuilder<DataParameter> for UpdateMutationBuilder {
                         let base_type = tpe.1.clone();
                         let mut base_type_fields = base_type.fields;
 
-                        let base_type_pk_field = base_type_fields
-                            .iter_mut()
-                            .find(|f| matches!(f.relation, PostgresRelation::Pk { .. }));
+                        let base_type_pk_field =
+                            base_type_fields.iter_mut().find(|f| f.relation.is_pk());
 
                         // For a non-nested type ("base type"), we already have the PK field, but it is optional. So here
                         // we make it required (by not wrapping the entity_pk_field it as optional)

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/update_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/update_mutation_builder.rs
@@ -303,21 +303,19 @@ impl DataParamBuilder<DataParameter> for UpdateMutationBuilder {
                         let base_type = tpe.1.clone();
                         let mut base_type_fields = base_type.fields;
 
-                        let base_type_pk_field =
-                            base_type_fields.iter_mut().find(|f| f.relation.is_pk());
+                        let base_type_pk_fields =
+                            base_type_fields.iter_mut().filter(|f| f.relation.is_pk());
 
                         // For a non-nested type ("base type"), we already have the PK field, but it is optional. So here
                         // we make it required (by not wrapping the entity_pk_field it as optional)
-                        if let Some(base_type_pk_field) = base_type_pk_field {
-                            let entity_pk_field = entity_type.pk_fields()[0];
+                        for (i, base_type_pk_field) in base_type_pk_fields.enumerate() {
+                            let entity_pk_field = entity_type.pk_fields()[i];
                             base_type_pk_field.typ = to_mutation_type(
                                 &entity_pk_field.typ,
                                 MutationTypeKind::Update,
                                 building,
                             );
-                        } else {
-                            panic!("Expected a PK field in the base type")
-                        };
+                        }
 
                         let type_with_id = MutationType {
                             name: nested_existing_type_name,

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/utils.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/utils.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use core_plugin_interface::core_model::types::FieldType;
-use postgres_core_model::types::{EntityRepresentation, EntityType, PostgresFieldType, TypeIndex};
+use postgres_core_model::types::{EntityType, PostgresFieldType, TypeIndex};
 use postgres_graphql_model::types::MutationType;
 
 use crate::{naming::ToPostgresTypeNames, system_builder::SystemContextBuilding};
@@ -33,9 +33,6 @@ pub(super) fn to_mutation_type(
             TypeIndex::Composite(index) => {
                 let entity_type = &building.core_subsystem.entity_types[*index];
 
-                if entity_type.representation == EntityRepresentation::Managed {
-                    panic!("Composite field in mutation: {:?}", type_name);
-                }
                 let entity_type_name = &entity_type.name;
 
                 let mutation_type_name = match kind {

--- a/crates/postgres-subsystem/postgres-graphql-model/src/aggregate.rs
+++ b/crates/postgres-subsystem/postgres-graphql-model/src/aggregate.rs
@@ -49,9 +49,7 @@ impl FieldDefinitionProvider<PostgresGraphQLSubsystem> for AggregateField {
     fn field_definition(&self, system: &PostgresGraphQLSubsystem) -> FieldDefinition {
         let arguments = match &self.relation {
             Some(relation) => match relation {
-                PostgresRelation::Pk { .. }
-                | PostgresRelation::Scalar { .. }
-                | PostgresRelation::ManyToOne { .. } => {
+                PostgresRelation::Scalar { .. } | PostgresRelation::ManyToOne { .. } => {
                     vec![]
                 }
                 PostgresRelation::OneToMany(OneToManyRelation {

--- a/crates/postgres-subsystem/postgres-graphql-model/src/aggregate.rs
+++ b/crates/postgres-subsystem/postgres-graphql-model/src/aggregate.rs
@@ -53,10 +53,9 @@ impl FieldDefinitionProvider<PostgresGraphQLSubsystem> for AggregateField {
                     vec![]
                 }
                 PostgresRelation::OneToMany(OneToManyRelation {
-                    foreign_field_id, ..
+                    foreign_entity_id, ..
                 }) => {
-                    let foreign_type_id = foreign_field_id.entity_type_id();
-                    let aggregate_query = system.get_aggregate_query(foreign_type_id);
+                    let aggregate_query = system.get_aggregate_query(*foreign_entity_id);
 
                     let AggregateQueryParameters { predicate_param } = &aggregate_query.parameters;
 

--- a/crates/postgres-subsystem/postgres-graphql-model/src/types.rs
+++ b/crates/postgres-subsystem/postgres-graphql-model/src/types.rs
@@ -163,10 +163,9 @@ impl<CT> FieldDefinitionProvider<PostgresGraphQLSubsystem> for PostgresField<CT>
                 vec![]
             }
             PostgresRelation::OneToMany(OneToManyRelation {
-                foreign_field_id, ..
+                foreign_entity_id, ..
             }) => {
-                let foreign_type_id = foreign_field_id.entity_type_id();
-                let collection_query = system.get_collection_query(foreign_type_id);
+                let collection_query = system.get_collection_query(foreign_entity_id);
 
                 let CollectionQueryParameters {
                     predicate_param,

--- a/crates/postgres-subsystem/postgres-graphql-model/src/types.rs
+++ b/crates/postgres-subsystem/postgres-graphql-model/src/types.rs
@@ -157,8 +157,7 @@ impl<CT> FieldDefinitionProvider<PostgresGraphQLSubsystem> for PostgresField<CT>
         }
 
         let arguments = match self.relation {
-            PostgresRelation::Pk { .. }
-            | PostgresRelation::Scalar { .. }
+            PostgresRelation::Scalar { .. }
             | PostgresRelation::ManyToOne { .. }
             | PostgresRelation::Embedded => {
                 vec![]

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/aggregate_query.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/aggregate_query.rs
@@ -107,26 +107,7 @@ async fn map_field<'content>(
         let model_field_agg_type = format!("{model_field_type}Agg");
 
         match &model_field.relation {
-            PostgresRelation::Pk { column_ids } => {
-                let elements = field
-                    .subfields
-                    .iter()
-                    .map(|subfield| {
-                        let selection_elem = if subfield.name == "__typename" {
-                            SelectionElement::Constant(model_field_agg_type.clone())
-                        } else {
-                            SelectionElement::Function(exo_sql::Function::Named {
-                                function_name: subfield.name.to_string(),
-                                column_id: column_ids[0],
-                            })
-                        };
-                        (subfield.output_name(), selection_elem)
-                    })
-                    .collect();
-                SelectionElement::Object(elements)
-            }
-
-            PostgresRelation::Scalar { column_id } => {
+            PostgresRelation::Scalar { column_id, .. } => {
                 let elements = field
                     .subfields
                     .iter()

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/postgres_query.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/postgres_query.rs
@@ -221,9 +221,8 @@ async fn map_persistent_field<'content>(
     request_context: &'content RequestContext<'content>,
 ) -> Result<SelectionElement, PostgresExecutionError> {
     match &entity_field.relation {
-        PostgresRelation::Pk { column_ids } => Ok(SelectionElement::Physical(column_ids[0])),
-        PostgresRelation::Scalar { column_id } => Ok(SelectionElement::Physical(*column_id)),
-        PostgresRelation::ManyToOne(relation) => {
+        PostgresRelation::Scalar { column_id, .. } => Ok(SelectionElement::Physical(*column_id)),
+        PostgresRelation::ManyToOne { relation, .. } => {
             let ManyToOneRelation {
                 foreign_pk_field_ids,
                 ..

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/postgres_query.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/postgres_query.rs
@@ -224,13 +224,10 @@ async fn map_persistent_field<'content>(
         PostgresRelation::Scalar { column_id, .. } => Ok(SelectionElement::Physical(*column_id)),
         PostgresRelation::ManyToOne { relation, .. } => {
             let ManyToOneRelation {
-                foreign_pk_field_ids,
-                ..
+                foreign_entity_id, ..
             } = relation;
 
-            let foreign_type_id = foreign_pk_field_ids[0].entity_type_id();
-
-            let foreign_table_pk_query = subsystem.get_pk_query(foreign_type_id);
+            let foreign_table_pk_query = subsystem.get_pk_query(*foreign_entity_id);
 
             let nested_abstract_select = foreign_table_pk_query
                 .resolve_select(field, request_context, subsystem)
@@ -243,23 +240,21 @@ async fn map_persistent_field<'content>(
         }
         PostgresRelation::OneToMany(relation) => {
             let OneToManyRelation {
-                foreign_field_id,
+                foreign_entity_id,
                 cardinality,
                 ..
             } = relation;
 
-            let foreign_type_id = foreign_field_id.entity_type_id();
-
             let nested_abstract_select = {
                 // Get an appropriate query based on the cardinality of the relation
                 if cardinality == &RelationCardinality::Unbounded {
-                    let collection_query = subsystem.get_collection_query(foreign_type_id);
+                    let collection_query = subsystem.get_collection_query(*foreign_entity_id);
 
                     collection_query
                         .resolve_select(field, request_context, subsystem)
                         .await?
                 } else {
-                    let pk_query = subsystem.get_pk_query(foreign_type_id);
+                    let pk_query = subsystem.get_pk_query(*foreign_entity_id);
 
                     pk_query
                         .resolve_select(field, request_context, subsystem)
@@ -286,17 +281,16 @@ async fn map_aggregate_field<'content>(
 ) -> Result<SelectionElement, PostgresExecutionError> {
     if let Some(PostgresRelation::OneToMany(relation)) = &agg_field.relation {
         let OneToManyRelation {
-            foreign_field_id,
+            foreign_entity_id,
             cardinality,
             relation_id,
         } = relation;
         // TODO: Avoid code duplication with map_persistent_field
-        let foreign_type_id = foreign_field_id.entity_type_id();
 
         let nested_abstract_select = {
             // Aggregate is supported only for unbounded relations (i.e. not supported for one-to-one)
             if cardinality == &RelationCardinality::Unbounded {
-                let aggregate_query = subsystem.get_aggregate_query(foreign_type_id);
+                let aggregate_query = subsystem.get_aggregate_query(*foreign_entity_id);
 
                 aggregate_query
                     .resolve_select(field, request_context, subsystem)

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/update_data_param_mapper.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/update_data_param_mapper.rs
@@ -352,7 +352,11 @@ async fn compute_nested_inserts<'a>(
         .await?;
 
         Ok(NestedAbstractInsert {
-            relation_column_id: nesting_relation.column_pairs[0].foreign_column_id,
+            relation_column_ids: nesting_relation
+                .column_pairs
+                .iter()
+                .map(|pair| pair.foreign_column_id)
+                .collect(),
             insert: AbstractInsert {
                 table_id,
                 rows,

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/update_data_param_mapper.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/update_data_param_mapper.rs
@@ -86,25 +86,22 @@ fn compute_update_columns<'a>(
         .fields
         .iter()
         .flat_map(|field| match &field.relation {
-            PostgresRelation::Pk { column_ids } => {
-                get_argument_field(argument, &field.name).map(|argument_value| {
-                    let column = column_ids[0].get_column(&subsystem.core_subsystem.database);
-                    let value_column = cast::literal_column(argument_value, column);
-                    (column_ids[0], value_column.unwrap())
-                })
-            }
-            PostgresRelation::Scalar { column_id } => get_argument_field(argument, &field.name)
+            PostgresRelation::Scalar { column_id, .. } => get_argument_field(argument, &field.name)
                 .map(|argument_value| {
                     let column = column_id.get_column(&subsystem.core_subsystem.database);
                     let value_column = cast::literal_column(argument_value, column);
                     (*column_id, value_column.unwrap())
                 }),
 
-            PostgresRelation::ManyToOne(ManyToOneRelation {
-                foreign_pk_field_ids,
-                relation_id,
+            PostgresRelation::ManyToOne {
+                relation:
+                    ManyToOneRelation {
+                        foreign_pk_field_ids,
+                        relation_id,
+                        ..
+                    },
                 ..
-            }) => {
+            } => {
                 let ManyToOne { column_pairs, .. } =
                     relation_id.deref(&subsystem.core_subsystem.database);
 

--- a/integration-tests/composite-pk/non-scalar/no-auth/src/index.exo
+++ b/integration-tests/composite-pk/non-scalar/no-auth/src/index.exo
@@ -4,14 +4,11 @@ module ChatModule {
   type Chat {
     @pk id: Int = autoIncrement()
     title: String
-    participants: Set<ChatParticipant>?
+    participants: Set<ChatParticipation>?
   }
 
   @access(true)
-  type ChatParticipant {
-    // @pk id: Int = autoIncrement()
-    // @unique("participant") chat: Chat
-    // @unique("participant") user: User
+  type ChatParticipation {
     @pk chat: Chat
     @pk user: User
   }
@@ -20,6 +17,6 @@ module ChatModule {
   type User {
     @pk id: Int = autoIncrement()
     name: String
-    chats: Set<ChatParticipant>?
+    participatesIn: Set<ChatParticipation>?
   }
 }

--- a/integration-tests/composite-pk/non-scalar/no-auth/src/index.exo
+++ b/integration-tests/composite-pk/non-scalar/no-auth/src/index.exo
@@ -1,0 +1,25 @@
+@postgres
+module ChatModule {
+  @access(true)
+  type Chat {
+    @pk id: Int = autoIncrement()
+    title: String
+    participants: Set<ChatParticipant>?
+  }
+
+  @access(true)
+  type ChatParticipant {
+    // @pk id: Int = autoIncrement()
+    // @unique("participant") chat: Chat
+    // @unique("participant") user: User
+    @pk chat: Chat
+    @pk user: User
+  }
+
+  @access(true)
+  type User {
+    @pk id: Int = autoIncrement()
+    name: String
+    chats: Set<ChatParticipant>?
+  }
+}

--- a/integration-tests/composite-pk/non-scalar/no-auth/src/index.exo
+++ b/integration-tests/composite-pk/non-scalar/no-auth/src/index.exo
@@ -11,6 +11,7 @@ module ChatModule {
   type ChatParticipation {
     @pk chat: Chat
     @pk user: User
+    moods: Set<Mood>?
   }
 
   @access(true)
@@ -18,5 +19,12 @@ module ChatModule {
     @pk id: Int = autoIncrement()
     name: String
     participatesIn: Set<ChatParticipation>?
+  }
+
+  @access(true)
+  type Mood {
+    @pk id: Int = autoIncrement()
+    name: String
+    chatParticipation: ChatParticipation
   }
 }

--- a/integration-tests/composite-pk/non-scalar/no-auth/tests/init.gql
+++ b/integration-tests/composite-pk/non-scalar/no-auth/tests/init.gql
@@ -1,0 +1,36 @@
+stages:
+    - operation: |
+        mutation {
+          u1: createUser(data: { name: "u1" }) {
+            id @bind(name: "u1_id")
+          }
+          u2: createUser(data: { name: "u2" }) {
+              id @bind(name: "u2_id")
+          }
+          u3: createUser(data: { name: "u3" }) {
+              id @bind(name: "u3_id")
+          }
+          u4: createUser(data: { name: "u4" }) {
+              id @bind(name: "u4_id")
+          }
+        }
+    - operation: |
+        mutation($u1_id: Int!, $u2_id: Int!, $u3_id: Int!) {
+            c1: createChat(data: { title: "c1-between-u1-u2", participants: [{ user: { id: $u1_id } }, { user: { id: $u2_id } }] }) {
+                id @bind(name: "c1_id")
+            }
+            c2: createChat(data: { title: "c2-between-u1-u3", participants: [{ user: { id: $u1_id } }, { user: { id: $u3_id } }] }) {
+                id @bind(name: "c2_id")
+            }
+            c3: createChat(data: { title: "c3-between-u1-u2-u3", participants: [{ user: { id: $u1_id } }, { user: { id: $u2_id } }, { user: { id: $u3_id } }] }) {
+                id @bind(name: "c3_id")
+            }
+        }
+      variable: |
+        {
+            "u1_id": $.u1_id,
+            "u2_id": $.u2_id,
+            "u3_id": $.u3_id,
+            "u4_id": $.u4_id
+        }
+

--- a/integration-tests/composite-pk/non-scalar/no-auth/tests/mutation/add-chat-participant.exotest
+++ b/integration-tests/composite-pk/non-scalar/no-auth/tests/mutation/add-chat-participant.exotest
@@ -1,0 +1,118 @@
+stages:
+  - operation: |
+      # Add u4 to c1 (c1 already has u1 and u2)
+      mutation($u4_id: Int!, $c1_id: Int!) {
+        createChatParticipation(data: {user: { id: $u4_id }, chat: { id: $c1_id }}) {
+          user {
+            id
+          }
+          chat {
+            id
+          }
+        }
+      }
+    variable: |
+      {
+        "u4_id": $.u4_id,
+        "c1_id": $.c1_id
+      }
+    response: |
+      {
+        "data": {
+          "createChatParticipation": {
+            "user": {
+              "id": 4
+            },
+            "chat": {
+              "id": 1
+            }
+          }
+        }
+      }
+  - operation: |
+      query {
+        chats @unordered {
+          id
+          title
+          participants @unordered {
+            user {
+              id
+              name
+            }
+          }
+        }
+      }
+    response: |
+      {
+        "data": {
+          "chats": [
+            {
+              "id": $.c1_id,
+              "title": "c1-between-u1-u2",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u2_id,
+                    "name": "u2"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u4_id,
+                    "name": "u4"
+                  }
+                }
+              ]
+            },
+            {
+              "id": $.c2_id,
+              "title": "c2-between-u1-u3",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u3_id,
+                    "name": "u3"
+                  }
+                }
+              ]
+            },
+            {
+              "id": $.c3_id,
+              "title": "c3-between-u1-u2-u3",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u2_id,
+                    "name": "u2"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u3_id,
+                    "name": "u3"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+

--- a/integration-tests/composite-pk/non-scalar/no-auth/tests/mutation/add-chat-participants.exotest
+++ b/integration-tests/composite-pk/non-scalar/no-auth/tests/mutation/add-chat-participants.exotest
@@ -1,0 +1,153 @@
+stages:
+  - operation: |
+      # Add u4 to c1 all chats
+      mutation($u4_id: Int!, $c1_id: Int!, $c2_id: Int!, $c3_id: Int!) {
+        createChatParticipations(data: [
+          {user: { id: $u4_id }, chat: { id: $c1_id }}, 
+          {user: { id: $u4_id }, chat: { id: $c2_id }}, 
+          {user: { id: $u4_id }, chat: { id: $c3_id }}]) @unordered{
+          user {
+            id
+          }
+          chat {
+            id
+          }
+        }
+      }
+    variable: |
+      {
+        "u4_id": $.u4_id,
+        "c1_id": $.c1_id,
+        "c2_id": $.c2_id,
+        "c3_id": $.c3_id
+      }
+    response: |
+      {
+        "data": {
+          "createChatParticipations": [
+            {
+              "user": {
+                "id": $.u4_id
+              },
+              "chat": {
+                "id": $.c1_id
+              }
+            },
+            {
+              "user": {
+                "id": $.u4_id
+              },
+              "chat": {
+                "id": $.c2_id
+              }
+            },
+            {
+              "user": {
+                "id": $.u4_id
+              },
+              "chat": {
+                "id": $.c3_id
+              }
+            }
+          ]
+        }
+      }
+
+  - operation: |
+      query {
+        chats @unordered {
+          id
+          title
+          participants @unordered {
+            user {
+              id
+              name
+            }
+          }
+        }
+      }
+    response: |
+      {
+        "data": {
+          "chats": [
+            {
+              "id": $.c1_id,
+              "title": "c1-between-u1-u2",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u2_id,
+                    "name": "u2"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u4_id,
+                    "name": "u4"
+                  }
+                }
+              ]
+            },
+            {
+              "id": $.c2_id,
+              "title": "c2-between-u1-u3",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u3_id,
+                    "name": "u3"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u4_id,
+                    "name": "u4"
+                  }
+                }
+              ]
+            },
+            {
+              "id": $.c3_id,
+              "title": "c3-between-u1-u2-u3",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u2_id,
+                    "name": "u2"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u3_id,
+                    "name": "u3"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u4_id,
+                    "name": "u4"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }

--- a/integration-tests/composite-pk/non-scalar/no-auth/tests/mutation/delete-chat-participant.exotest
+++ b/integration-tests/composite-pk/non-scalar/no-auth/tests/mutation/delete-chat-participant.exotest
@@ -1,0 +1,104 @@
+stages:
+  - operation: |
+      mutation($u1_id: Int!, $c1_id: Int!) {
+        deleteChatParticipation(user: { id: $u1_id }, chat: { id: $c1_id }) {
+          user {
+            id
+          }
+          chat {
+            id
+          }
+        }
+      }
+    variable: |
+      {
+        "u1_id": $.u1_id,
+        "c1_id": $.c1_id
+      }
+    response: |
+      {
+        "data": {
+          "deleteChatParticipation": {
+            "user": {
+                "id": $.u1_id
+              },
+              "chat": {
+                "id": $.c1_id
+            }
+          }
+        }
+      }
+  - operation: |
+      query {
+        chats @unordered {
+          id
+          title
+          participants @unordered {
+            user {
+              id
+              name
+            }
+          }
+        }
+      }
+    response: |
+      {
+        "data": {
+          "chats": [
+            {
+              "id": $.c1_id,
+              "title": "c1-between-u1-u2",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u2_id,
+                    "name": "u2"
+                  }
+                }
+              ]
+            },
+            {
+              "id": $.c2_id,
+              "title": "c2-between-u1-u3",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u3_id,
+                    "name": "u3"
+                  }
+                }
+              ]
+            },
+            {
+              "id": $.c3_id,
+              "title": "c3-between-u1-u2-u3",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u2_id,
+                    "name": "u2"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u3_id,
+                    "name": "u3"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }

--- a/integration-tests/composite-pk/non-scalar/no-auth/tests/mutation/delete-chat-participants.exotest
+++ b/integration-tests/composite-pk/non-scalar/no-auth/tests/mutation/delete-chat-participants.exotest
@@ -1,0 +1,110 @@
+stages:
+  - operation: |
+      mutation($u1_id: Int!) {
+        # Delete all chat participations for user u1 (user u1 leaves the organization, for example)
+        deleteChatParticipations(where: { user: { id: { eq: $u1_id } } }) @unordered {
+          user {
+            id
+          }
+          chat {
+            id
+          }
+        }
+      }
+    variable: |
+      {
+        "u1_id": $.u1_id
+      }
+    response: |
+      {
+        "data": {
+          "deleteChatParticipations": [
+            {
+              "user": {
+                "id": $.u1_id
+              },
+              "chat": {
+                "id": $.c1_id
+              }
+            },
+            {
+              "user": {
+                "id": $.u1_id
+              },
+              "chat": {
+                "id": $.c2_id
+              }
+            },
+            {
+              "user": {
+                "id": $.u1_id
+              },
+              "chat": {
+                "id": $.c3_id
+              }
+            }
+          ]
+        }
+      }
+  - operation: |
+      query {
+        chats @unordered {
+          id
+          title
+          participants @unordered {
+            user {
+              id
+              name
+            }
+          }
+        }
+      }
+    response: |
+      {
+        "data": {
+          "chats": [
+            {
+              "id": $.c1_id,
+              "title": "c1-between-u1-u2",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u2_id,
+                    "name": "u2"
+                  }
+                }
+              ]
+            },
+            {
+              "id": $.c2_id,
+              "title": "c2-between-u1-u3",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u3_id,
+                    "name": "u3"
+                  }
+                }
+              ]
+            },
+            {
+              "id": $.c3_id,
+              "title": "c3-between-u1-u2-u3",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u2_id,
+                    "name": "u2"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u3_id,
+                    "name": "u3"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }

--- a/integration-tests/composite-pk/non-scalar/no-auth/tests/mutation/update-chat-nested.exotest
+++ b/integration-tests/composite-pk/non-scalar/no-auth/tests/mutation/update-chat-nested.exotest
@@ -1,0 +1,155 @@
+stages:
+  - operation: |
+      mutation($u1_id: Int!, $u4_id: Int!, $c1_id: Int!) {
+        # add user 4 to chat 1
+        updateChat(id: $c1_id, data: { title: "updated", participants: { create: { user: { id: $u4_id } } } }) {
+          id
+          title
+          participants @unordered {
+            user {
+              id
+              name
+            }
+            chat {
+              id
+              title
+            }
+          }
+        }
+      }
+    variable: |
+      {
+        "u1_id": $.u1_id,
+        "u4_id": $.u4_id,
+        "c1_id": $.c1_id
+      }
+    response: |
+      {
+        "data": {
+          "updateChat": {
+            "id": $.c1_id,
+            "title": "updated",
+            "participants": [
+              {
+                "user": {
+                  "id": $.u1_id,
+                  "name": "u1"
+                },
+                "chat": {
+                  "id": $.c1_id,
+                  "title": "updated"
+                }
+              },
+              {
+                "user": {
+                  "id": $.u2_id,
+                  "name": "u2"
+                },
+                "chat": {
+                  "id": $.c1_id,
+                  "title": "updated"
+                }
+              },
+              {
+                "user": {
+                  "id": $.u4_id,
+                  "name": "u4"
+                },
+                "chat": {
+                  "id": $.c1_id,
+                  "title": "updated"
+                }
+              }
+            ]
+          }
+        }
+      }
+
+
+
+  - operation: |
+      query {
+        chats @unordered {
+          id
+          title
+          participants @unordered {
+            user {
+              id
+              name
+            }
+          }
+        }
+      }
+    response: |
+      {
+        "data": {
+          "chats": [
+            {
+              "id": $.c2_id,
+              "title": "c2-between-u1-u3",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u3_id,
+                    "name": "u3"
+                  }
+                }
+              ]
+            },
+            {
+              "id": $.c3_id,
+              "title": "c3-between-u1-u2-u3",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u2_id,
+                    "name": "u2"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u3_id,
+                    "name": "u3"
+                  }
+                }
+              ]
+            },
+            {
+              "id": $.c1_id,
+              "title": "updated",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u2_id,
+                    "name": "u2"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u4_id,
+                    "name": "u4"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }

--- a/integration-tests/composite-pk/non-scalar/no-auth/tests/mutation/update-chat-participant-nested.exotest
+++ b/integration-tests/composite-pk/non-scalar/no-auth/tests/mutation/update-chat-participant-nested.exotest
@@ -1,0 +1,138 @@
+stages:
+  - operation: |
+      mutation($u1_id: Int!, $c2_id: Int!) {
+        # Add a mood participation to user 1's chat 2
+        updateChatParticipation(user: { id: $u1_id }, chat: { id: $c2_id }, data: { moods: { create: { name: "happy" } } }) {
+          user {
+            id
+          }
+          chat {
+            id
+          }
+          moods @unordered @bind(name: "moods") {
+            id
+            name
+          }
+        }
+      }
+    variable: |
+      {
+        "u1_id": $.u1_id,
+        "c2_id": $.c2_id
+      }
+    response: |
+      {
+        "data": {
+          "updateChatParticipation": {
+            "user": {
+              "id": $.u1_id
+            },
+            "chat": {
+              "id": $.c2_id
+            },
+            "moods": [
+              {
+                "id": $.moods[0].id,
+                "name": "happy"
+              }
+            ]
+          }
+        }
+      }
+
+  - operation: |
+      query {
+        chats @unordered {
+          id
+          title
+          participants @unordered {
+            user {
+              id
+              name
+            }
+            moods @unordered {
+              id
+              name
+            }
+          }
+        }
+      }
+    response: |
+      {
+        "data": {
+          "chats": [
+            {
+              "id": $.c1_id,
+              "title": "c1-between-u1-u2",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  },
+                  "moods": []
+                },
+                {
+                  "user": {
+                    "id": $.u2_id,
+                    "name": "u2"
+                  },
+                  "moods": []
+                }
+              ]
+            },
+            {
+              "id": $.c2_id,
+              "title": "c2-between-u1-u3",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  },
+                  "moods": [
+                    {
+                      "id": $.moods[0].id,
+                      "name": "happy"
+                    }
+                  ]
+                },
+                {
+                  "user": {
+                    "id": $.u3_id,
+                    "name": "u3"
+                  },
+                  "moods": []
+                }
+              ]
+            },
+            {
+              "id": $.c3_id,
+              "title": "c3-between-u1-u2-u3",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  },
+                  "moods": []
+                },
+                {
+                  "user": {
+                    "id": $.u2_id,
+                    "name": "u2"
+                  },
+                  "moods": []
+                },
+                {
+                  "user": {
+                    "id": $.u3_id,
+                    "name": "u3"
+                  },
+                  "moods": []
+                }
+              ]
+            }
+          ]
+        }
+      }

--- a/integration-tests/composite-pk/non-scalar/no-auth/tests/mutation/update-chat-participant.exotest
+++ b/integration-tests/composite-pk/non-scalar/no-auth/tests/mutation/update-chat-participant.exotest
@@ -1,0 +1,112 @@
+stages:
+  - operation: |
+      mutation($u1_id: Int!, $u4_id: Int!, $c1_id: Int!) {
+        # Substitute user 1 with user 4
+        updateChatParticipation(user: { id: $u1_id }, chat: { id: $c1_id }, data: { user: { id: $u4_id } }) {
+          user {
+            id
+          }
+          chat {
+            id
+          }
+        }
+      }
+    variable: |
+      {
+        "u1_id": $.u1_id,
+        "u4_id": $.u4_id,
+        "c1_id": $.c1_id
+      }
+    response: |
+      {
+        "data": {
+          "updateChatParticipation": {
+            "user": {
+              "id": 4
+            },
+            "chat": {
+              "id": 1
+            }
+          }
+        }
+      }
+  - operation: |
+      query {
+        chats @unordered {
+          id
+          title
+          participants @unordered {
+            user {
+              id
+              name
+            }
+          }
+        }
+      }
+    response: |
+      {
+        "data": {
+          "chats": [
+            {
+              "id": $.c1_id,
+              "title": "c1-between-u1-u2",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u2_id,
+                    "name": "u2"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u4_id,
+                    "name": "u4"
+                  }
+                }
+              ]
+            },
+            {
+              "id": $.c2_id,
+              "title": "c2-between-u1-u3",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u3_id,
+                    "name": "u3"
+                  }
+                }
+              ]
+            },
+            {
+              "id": $.c3_id,
+              "title": "c3-between-u1-u2-u3",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u2_id,
+                    "name": "u2"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u3_id,
+                    "name": "u3"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }

--- a/integration-tests/composite-pk/non-scalar/no-auth/tests/mutation/update-chat-participants.exotest
+++ b/integration-tests/composite-pk/non-scalar/no-auth/tests/mutation/update-chat-participants.exotest
@@ -1,0 +1,122 @@
+stages:
+  - operation: |
+      mutation($u2_id: Int!, $u4_id: Int!) {
+        # Substitute user 2 with user 4 in all chats
+        updateChatParticipations(where: { user: { id: {eq: $u2_id } } }, data: { user: { id: $u4_id } }) {
+          user {
+            id
+          }
+          chat {
+            id
+          }
+        }
+      }
+    variable: |
+      {
+        "u2_id": $.u2_id,
+        "u4_id": $.u4_id
+      }
+    response: |
+      {
+        "data": {
+          "updateChatParticipations": [
+            {
+              "user": {
+                "id": $.u4_id
+              },
+              "chat": {
+                "id": $.c1_id
+              }
+            },
+            {
+              "user": {
+                "id": $.u4_id
+              },
+              "chat": {
+                "id": $.c3_id
+              }
+            }
+          ]
+        }
+      }
+
+  - operation: |
+      query {
+        chats @unordered {
+          id
+          title
+          participants @unordered {
+            user {
+              id
+              name
+            }
+          }
+        }
+      }
+    response: |
+      {
+        "data": {
+          "chats": [
+            {
+              "id": $.c1_id,
+              "title": "c1-between-u1-u2",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u4_id,
+                    "name": "u4"
+                  }
+                }
+              ]
+            },
+            {
+              "id": $.c2_id,
+              "title": "c2-between-u1-u3",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u3_id,
+                    "name": "u3"
+                  }
+                }
+              ]
+            },
+            {
+              "id": $.c3_id,
+              "title": "c3-between-u1-u2-u3",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u3_id,
+                    "name": "u3"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u4_id,
+                    "name": "u4"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }

--- a/integration-tests/composite-pk/non-scalar/no-auth/tests/mutation/update-chats-nested.exotest
+++ b/integration-tests/composite-pk/non-scalar/no-auth/tests/mutation/update-chats-nested.exotest
@@ -1,0 +1,209 @@
+stages:
+  - operation: |
+      mutation( $u4_id: Int!) {
+        # Add user 4 to all chats that user 2 is in (and update the title)
+        updateChats(
+          where: { participants: { user: { name: {eq: "u2" } } } }, 
+          data: { title: "u2-and-u4-are-here (others may be, too)", participants: { create: { user: { id: $u4_id } } } }
+        ) {
+          id
+          title
+          participants @unordered {
+            user {
+              id
+              name
+            }
+            chat {
+              id
+              title
+            }
+          }
+        }
+      }
+    variable: |
+      {
+        "u4_id": $.u4_id
+      }
+    response: |
+      {
+        "data": {
+          "updateChats": [
+            {
+              "id": $.c1_id,
+              "title": "u2-and-u4-are-here (others may be, too)",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  },
+                  "chat": {
+                    "id": $.c1_id,
+                    "title": "u2-and-u4-are-here (others may be, too)"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u2_id,
+                    "name": "u2"
+                  },
+                  "chat": {
+                    "id": $.c1_id,
+                    "title": "u2-and-u4-are-here (others may be, too)"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u4_id,
+                    "name": "u4"
+                  },
+                  "chat": {
+                    "id": 1,
+                    "title": "u2-and-u4-are-here (others may be, too)"
+                  }
+                }
+              ]
+            },
+            {
+              "id": $.c3_id,
+              "title": "u2-and-u4-are-here (others may be, too)",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  },
+                  "chat": {
+                    "id": $.c3_id,
+                    "title": "u2-and-u4-are-here (others may be, too)"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u2_id,
+                    "name": "u2"
+                  },
+                  "chat": {
+                    "id": $.c3_id,
+                    "title": "u2-and-u4-are-here (others may be, too)"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u3_id,
+                    "name": "u3"
+                  },
+                  "chat": {
+                    "id": $.c3_id,
+                    "title": "u2-and-u4-are-here (others may be, too)"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u4_id,
+                    "name": "u4"
+                  },
+                  "chat": {
+                    "id": $.c3_id,
+                    "title": "u2-and-u4-are-here (others may be, too)"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+
+
+  - operation: |
+      query {
+        chats @unordered {
+          id
+          title
+          participants @unordered {
+            user {
+              id
+              name
+            }
+          }
+        }
+      }
+    response: |
+      {
+        "data": {
+          "chats": [
+            {
+              "id": $.c2_id,
+              "title": "c2-between-u1-u3",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u3_id,
+                    "name": "u3"
+                  }
+                }
+              ]
+            },
+            {
+              "id": $.c1_id,
+              "title": "u2-and-u4-are-here (others may be, too)",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u2_id,
+                    "name": "u2"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u4_id,
+                    "name": "u4"
+                  }
+                }
+              ]
+            },
+            {
+              "id": $.c3_id,
+              "title": "u2-and-u4-are-here (others may be, too)",
+              "participants": [
+                {
+                  "user": {
+                    "id": $.u1_id,
+                    "name": "u1"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u2_id,
+                    "name": "u2"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u3_id,
+                    "name": "u3"
+                  }
+                },
+                {
+                  "user": {
+                    "id": $.u4_id,
+                    "name": "u4"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }

--- a/integration-tests/composite-pk/non-scalar/no-auth/tests/query/chats.exotest
+++ b/integration-tests/composite-pk/non-scalar/no-auth/tests/query/chats.exotest
@@ -1,0 +1,112 @@
+operation: |
+  query {
+      chats @unordered {
+          id
+          title
+          participants @unordered {
+              user {
+                  id
+                  name
+              }
+              chat {
+                  id
+                  title
+              }
+          }
+      }
+  }
+response: |
+  {
+    "data": {
+      "chats": [
+        {
+          "id": $.c1_id,
+          "title": "c1-between-u1-u2",
+          "participants": [
+            {
+              "user": {
+                "id": $.u1_id,
+                "name": "u1"
+              },
+              "chat": {
+                "id": $.c1_id,
+                "title": "c1-between-u1-u2"
+              }
+            },
+            {
+              "user": {
+                "id": $.u2_id,
+                "name": "u2"
+              },
+              "chat": {
+                "id": $.c1_id,
+                "title": "c1-between-u1-u2"
+              }
+            }
+          ]
+        },
+        {
+          "id": $.c2_id,
+          "title": "c2-between-u1-u3",
+          "participants": [
+            {
+              "user": {
+                "id": $.u1_id,
+                "name": "u1"
+              },
+              "chat": {
+                "id": $.c2_id,
+                "title": "c2-between-u1-u3"
+              }
+            },
+            {
+              "user": {
+                "id": $.u3_id,
+                "name": "u3"
+              },
+              "chat": {
+                "id": $.c2_id,
+                "title": "c2-between-u1-u3"
+              }
+            }
+          ]
+        },
+        {
+          "id": $.c3_id,
+          "title": "c3-between-u1-u2-u3",
+          "participants": [
+            {
+              "user": {
+                "id": $.u1_id,
+                "name": "u1"
+              },
+              "chat": {
+                "id": $.c3_id,
+                "title": "c3-between-u1-u2-u3"
+              }
+            },
+            {
+              "user": {
+                "id": $.u2_id,
+                "name": "u2"
+              },
+              "chat": {
+                "id": $.c3_id,
+                "title": "c3-between-u1-u2-u3"
+              }
+            },
+            {
+              "user": {
+                "id": $.u3_id,
+                "name": "u3"
+              },
+              "chat": {
+                "id": $.c3_id,
+                "title": "c3-between-u1-u2-u3"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }

--- a/integration-tests/composite-pk/non-scalar/no-auth/tests/query/participant.exotest
+++ b/integration-tests/composite-pk/non-scalar/no-auth/tests/query/participant.exotest
@@ -1,0 +1,33 @@
+operation: |
+  query($chat_id: Int!, $user_id: Int!) {
+      chatParticipation(chat: {id: $chat_id}, user: {id: $user_id}) {
+          user {
+              id
+              name
+          }
+          chat {
+              id
+              title
+          }
+      }
+  }
+variable: |
+  {
+    "chat_id": $.c1_id,
+    "user_id": $.u1_id
+  }
+response: |
+  {
+    "data": {
+      "chatParticipation": {
+        "user": {
+          "id": 1,
+          "name": "u1"
+        },
+        "chat": {
+          "id": 1,
+          "title": "c1-between-u1-u2"
+        }
+      }
+    }
+  }

--- a/integration-tests/composite-pk/non-scalar/no-auth/tests/query/participants.exotest
+++ b/integration-tests/composite-pk/non-scalar/no-auth/tests/query/participants.exotest
@@ -1,0 +1,90 @@
+operation: |
+  query {
+      chatParticipations @unordered {
+          user {
+              id
+              name
+          }
+          chat {
+              id
+              title
+          }
+      }
+  }
+response: |
+  {
+    "data": {
+      "chatParticipations": [
+        {
+          "user": {
+            "id": $.u1_id,
+            "name": "u1"
+          },
+          "chat": {
+            "id": $.c1_id,
+            "title": "c1-between-u1-u2"
+          }
+        },
+        {
+          "user": {
+            "id": $.u2_id,
+            "name": "u2"
+          },
+          "chat": {
+            "id": $.c1_id,
+            "title": "c1-between-u1-u2"
+          }
+        },
+        {
+          "user": {
+            "id": $.u1_id,
+            "name": "u1"
+          },
+          "chat": {
+            "id": $.c2_id,
+            "title": "c2-between-u1-u3"
+          }
+        },
+        {
+          "user": {
+            "id": $.u3_id,
+            "name": "u3"
+          },
+          "chat": {
+            "id": $.c2_id,
+            "title": "c2-between-u1-u3"
+          }
+        },
+        {
+          "user": {
+            "id": $.u1_id,
+            "name": "u1"
+          },
+          "chat": {
+            "id": $.c3_id,
+            "title": "c3-between-u1-u2-u3"
+          }
+        },
+        {
+          "user": {
+            "id": $.u2_id,
+            "name": "u2"
+          },
+          "chat": {
+            "id": $.c3_id,
+            "title": "c3-between-u1-u2-u3"
+          }
+        },
+        {
+          "user": {
+            "id": $.u3_id,
+            "name": "u3"
+          },
+          "chat": {
+            "id": $.c3_id,
+            "title": "c3-between-u1-u2-u3"
+          }
+        }
+      ]
+    }
+  }

--- a/integration-tests/composite-pk/non-scalar/no-auth/tests/query/users.exotest
+++ b/integration-tests/composite-pk/non-scalar/no-auth/tests/query/users.exotest
@@ -1,0 +1,85 @@
+operation: |
+  query {
+      users @unordered {
+          id
+          name
+          participatesIn @unordered {
+              chat {
+                  id
+                  title
+              }
+          }
+      }
+  }
+response: |
+  {
+    "data": {
+      "users": [
+        {
+          "id": $.u1_id,
+          "name": "u1",
+          "participatesIn": [
+            {
+              "chat": {
+                "id": $.c1_id,
+                "title": "c1-between-u1-u2"
+              }
+            },
+            {
+              "chat": {
+                "id": $.c2_id,
+                "title": "c2-between-u1-u3"
+              }
+            },
+            {
+              "chat": {
+                "id": $.c3_id,
+                "title": "c3-between-u1-u2-u3"
+              }
+            }
+          ]
+        },
+        {
+          "id": $.u2_id,
+          "name": "u2",
+          "participatesIn": [
+            {
+              "chat": {
+                "id": $.c1_id,
+                "title": "c1-between-u1-u2"
+              }
+            },
+            {
+              "chat": {
+                "id": $.c3_id,
+                "title": "c3-between-u1-u2-u3"
+              }
+            }
+          ]
+        },
+        {
+          "id": $.u3_id,
+          "name": "u3",
+          "participatesIn": [
+            {
+              "chat": {
+                "id": $.c2_id,
+                "title": "c2-between-u1-u3"
+              }
+            },
+            {
+              "chat": {
+                "id": $.c3_id,
+                "title": "c3-between-u1-u2-u3"
+              }
+            }
+          ]
+        },
+        {
+          "id": $.u4_id,
+          "name": "u4",
+          "participatesIn": []
+        }
+      ]
+    }
+  }

--- a/integration-tests/composite-pk/non-scalar/one-to-one/src/index.exo
+++ b/integration-tests/composite-pk/non-scalar/one-to-one/src/index.exo
@@ -1,13 +1,20 @@
+context AuthContext {
+  @jwt orgId: Int
+  @jwt email: String
+  @jwt role: String
+}
+
 @postgres
 module UserModule {
-  @access(true)
+  @access(AuthContext.role == "admin" || (AuthContext.orgId == self.orgId && AuthContext.email == self.email))
   type User {
     @pk orgId: Int
     @pk email: String
+    phone: String?
     profile: Profile?
   }
 
-  @access(true)
+  @access(AuthContext.role == "admin" || (AuthContext.orgId == self.user.orgId && AuthContext.email == self.user.email))
   type Profile {
     @pk user: User
     name: String

--- a/integration-tests/composite-pk/non-scalar/one-to-one/src/index.exo
+++ b/integration-tests/composite-pk/non-scalar/one-to-one/src/index.exo
@@ -1,0 +1,15 @@
+@postgres
+module UserModule {
+  @access(true)
+  type User {
+    @pk orgId: Int
+    @pk email: String
+    profile: Profile?
+  }
+
+  @access(true)
+  type Profile {
+    @pk user: User
+    name: String
+  }
+}

--- a/integration-tests/composite-pk/non-scalar/one-to-one/tests/init.gql
+++ b/integration-tests/composite-pk/non-scalar/one-to-one/tests/init.gql
@@ -37,3 +37,7 @@ operation: |
             }
         }
     }  
+auth: |
+    {
+        role: "admin"
+    }

--- a/integration-tests/composite-pk/non-scalar/one-to-one/tests/init.gql
+++ b/integration-tests/composite-pk/non-scalar/one-to-one/tests/init.gql
@@ -1,0 +1,39 @@
+operation: |
+    mutation {
+        user1: createUser(data: {
+            orgId: 1,
+            email: "user1@example.com",
+            profile: {
+                name: "User 1"
+            }
+        }) {
+            orgId
+            email
+            profile {
+                name
+            }
+        }
+        user2: createUser(data: {
+            orgId: 2,
+            email: "user2@example.com",
+            profile: {
+                name: "User 2"
+            }
+        }) {
+            orgId
+            email
+            profile {
+                name
+            }
+        }
+        user3: createUser(data: {
+            orgId: 3,
+            email: "user3@example.com",
+        }) {
+            orgId
+            email
+            profile {
+                name
+            }
+        }
+    }  

--- a/integration-tests/composite-pk/non-scalar/one-to-one/tests/mutation/create-profile-user.exotest
+++ b/integration-tests/composite-pk/non-scalar/one-to-one/tests/mutation/create-profile-user.exotest
@@ -1,0 +1,80 @@
+stages:
+    - operation: |
+        mutation {
+            createProfile(data: {user: {orgId: 3, email: "user3@example.com"}, name: "User Profile 3"}) {
+                user {
+                    orgId
+                    email
+                }
+                name
+            }
+        }
+      auth: |
+        {
+            "orgId": 3,
+            "email": "user3@example.com"
+        }        
+      response: |
+        {
+          "data": {
+            "createProfile": {
+              "user": {
+                "orgId": 3,
+                "email": "user3@example.com"
+              },
+              "name": "User Profile 3"
+            }
+          }
+        }
+
+
+    # User is trying to create a duplicate profile
+    - operation: |
+        mutation {
+            createProfile(data: {user: {orgId: 3, email: "user3@example.com"}, name: "User Profile 3-duplicate"}) {
+                user {
+                    orgId
+                    email
+                }
+                name
+            }
+        }
+      auth: |
+        {
+            "orgId": 3,
+            "email": "user3@example.com"
+        }  
+      response: |
+        {
+          "errors": [
+            {
+              "message": "Operation failed"
+            }
+          ]
+        }
+      
+
+    # Creating a profile for a different user
+    - operation: |
+        mutation {
+            createProfile(data: {user: {orgId: 2, email: "user2@example.com"}, name: "User Profile 2"}) {
+                user {
+                    orgId
+                    email
+                }
+                name
+            }
+        }
+      auth: |
+        {
+            "orgId": 1,
+            "email": "user1@example.com"
+        }
+      response: |
+        {
+          "errors": [
+            {
+              "message": "Not authorized"
+            }
+          ]
+        }

--- a/integration-tests/composite-pk/non-scalar/one-to-one/tests/mutation/create-user-user.exotest
+++ b/integration-tests/composite-pk/non-scalar/one-to-one/tests/mutation/create-user-user.exotest
@@ -1,0 +1,78 @@
+stages:
+    - operation: |
+        mutation {
+            createUser(data: {orgId: 1, email: "user11@example.com", phone: "1234567890", profile: {name: "User 11"}}) {
+                orgId
+                email
+                profile {
+                    name
+                }
+            }
+        }
+      response: |
+          {
+            "data": {
+              "createUser": {
+                "orgId": 1,
+                "email": "user11@example.com",
+                "profile": {
+                  "name": "User 11"
+                }
+              }
+            }
+          }
+      auth: |
+        {
+            "orgId": 1,
+            "email": "user11@example.com"
+        }
+
+    # User is trying to create a user with a different email
+    - operation: |
+        mutation {
+            createUser(data: {orgId: 1, email: "user11@example.com", phone: "1234567890", profile: {name: "User 11"}}) {
+                orgId
+                email
+                profile {
+                    name
+                }
+            }
+        }
+      response: |
+        {
+          "errors": [
+            {
+              "message": "Not authorized"
+            }
+          ]
+        }
+      auth: |
+        {
+            "orgId": 1,
+            "email": "user1@example.com"
+        }
+      
+    # User is trying to create a user with a different orgId
+    - operation: |
+        mutation {
+            createUser(data: {orgId: 1, email: "user11@example.com", phone: "1234567890", profile: {name: "User 11"}}) {
+                orgId
+                email
+                profile {
+                    name
+                }
+            }
+        }
+      response: |
+        {
+          "errors": [
+            {
+              "message": "Not authorized"
+            }
+          ]
+        }
+      auth: |
+        {
+            "orgId": 2,
+            "email": "user11@example.com"
+        }              

--- a/integration-tests/composite-pk/non-scalar/one-to-one/tests/mutation/delete-profile-user.exotest
+++ b/integration-tests/composite-pk/non-scalar/one-to-one/tests/mutation/delete-profile-user.exotest
@@ -1,0 +1,74 @@
+stages:
+    - operation: |
+        mutation {
+            deleteProfile(user: {orgId: 1, email: "user1@example.com"}) {
+                user {
+                    orgId
+                    email
+                }
+                name
+            }
+        }
+      auth: |
+        {
+            "orgId": 1,
+            "email": "user1@example.com"
+        }        
+      response: |
+        {
+          "data": {
+            "deleteProfile": {
+              "user": {
+                "orgId": 1,
+                "email": "user1@example.com"
+              },
+              "name": "User 1"
+            }
+          }
+        }
+
+    # Deleting non-existent profile should be allowed
+    - operation: |
+        mutation {
+            deleteProfile(user: {orgId: 3, email: "user3@example.com"}) {
+                user {
+                    orgId
+                    email
+                }
+                name
+            }
+        }
+      auth: |
+        {
+            "orgId": 3,
+            "email": "user3@example.com"
+        }        
+      response: |
+        {
+          "data": {
+            "deleteProfile": null
+          }
+        }
+
+    # Deleting profile for a different user should be forbidden
+    - operation: |
+        mutation {
+            deleteProfile(user: {orgId: 1, email: "user1@example.com"}) {
+                user {
+                    orgId
+                    email
+                }
+                name
+            }
+        }
+      auth: |
+        {
+            "orgId": 2,
+            "email": "user2@example.com"
+        }        
+      response: |
+        {
+          "data": {
+            "deleteProfile": null
+          }
+        }

--- a/integration-tests/composite-pk/non-scalar/one-to-one/tests/mutation/delete-user-user.exotest
+++ b/integration-tests/composite-pk/non-scalar/one-to-one/tests/mutation/delete-user-user.exotest
@@ -1,0 +1,86 @@
+stages:
+    - operation: |
+        mutation {
+            deleteProfile(user: {orgId: 1, email: "user1@example.com"}) {
+              name
+            }
+            deleteUser(orgId: 1, email: "user1@example.com") {
+                orgId
+                email
+                profile {
+                    name
+                }
+            }
+        }
+      response: |
+        {
+          "data": {
+            "deleteProfile": {
+              "name": "User 1"
+            },
+            "deleteUser": {
+              "orgId": 1,
+              "email": "user1@example.com",
+              "profile": null
+            }
+          }
+        }
+      auth: |
+        {
+            "orgId": 1,
+            "email": "user1@example.com"
+        }
+
+    # User is trying to delete a user with a different email
+    - operation: |
+        mutation {
+            deleteProfile(user: {orgId: 1, email: "user1@example.com"}) {
+              name
+            }
+            deleteUser(orgId: 1, email: "user1@example.com") {
+                orgId
+                email
+                profile {
+                    name
+                }
+            }
+        }
+      response: |
+        {
+          "data": {
+            "deleteProfile": null,
+            "deleteUser": null
+          }
+        }
+      auth: |
+        {
+            "orgId": 1,
+            "email": "user2@example.com"
+        }
+      
+    # User is trying to delete a user with a different orgId
+    - operation: |
+        mutation {
+            deleteProfile(user: {orgId: 1, email: "user1@example.com"}) {
+              name
+            }
+            deleteUser(orgId: 1, email: "user1@example.com") {
+                orgId
+                email
+                profile {
+                    name
+                }
+            }
+        }
+      response: |
+        {
+          "data": {
+            "deleteProfile": null,
+            "deleteUser": null
+          }
+        }
+      auth: |
+        {
+            "orgId": 2,
+            "email": "user1@example.com"
+        }              

--- a/integration-tests/composite-pk/non-scalar/one-to-one/tests/mutation/update-profile-user.exotest
+++ b/integration-tests/composite-pk/non-scalar/one-to-one/tests/mutation/update-profile-user.exotest
@@ -1,0 +1,74 @@
+stages:
+    - operation: |
+        mutation {
+            updateProfile(user: {orgId: 1, email: "user1@example.com"}, data: {name: "User 1 Updated"}) {
+                user {
+                    orgId
+                    email
+                }
+                name
+            }
+        }
+      auth: |
+        {
+            "orgId": 1,
+            "email": "user1@example.com"
+        }        
+      response: |
+        {
+          "data": {
+            "updateProfile": {
+              "user": {
+                "orgId": 1,
+                "email": "user1@example.com"
+              },
+              "name": "User 1 Updated"
+            }
+          }
+        }
+
+    # Deleting non-existent profile should be allowed
+    - operation: |
+        mutation {
+            updateProfile(user: {orgId: 3, email: "user3@example.com"}, data: {name: "User 3 Updated"}) {
+                user {
+                    orgId
+                    email
+                }
+                name
+            }
+        }
+      auth: |
+        {
+            "orgId": 3,
+            "email": "user3@example.com"
+        }        
+      response: |
+        {
+          "data": {
+            "updateProfile": null
+          }
+        }
+
+    # Deleting profile for a different user should be forbidden
+    - operation: |
+        mutation {
+            updateProfile(user: {orgId: 1, email: "user1@example.com"}, data: {name: "User 1 Updated"}) {
+                user {
+                    orgId
+                    email
+                }
+                name
+            }
+        }
+      auth: |
+        {
+            "orgId": 2,
+            "email": "user2@example.com"
+        }        
+      response: |
+        {
+          "data": {
+            "updateProfile": null
+          }
+        }

--- a/integration-tests/composite-pk/non-scalar/one-to-one/tests/mutation/update-user-user.exotest
+++ b/integration-tests/composite-pk/non-scalar/one-to-one/tests/mutation/update-user-user.exotest
@@ -1,0 +1,74 @@
+stages:
+    - operation: |
+        mutation {
+            updateUser(orgId: 1, email: "user1@example.com", data: {phone: "1111111111", profile: {update: {name: "User 1-updated"}}}) {
+                orgId
+                email
+                profile {
+                    name
+                }
+            }
+        }
+      response: |
+          {
+            "data": {
+              "updateUser": {
+                "orgId": 1,
+                "email": "user1@example.com",
+                "profile": {
+                  "name": "User 1-updated"
+                }
+              }
+            }
+          }
+      auth: |
+        {
+            "orgId": 1,
+            "email": "user1@example.com"
+        }
+
+    # User is trying to create a user with a different email
+    - operation: |
+        mutation {
+            updateUser(orgId: 1, email: "user1@example.com", data: {phone: "1234567890", profile: {update: {name: "User 1-updated"}}}) {
+                orgId
+                email
+                profile {
+                    name
+                }
+            }
+        }
+      response: |
+        {
+          "data": {
+            "updateUser": null
+          }
+        }
+      auth: |
+        {
+            "orgId": 1,
+            "email": "user2@example.com"
+        }
+      
+    # User is trying to create a user with a different orgId
+    - operation: |
+        mutation {
+            updateUser(orgId: 1, email: "user1@example.com", data: {phone: "1234567890", profile: {update: {name: "User 1-updated"}}}) {
+                orgId
+                email
+                profile {
+                    name
+                }
+            }
+        }
+      response: |
+        {
+          "data": {
+            "updateUser": null
+          }
+        }
+      auth: |
+        {
+            "orgId": 2,
+            "email": "user1@example.com"
+        }              

--- a/integration-tests/composite-pk/non-scalar/one-to-one/tests/query/profile-admin.exotest
+++ b/integration-tests/composite-pk/non-scalar/one-to-one/tests/query/profile-admin.exotest
@@ -20,3 +20,7 @@ response: |
             }
         }
     }
+auth: |
+    {
+        role: "admin"
+    }

--- a/integration-tests/composite-pk/non-scalar/one-to-one/tests/query/profile-user.exotest
+++ b/integration-tests/composite-pk/non-scalar/one-to-one/tests/query/profile-user.exotest
@@ -1,0 +1,50 @@
+stages:
+    - operation: |
+        query {
+            profile(user: {email: "user1@example.com", orgId: 1}) {
+                user {
+                    orgId
+                    email
+                }
+                name
+            }
+        }
+      response: |
+        {
+            "data": {
+                "profile": {
+                    "user": {
+                        "orgId": 1,
+                        "email": "user1@example.com"
+                    },
+                    "name": "User 1"
+                }
+            }
+        }
+      auth: |
+        {
+            "orgId": 1,
+            "email": "user1@example.com"
+        }
+
+    - operation: |
+        query {
+            profile(user: {email: "user1@example.com", orgId: 1}) {
+                user {
+                    orgId
+                    email
+                }
+                name
+            }
+        }
+      response: |
+        {
+            "data": {
+                "profile": null
+            }
+        }
+      auth: |
+        {
+            "orgId": 1,
+            "email": "user2@example.com"
+        }        

--- a/integration-tests/composite-pk/non-scalar/one-to-one/tests/query/profile.exotest
+++ b/integration-tests/composite-pk/non-scalar/one-to-one/tests/query/profile.exotest
@@ -1,0 +1,22 @@
+operation: |
+    query {
+        profile(user: {email: "user1@example.com", orgId: 1}) {
+            user {
+                orgId
+                email
+            }
+            name
+        }
+    }
+response: |
+    {
+        "data": {
+            "profile": {
+                "user": {
+                    "orgId": 1,
+                    "email": "user1@example.com"
+                },
+                "name": "User 1"
+            }
+        }
+    }

--- a/integration-tests/composite-pk/non-scalar/one-to-one/tests/query/profiles-admin.exotest
+++ b/integration-tests/composite-pk/non-scalar/one-to-one/tests/query/profiles-admin.exotest
@@ -30,3 +30,7 @@ response: |
         ]
     }
     }
+auth: |
+    {
+        role: "admin"
+    }

--- a/integration-tests/composite-pk/non-scalar/one-to-one/tests/query/profiles-user.exotest
+++ b/integration-tests/composite-pk/non-scalar/one-to-one/tests/query/profiles-user.exotest
@@ -1,0 +1,30 @@
+operation: |
+    query {
+        profiles {
+            user {
+                orgId
+                email
+            }
+            name
+                name
+        }
+    }
+response: |
+    {
+        "data": {
+            "profiles": [
+                {
+                    "user": {
+                        "orgId": 1,
+                        "email": "user1@example.com"
+                    },
+                    "name": "User 1"
+                }
+            ]
+        }
+    }
+auth: |
+    {
+        "orgId": 1,
+        "email": "user1@example.com"
+    }

--- a/integration-tests/composite-pk/non-scalar/one-to-one/tests/query/profiles.exotest
+++ b/integration-tests/composite-pk/non-scalar/one-to-one/tests/query/profiles.exotest
@@ -1,0 +1,32 @@
+operation: |
+    query {
+        profiles {
+            user {
+                orgId
+                email
+            }
+            name
+                name
+        }
+    }
+response: |
+    {
+    "data": {
+        "profiles": [
+        {
+            "user": {
+                "orgId": 1,
+                "email": "user1@example.com"
+            },
+            "name": "User 1"
+        },
+        {
+            "user": {
+                "orgId": 2,
+                "email": "user2@example.com"
+            },
+            "name": "User 2"
+        }
+        ]
+    }
+    }

--- a/integration-tests/composite-pk/non-scalar/one-to-one/tests/query/users-admin.exotest
+++ b/integration-tests/composite-pk/non-scalar/one-to-one/tests/query/users-admin.exotest
@@ -1,0 +1,24 @@
+operation: |
+    query {
+        users {
+            orgId
+            email
+            profile {
+                name
+            }
+        }
+    }
+response: |
+    {
+        "data": {
+            "users": [
+                {"orgId": 1, "email": "user1@example.com", "profile": {"name": "User 1"}},
+                {"orgId": 2, "email": "user2@example.com", "profile": {"name": "User 2"}},
+                {"orgId": 3, "email": "user3@example.com", "profile": null}
+            ]
+        }
+    }
+auth: |
+    {
+        role: "admin"
+    }

--- a/integration-tests/composite-pk/non-scalar/one-to-one/tests/query/users-user.exotest
+++ b/integration-tests/composite-pk/non-scalar/one-to-one/tests/query/users-user.exotest
@@ -13,8 +13,11 @@ response: |
         "data": {
             "users": [
                 {"orgId": 1, "email": "user1@example.com", "profile": {"name": "User 1"}},
-                {"orgId": 2, "email": "user2@example.com", "profile": {"name": "User 2"}},
-                {"orgId": 3, "email": "user3@example.com", "profile": null}
             ]
         }
+    }
+auth: |
+    {
+        "orgId": 1,
+        "email": "user1@example.com"
     }

--- a/integration-tests/composite-pk/non-scalar/one-to-one/tests/query/users.exotest
+++ b/integration-tests/composite-pk/non-scalar/one-to-one/tests/query/users.exotest
@@ -1,0 +1,20 @@
+operation: |
+    query {
+        users {
+            orgId
+            email
+            profile {
+                name
+            }
+        }
+    }
+response: |
+    {
+        "data": {
+            "users": [
+                {"orgId": 1, "email": "user1@example.com", "profile": {"name": "User 1"}},
+                {"orgId": 2, "email": "user2@example.com", "profile": {"name": "User 2"}},
+                {"orgId": 3, "email": "user3@example.com", "profile": null}
+            ]
+        }
+    }

--- a/integration-tests/composite-pk/scalars/no-auth/src/index.exo
+++ b/integration-tests/composite-pk/scalars/no-auth/src/index.exo
@@ -16,6 +16,7 @@ module PeopleDatabase {
     @pk city: String
     @pk state: String
     @pk zip: Int
+    info: String?
     people: Set<Person>?
   }
 }

--- a/integration-tests/composite-pk/scalars/no-auth/tests/mutation/create-address-nested.exotest
+++ b/integration-tests/composite-pk/scalars/no-auth/tests/mutation/create-address-nested.exotest
@@ -1,0 +1,168 @@
+stages:
+  - operation: |
+      mutation {
+        createAddress(data: {
+          street: "123 Main St"
+          city: "San Francisco"
+          state: "CA"
+          zip: 94101
+          info: "Creating a new address and adding people to it"
+          people: [
+            {
+              firstName: "John",
+              lastName: "DoeSan Francisco",
+              age: 20
+            },
+            {
+              firstName: "Jane",
+              lastName: "SmithSan Francisco",
+              age: 25
+            }
+          ]
+        }) {
+          street
+          city
+          state
+          zip
+          people {
+            firstName
+            lastName
+            age
+          }
+        }
+      }
+    response: |
+      {
+        "data": {
+          "createAddress": {
+            "street": "123 Main St",
+            "city": "San Francisco",
+            "state": "CA",
+            "zip": 94101,
+            "people": [
+              {
+                "firstName": "John",
+                "lastName": "DoeSan Francisco",
+                "age": 20
+              },
+              {
+                "firstName": "Jane",
+                "lastName": "SmithSan Francisco",
+                "age": 25
+              }
+            ]
+          }
+        }
+      }
+
+  - operation: |
+      query {
+        addresses @unordered {
+          street
+          city
+          state
+          zip
+          people @unordered {
+            firstName
+            lastName
+            age
+          }
+        }
+      }
+    response: |
+      {
+        "data": {
+          "addresses": [
+            {
+              "street": "1 Main St",
+              "city": "Albany",
+              "state": "NY",
+              "zip": 10001,
+              "people": [
+                {
+                  "firstName": "John",
+                  "lastName": "DoeAlbany",
+                  "age": 20
+                },
+                {
+                  "firstName": "Jane",
+                  "lastName": "SmithAlbany",
+                  "age": 25
+                }
+              ]
+            },
+            {
+              "street": "2 Main St",
+              "city": "Boston",
+              "state": "MA",
+              "zip": 22101,
+              "people": [
+                {
+                  "firstName": "John",
+                  "lastName": "DoeBoston",
+                  "age": 30
+                },
+                {
+                  "firstName": "Jane",
+                  "lastName": "SmithBoston",
+                  "age": 35
+                }
+              ]
+            },
+            {
+              "street": "3 Main St",
+              "city": "Chicago",
+              "state": "IL",
+              "zip": 60601,
+              "people": [
+                {
+                  "firstName": "John",
+                  "lastName": "DoeChicago",
+                  "age": 40
+                },
+                {
+                  "firstName": "Jane",
+                  "lastName": "SmithChicago",
+                  "age": 45
+                }
+              ]
+            },
+            {
+              "street": "4 Main St",
+              "city": "Plymouth",
+              "state": "MA",
+              "zip": 23600,
+              "people": [
+                {
+                  "firstName": "John",
+                  "lastName": "DoePlymouth",
+                  "age": 50
+                },
+                {
+                  "firstName": "Jane",
+                  "lastName": "SmithPlymouth",
+                  "age": 55
+                }
+              ]
+            },
+            {
+              "street": "123 Main St",
+              "city": "San Francisco",
+              "state": "CA",
+              "zip": 94101,
+              "people": [
+                {
+                  "firstName": "John",
+                  "lastName": "DoeSan Francisco",
+                  "age": 20
+                },
+                {
+                  "firstName": "Jane",
+                  "lastName": "SmithSan Francisco",
+                  "age": 25
+                }
+              ]
+            }
+          ]
+        }
+      }

--- a/integration-tests/composite-pk/scalars/no-auth/tests/mutation/create-person-nested.exotest
+++ b/integration-tests/composite-pk/scalars/no-auth/tests/mutation/create-person-nested.exotest
@@ -1,0 +1,153 @@
+stages:
+  - operation: |
+      # Create a new person to live in an existing address
+      mutation {
+        createPerson(data: { firstName: "John", lastName: "DoeAlbany-new", age: 20, address: { street: "1 Main St", city: "Albany", state: "NY", zip: 10001 } }) {
+          firstName
+          lastName
+          age
+          address {
+            street
+            city
+            state
+            zip
+          }
+        }
+      }
+    response: |
+      {
+        "data": {
+          "createPerson": {
+            "firstName": "John",
+            "lastName": "DoeAlbany-new",
+            "age": 20,
+            "address": {
+              "street": "1 Main St",
+              "city": "Albany",
+              "state": "NY",
+              "zip": 10001
+            }
+          }
+        }
+      }
+
+  - operation: |
+      query {
+        people @unordered {
+          firstName
+          lastName
+          age
+          address {
+            street
+            city
+            state
+            zip
+          }
+        }
+      }
+    response: |
+      {
+        "data": {
+          "people": [
+            {
+              "firstName": "John",
+              "lastName": "DoeAlbany",
+              "age": 20,
+              "address": {
+                "street": "1 Main St",
+                "city": "Albany",
+                "state": "NY",
+                "zip": 10001
+              }
+            },
+            {
+              "firstName": "Jane",
+              "lastName": "SmithAlbany",
+              "age": 25,
+              "address": {
+                "street": "1 Main St",
+                "city": "Albany",
+                "state": "NY",
+                "zip": 10001
+              }
+            },
+            {
+              "firstName": "John",
+              "lastName": "DoeBoston",
+              "age": 30,
+              "address": {
+                "street": "2 Main St",
+                "city": "Boston",
+                "state": "MA",
+                "zip": 22101
+              }
+            },
+            {
+              "firstName": "Jane",
+              "lastName": "SmithBoston",
+              "age": 35,
+              "address": {
+                "street": "2 Main St",
+                "city": "Boston",
+                "state": "MA",
+                "zip": 22101
+              }
+            },
+            {
+              "firstName": "John",
+              "lastName": "DoeChicago",
+              "age": 40,
+              "address": {
+                "street": "3 Main St",
+                "city": "Chicago",
+                "state": "IL",
+                "zip": 60601
+              }
+            },
+            {
+              "firstName": "Jane",
+              "lastName": "SmithChicago",
+              "age": 45,
+              "address": {
+                "street": "3 Main St",
+                "city": "Chicago",
+                "state": "IL",
+                "zip": 60601
+              }
+            },
+            {
+              "firstName": "John",
+              "lastName": "DoePlymouth",
+              "age": 50,
+              "address": {
+                "street": "4 Main St",
+                "city": "Plymouth",
+                "state": "MA",
+                "zip": 23600
+              }
+            },
+            {
+              "firstName": "Jane",
+              "lastName": "SmithPlymouth",
+              "age": 55,
+              "address": {
+                "street": "4 Main St",
+                "city": "Plymouth",
+                "state": "MA",
+                "zip": 23600
+              }
+            },
+            {
+              "firstName": "John",
+              "lastName": "DoeAlbany-new",
+              "age": 20,
+              "address": {
+                "street": "1 Main St",
+                "city": "Albany",
+                "state": "NY",
+                "zip": 10001
+              }
+            }
+          ]
+        }
+      }

--- a/integration-tests/composite-pk/scalars/no-auth/tests/mutation/update-address-nested-create.exotest
+++ b/integration-tests/composite-pk/scalars/no-auth/tests/mutation/update-address-nested-create.exotest
@@ -1,0 +1,44 @@
+operation: |
+    mutation {
+      updateAddress(street: "2 Main St", city: "Boston", state: "MA", zip: 22101, data: { info: "The best address in the world", people: { create: { firstName: "Alex", lastName: "NewBoston", age: 20 } } }) @unordered {
+        street
+        city
+        state
+        zip
+        info
+        people @unordered {
+          firstName
+          lastName
+          age
+        }
+      }
+    }
+response: |
+    {
+      "data": {
+        "updateAddress": {
+          "street": "2 Main St",
+          "city": "Boston",
+          "state": "MA",
+          "zip": 22101,
+          "info": "The best address in the world",
+          "people": [
+            {
+              "firstName": "John",
+              "lastName": "DoeBoston",
+              "age": 30
+            },
+            {
+              "firstName": "Jane",
+              "lastName": "SmithBoston",
+              "age": 35
+            },
+            {
+              "firstName": "Alex",
+              "lastName": "NewBoston",
+              "age": 20
+            }
+          ]
+        }
+      }
+    }

--- a/integration-tests/composite-pk/scalars/no-auth/tests/mutation/update-address-nested-delete.exotest
+++ b/integration-tests/composite-pk/scalars/no-auth/tests/mutation/update-address-nested-delete.exotest
@@ -1,0 +1,34 @@
+operation: |
+    mutation {
+      updateAddress(street: "2 Main St", city: "Boston", state: "MA", zip: 22101, data: { info: "John moved out", people: { delete: { firstName: "John", lastName: "DoeBoston" } } }) {
+        street
+        city
+        state
+        zip
+        info
+        people @unordered {
+          firstName
+          lastName
+          age
+        }
+      }
+    }
+response: |
+    {
+      "data": {
+        "updateAddress": {
+          "street": "2 Main St",
+          "city": "Boston",
+          "state": "MA",
+          "zip": 22101,
+          "info": "John moved out",
+          "people": [
+            {
+              "firstName": "Jane",
+              "lastName": "SmithBoston",
+              "age": 35
+            }
+          ]
+        }
+      }
+    }

--- a/integration-tests/composite-pk/scalars/no-auth/tests/mutation/update-address-nested-update.exotest
+++ b/integration-tests/composite-pk/scalars/no-auth/tests/mutation/update-address-nested-update.exotest
@@ -1,0 +1,39 @@
+operation: |
+    mutation {
+      updateAddress(street: "2 Main St", city: "Boston", state: "MA", zip: 22101, data: { info: "The best address in the world", people: { update: { firstName: "John", lastName: "DoeBoston", age: 20 } } }) @unordered {
+        street
+        city
+        state
+        zip
+        info
+        people @unordered {
+          firstName
+          lastName
+          age
+        }
+      }
+    }
+response: |
+    {
+      "data": {
+        "updateAddress": {
+          "street": "2 Main St",
+          "city": "Boston",
+          "state": "MA",
+          "zip": 22101,
+          "info": "The best address in the world",
+          "people": [
+            {
+              "firstName": "Jane",
+              "lastName": "SmithBoston",
+              "age": 35
+            },
+            {
+              "firstName": "John",
+              "lastName": "DoeBoston",
+              "age": 20
+            }
+          ]
+        }
+      }
+    }

--- a/integration-tests/composite-pk/scalars/no-auth/tests/mutation/update-addresses-nested.exotest
+++ b/integration-tests/composite-pk/scalars/no-auth/tests/mutation/update-addresses-nested.exotest
@@ -1,0 +1,57 @@
+operation: |
+    mutation {
+      updateAddresses(where: { state: {eq: "MA"} }, data: { people: { update: { firstName: "John", lastName: "DoeBoston", age: 20 } } }) @unordered {
+        street
+        city
+        state
+        zip
+        people @unordered {
+          firstName
+          lastName
+          age
+        }
+      }
+    }
+response: |
+    {
+      "data": {
+        "updateAddresses": [
+          {
+            "street": "2 Main St",
+            "city": "Boston",
+            "state": "MA",
+            "zip": 22101,
+            "people": [
+              {
+                "firstName": "Jane",
+                "lastName": "SmithBoston",
+                "age": 35
+              },
+              {
+                "firstName": "John",
+                "lastName": "DoeBoston",
+                "age": 20
+              }
+            ]
+          },
+          {
+            "street": "4 Main St",
+            "city": "Plymouth",
+            "state": "MA",
+            "zip": 23600,
+            "people": [
+              {
+                "firstName": "John",
+                "lastName": "DoePlymouth",
+                "age": 50
+              },
+              {
+                "firstName": "Jane",
+                "lastName": "SmithPlymouth",
+                "age": 55
+              }
+            ]
+          }
+        ]
+      }
+    }

--- a/integration-tests/composite-pk/scalars/no-auth/tests/mutation/update-person-nested.exotest
+++ b/integration-tests/composite-pk/scalars/no-auth/tests/mutation/update-person-nested.exotest
@@ -1,0 +1,142 @@
+stages:
+  - operation: |
+      mutation {
+        # John DoeBoston moves to 1 Main St, Albany, NY, 10001 to live with John DoeAlbany and Jane SmithAlbany
+        updatePerson(firstName: "John", lastName: "DoeBoston", data: { address: {street: "1 Main St", city: "Albany", state: "NY", zip: 10001} }) {
+          firstName
+          lastName
+          age
+          address {
+            street
+            city
+            state
+            zip
+          }
+        }
+      }
+    response: |
+      {
+        "data": {
+          "updatePerson": {
+            "firstName": "John",
+            "lastName": "DoeBoston",
+            "age": 30,
+            "address": {
+              "street": "1 Main St",
+              "city": "Albany",
+              "state": "NY",
+              "zip": 10001
+            }
+          }
+        }
+      }
+
+  - operation: |
+      query {
+        people @unordered {
+          firstName
+          lastName
+          age
+          address {
+            street
+            city
+            state
+            zip
+          }
+        }
+      }
+    response: |
+      {
+        "data": {
+          "people": [
+            {
+              "firstName": "John",
+              "lastName": "DoeAlbany",
+              "age": 20,
+              "address": {
+                "street": "1 Main St",
+                "city": "Albany",
+                "state": "NY",
+                "zip": 10001
+              }
+            },
+            {
+              "firstName": "Jane",
+              "lastName": "SmithAlbany",
+              "age": 25,
+              "address": {
+                "street": "1 Main St",
+                "city": "Albany",
+                "state": "NY",
+                "zip": 10001
+              }
+            },
+            {
+              "firstName": "Jane",
+              "lastName": "SmithBoston",
+              "age": 35,
+              "address": {
+                "street": "2 Main St",
+                "city": "Boston",
+                "state": "MA",
+                "zip": 22101
+              }
+            },
+            {
+              "firstName": "John",
+              "lastName": "DoeChicago",
+              "age": 40,
+              "address": {
+                "street": "3 Main St",
+                "city": "Chicago",
+                "state": "IL",
+                "zip": 60601
+              }
+            },
+            {
+              "firstName": "Jane",
+              "lastName": "SmithChicago",
+              "age": 45,
+              "address": {
+                "street": "3 Main St",
+                "city": "Chicago",
+                "state": "IL",
+                "zip": 60601
+              }
+            },
+            {
+              "firstName": "John",
+              "lastName": "DoePlymouth",
+              "age": 50,
+              "address": {
+                "street": "4 Main St",
+                "city": "Plymouth",
+                "state": "MA",
+                "zip": 23600
+              }
+            },
+            {
+              "firstName": "Jane",
+              "lastName": "SmithPlymouth",
+              "age": 55,
+              "address": {
+                "street": "4 Main St",
+                "city": "Plymouth",
+                "state": "MA",
+                "zip": 23600
+              }
+            },
+            {
+              "firstName": "John",
+              "lastName": "DoeBoston",
+              "age": 30,
+              "address": {
+                "street": "1 Main St",
+                "city": "Albany",
+                "state": "NY",
+                "zip": 10001
+              }
+            }
+          ]
+        }
+      }

--- a/integration-tests/composite-pk/scalars/no-auth/tests/mutation/update-person.exotest
+++ b/integration-tests/composite-pk/scalars/no-auth/tests/mutation/update-person.exotest
@@ -1,0 +1,74 @@
+stages:
+  - operation: |
+      mutation {
+        updatePerson(firstName: "John", lastName: "DoeBoston", data: { age: 100 }) {
+          firstName
+          lastName
+          age
+        }
+      }
+    response: |
+      {
+        "data": {
+          "updatePerson": {
+            "firstName": "John",
+            "lastName": "DoeBoston",
+            "age": 100
+          }
+        }
+      }
+  - operation: |
+      query {
+        people @unordered {
+          firstName
+          lastName
+          age
+        }
+      }
+    response: |
+      {
+        "data": {
+          "people": [
+            {
+              "firstName": "John",
+              "lastName": "DoeAlbany",
+              "age": 20
+            },
+            {
+              "firstName": "Jane",
+              "lastName": "SmithAlbany",
+              "age": 25
+            },
+            {
+              "firstName": "Jane",
+              "lastName": "SmithBoston",
+              "age": 35
+            },
+            {
+              "firstName": "John",
+              "lastName": "DoeChicago",
+              "age": 40
+            },
+            {
+              "firstName": "Jane",
+              "lastName": "SmithChicago",
+              "age": 45
+            },
+            {
+              "firstName": "John",
+              "lastName": "DoePlymouth",
+              "age": 50
+            },
+            {
+              "firstName": "Jane",
+              "lastName": "SmithPlymouth",
+              "age": 55
+            },
+            {
+              "firstName": "John",
+              "lastName": "DoeBoston",
+              "age": 100
+            }
+          ]
+        }
+      }

--- a/libs/exo-sql/src/asql/column_path.rs
+++ b/libs/exo-sql/src/asql/column_path.rs
@@ -83,7 +83,9 @@ impl ColumnPathLink {
             column_pairs
                 .iter()
                 .all(|RelationColumnPair { self_column_id, .. }| {
-                    self_column_id.table_id == column_pairs[0].self_column_id.table_id
+                    column_pairs.iter().all(|column_pair| {
+                        column_pair.self_column_id.table_id == self_column_id.table_id
+                    })
                 }),
             "All self columns in the column pairs must refer to the same table"
         );
@@ -93,7 +95,9 @@ impl ColumnPathLink {
                 |RelationColumnPair {
                      foreign_column_id, ..
                  }| {
-                    foreign_column_id.table_id == column_pairs[0].foreign_column_id.table_id
+                    column_pairs.iter().all(|column_pair| {
+                        column_pair.foreign_column_id.table_id == foreign_column_id.table_id
+                    })
                 }
             ),
             "All foreign columns in the column pairs must refer to the same table"

--- a/libs/exo-sql/src/asql/column_path.rs
+++ b/libs/exo-sql/src/asql/column_path.rs
@@ -251,6 +251,7 @@ impl PhysicalColumnPath {
     }
 
     pub fn lead_table_id(&self) -> TableId {
+        // The ColumnPathLink construction ensures that all links point to the same table, so we can use the first (or any) to get the table id
         self.0[0].self_column_ids()[0].table_id
     }
 

--- a/libs/exo-sql/src/asql/update.rs
+++ b/libs/exo-sql/src/asql/update.rs
@@ -110,7 +110,7 @@ impl NestedAbstractInsertSet {
         }
 
         assert!(
-            all_same(ops.iter().map(|op| op.relation_column_id)),
+            all_same(ops.iter().map(|op| op.relation_column_ids.clone())),
             "All nested inserts must be for the same relation"
         );
         assert!(
@@ -132,7 +132,7 @@ impl NestedAbstractInsertSet {
 #[derive(Debug)]
 pub struct NestedAbstractInsert {
     /// Same as `NestedAbstractUpdate::relation_column_id`
-    pub relation_column_id: ColumnId,
+    pub relation_column_ids: Vec<ColumnId>,
     /// The insert to apply to the nested table
     pub insert: AbstractInsert,
 }

--- a/libs/exo-sql/src/schema/database_spec.rs
+++ b/libs/exo-sql/src/schema/database_spec.rs
@@ -148,13 +148,13 @@ impl DatabaseSpec {
                                 column.name.clone()
                             });
 
-                            Some(ManyToOne {
-                                column_pairs: vec![RelationColumnPair {
+                            Some(ManyToOne::new(
+                                vec![RelationColumnPair {
                                     self_column_id,
                                     foreign_column_id: foreign_pk_column_id,
                                 }],
                                 foreign_table_alias,
-                            })
+                            ))
                         }
                         _ => None,
                     }

--- a/libs/exo-sql/src/schema/op.rs
+++ b/libs/exo-sql/src/schema/op.rs
@@ -257,7 +257,7 @@ impl SchemaOp<'_> {
                         .map(|c| format!("\"{}\"", c.name.as_str()))
                         .collect::<Vec<_>>()
                         .join(", "),
-                    foreign_columns[0].foreign_table_name.sql_name(),
+                    foreign_columns[0].foreign_table_name.sql_name(), // Foreign columns all point to the same table, so use any of them
                     foreign_reference_columns
                 );
 

--- a/libs/exo-sql/src/sql/column.rs
+++ b/libs/exo-sql/src/sql/column.rs
@@ -93,11 +93,11 @@ impl ExpressionBuilder for Column {
                 }
             }
             Column::ColumnArray(columns) => {
-                if columns.len() == 1 {
-                    columns[0].build(database, builder);
-                } else {
+                if columns.len() > 1 {
                     builder.push('(');
-                    builder.push_elems(database, columns, ",");
+                }
+                builder.push_elems(database, columns, ",");
+                if columns.len() > 1 {
                     builder.push(')');
                 }
             }

--- a/libs/exo-sql/src/transform/join_util.rs
+++ b/libs/exo-sql/src/transform/join_util.rs
@@ -48,10 +48,11 @@ pub fn compute_join(
             |acc, DependencyLink { link, dependency }| {
                 let (join_predicate, linked_table_alias) = match link {
                     ColumnPathLink::Relation(relation_link) => {
-                        let linked_table_id = relation_link.linked_table_id();
+                        let linked_table_id = relation_link.linked_table_id;
                         let RelationLink {
                             column_pairs,
                             linked_table_alias,
+                            ..
                         } = relation_link;
 
                         let new_alias =

--- a/libs/exo-sql/src/transform/join_util.rs
+++ b/libs/exo-sql/src/transform/join_util.rs
@@ -9,10 +9,7 @@
 
 use crate::{
     asql::column_path::{ColumnPathLink, RelationLink},
-    sql::{
-        column::Column, join::LeftJoin, predicate::ConcretePredicate, relation::RelationColumnPair,
-        table::Table,
-    },
+    sql::{column::Column, join::LeftJoin, predicate::ConcretePredicate, table::Table},
     transform::table_dependency::{DependencyLink, TableDependency},
     Database, PhysicalColumnPath, TableId,
 };
@@ -50,24 +47,32 @@ pub fn compute_join(
             init_table,
             |acc, DependencyLink { link, dependency }| {
                 let (join_predicate, linked_table_alias) = match link {
-                    ColumnPathLink::Relation(RelationLink {
-                        column_pairs,
-                        linked_table_alias,
-                    }) => {
-                        let RelationColumnPair {
-                            self_column_id,
-                            foreign_column_id: linked_column_id,
-                        } = column_pairs[0];
-                        let new_alias = selection_level
-                            .alias((linked_column_id.table_id, linked_table_alias), database);
+                    ColumnPathLink::Relation(relation_link) => {
+                        let linked_table_id = relation_link.linked_table_id();
+                        let RelationLink {
+                            column_pairs,
+                            linked_table_alias,
+                        } = relation_link;
 
-                        (
-                            ConcretePredicate::Eq(
-                                Column::physical(self_column_id, None),
-                                Column::physical(linked_column_id, Some(new_alias.clone())),
-                            ),
-                            new_alias,
-                        )
+                        let new_alias =
+                            selection_level.alias((linked_table_id, linked_table_alias), database);
+
+                        let predicate = column_pairs.iter().fold(
+                            ConcretePredicate::True,
+                            |acc, column_pair| {
+                                ConcretePredicate::and(
+                                    acc,
+                                    ConcretePredicate::Eq(
+                                        Column::physical(column_pair.self_column_id, None),
+                                        Column::physical(
+                                            column_pair.foreign_column_id,
+                                            Some(new_alias.clone()),
+                                        ),
+                                    ),
+                                )
+                            },
+                        );
+                        (predicate, new_alias)
                     }
                     ColumnPathLink::Leaf(_) => {
                         panic!("Unexpected leaf in dependency link")

--- a/libs/exo-sql/src/transform/pg/insert/insert_transformer.rs
+++ b/libs/exo-sql/src/transform/pg/insert/insert_transformer.rs
@@ -33,7 +33,7 @@ impl InsertTransformer for Postgres {
     fn update_transaction_script<'a>(
         &self,
         abstract_insert: &'a AbstractInsert,
-        parent_step: Option<(TransactionStepId, ColumnId)>,
+        parent_step: Option<(TransactionStepId, Vec<ColumnId>)>,
         database: &'a Database,
         transaction_script: &mut TransactionScript<'a>,
     ) {

--- a/libs/exo-sql/src/transform/pg/insert/insertion_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/insert/insertion_strategy.rs
@@ -24,7 +24,7 @@ pub(crate) trait InsertionStrategy {
     fn update_transaction_script<'a>(
         &self,
         abstract_insert: &'a AbstractInsert,
-        parent_step: Option<(TransactionStepId, ColumnId)>,
+        parent_step: Option<(TransactionStepId, Vec<ColumnId>)>,
         database: &'a Database,
         transformer: &Postgres,
         transaction_script: &mut TransactionScript<'a>,

--- a/libs/exo-sql/src/transform/pg/insert/insertion_strategy_chain.rs
+++ b/libs/exo-sql/src/transform/pg/insert/insertion_strategy_chain.rs
@@ -36,7 +36,7 @@ impl<'s> InsertionStrategyChain<'s> {
     pub fn update_transaction_script<'a>(
         &self,
         abstract_insert: &'a AbstractInsert,
-        parent_step: Option<(TransactionStepId, ColumnId)>,
+        parent_step: Option<(TransactionStepId, Vec<ColumnId>)>,
         database: &'a Database,
         transformer: &Postgres,
         transaction_script: &mut TransactionScript<'a>,

--- a/libs/exo-sql/src/transform/pg/insert/multi_statement_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/insert/multi_statement_strategy.rs
@@ -228,7 +228,7 @@ fn insert_nested_row<'a>(
     } = nested_row;
 
     let relation = relation_id.deref(database);
-    let foreign_table_id = relation.linked_table_id();
+    let foreign_table_id = relation.linked_table_id;
     let foreign_column_ids = relation
         .column_pairs
         .iter()

--- a/libs/exo-sql/src/transform/pg/predicate_transformer.rs
+++ b/libs/exo-sql/src/transform/pg/predicate_transformer.rs
@@ -196,7 +196,7 @@ fn form_subselect(
     );
 
     let abstract_select = AbstractSelect {
-        table_id: relation_link.self_table_id(),
+        table_id: relation_link.self_table_id,
         selection,
         predicate,
         order_by: None,

--- a/libs/exo-sql/src/transform/pg/select/selection_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/select/selection_strategy.rs
@@ -154,11 +154,11 @@ pub(super) fn compute_relation_predicate(
             let (relation_table_id, relation_column_pairs) = match relation_id {
                 RelationId::OneToMany(relation_id) => {
                     let relation = relation_id.deref(database);
-                    (relation.self_table_id(), relation.column_pairs)
+                    (relation.self_table_id, relation.column_pairs)
                 }
                 RelationId::ManyToOne(relation_id) => {
                     let relation = relation_id.deref(database);
-                    (relation.self_table_id(), relation.column_pairs)
+                    (relation.self_table_id, relation.column_pairs)
                 }
             };
 

--- a/libs/exo-sql/src/transform/pg/select/selection_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/select/selection_strategy.rs
@@ -17,8 +17,8 @@ use crate::{
         pg::{selection_level::SelectionLevel, Postgres},
         transformer::{OrderByTransformer, PredicateTransformer},
     },
-    AbstractOrderBy, AbstractPredicate, Column, Database, Limit, ManyToOne, Offset, OneToMany,
-    PhysicalColumnPath, RelationId, Selection, TableId,
+    AbstractOrderBy, AbstractPredicate, Column, Database, Limit, Offset, PhysicalColumnPath,
+    RelationId, Selection, TableId,
 };
 
 use super::selection_context::SelectionContext;
@@ -151,33 +151,34 @@ pub(super) fn compute_relation_predicate(
 
     subselect_relation
         .map(|relation_id| {
-            let (self_column_id, foreign_column_id) = match relation_id {
+            let (relation_table_id, relation_column_pairs) = match relation_id {
                 RelationId::OneToMany(relation_id) => {
-                    let OneToMany { column_pairs } = relation_id.deref(database);
-
-                    (
-                        column_pairs[0].self_column_id,
-                        column_pairs[0].foreign_column_id,
-                    )
+                    let relation = relation_id.deref(database);
+                    (relation.self_table_id(), relation.column_pairs)
                 }
                 RelationId::ManyToOne(relation_id) => {
-                    let ManyToOne { column_pairs, .. } = relation_id.deref(database);
-                    (
-                        column_pairs[0].self_column_id,
-                        column_pairs[0].foreign_column_id,
-                    )
+                    let relation = relation_id.deref(database);
+                    (relation.self_table_id(), relation.column_pairs)
                 }
             };
 
             let alias = if use_alias {
-                Some(selection_level.alias((self_column_id.table_id, None), database))
+                Some(selection_level.alias((relation_table_id, None), database))
             } else {
                 None
             };
 
-            ConcretePredicate::Eq(
-                Column::physical(self_column_id, alias),
-                Column::physical(foreign_column_id, None),
+            relation_column_pairs.into_iter().fold(
+                ConcretePredicate::True,
+                |predicate, column_pair| {
+                    ConcretePredicate::and(
+                        predicate,
+                        ConcretePredicate::Eq(
+                            Column::physical(column_pair.self_column_id, alias.clone()),
+                            Column::physical(column_pair.foreign_column_id, None),
+                        ),
+                    )
+                },
             )
         })
         .unwrap_or(ConcretePredicate::True)

--- a/libs/exo-sql/src/transform/pg/selection_level.rs
+++ b/libs/exo-sql/src/transform/pg/selection_level.rs
@@ -109,14 +109,14 @@ impl SelectionLevel {
                     RelationId::ManyToOne(r) => {
                         let many_to_one = r.deref(database);
                         (
-                            many_to_one.self_table_id(),
+                            many_to_one.self_table_id,
                             many_to_one.foreign_table_alias.clone(),
                         )
                     }
                     RelationId::OneToMany(r) => {
                         let one_to_many = r.deref(database);
 
-                        (one_to_many.self_table_id(), None)
+                        (one_to_many.self_table_id, None)
                     }
                 });
 

--- a/libs/exo-sql/src/transform/pg/selection_level.rs
+++ b/libs/exo-sql/src/transform/pg/selection_level.rs
@@ -108,16 +108,15 @@ impl SelectionLevel {
                 let table_linking = relation_ids.iter().map(|relation_id| match relation_id {
                     RelationId::ManyToOne(r) => {
                         let many_to_one = r.deref(database);
-
                         (
-                            many_to_one.column_pairs[0].self_column_id.table_id,
+                            many_to_one.self_table_id(),
                             many_to_one.foreign_table_alias.clone(),
                         )
                     }
                     RelationId::OneToMany(r) => {
                         let one_to_many = r.deref(database);
 
-                        (one_to_many.column_pairs[0].self_column_id.table_id, None)
+                        (one_to_many.self_table_id(), None)
                     }
                 });
 

--- a/libs/exo-sql/src/transform/transformer.rs
+++ b/libs/exo-sql/src/transform/transformer.rs
@@ -100,7 +100,7 @@ pub trait InsertTransformer {
     fn to_transaction_script<'a>(
         &self,
         abstract_insert: &'a AbstractInsert,
-        parent_step: Option<(TransactionStepId, ColumnId)>,
+        parent_step: Option<(TransactionStepId, Vec<ColumnId>)>,
         database: &'a Database,
     ) -> TransactionScript<'a> {
         let mut transaction_script = TransactionScript::default();
@@ -118,7 +118,7 @@ pub trait InsertTransformer {
     fn update_transaction_script<'a>(
         &self,
         abstract_insert: &'a AbstractInsert,
-        parent_step: Option<(TransactionStepId, ColumnId)>,
+        parent_step: Option<(TransactionStepId, Vec<ColumnId>)>,
         database: &'a Database,
         transaction_script: &mut TransactionScript<'a>,
     );


### PR DESCRIPTION
This supports a much cleaner way to express many-to-many and one-to-one relationships such as:

```exo
@postgres
module ChatModule {
  @access(true)
  type Chat {
    @pk id: Int = autoIncrement()
    title: String
    participants: Set<ChatParticipation>?
  }

  @access(true)
  type ChatParticipation {
    @pk chat: Chat
    @pk user: User
    moods: Set<Mood>?
  }

  @access(true)
  type User {
    @pk id: Int = autoIncrement()
    name: String
    participatesIn: Set<ChatParticipation>?
  }

  @access(true)
  type Mood {
    @pk id: Int = autoIncrement()
    name: String
    chatParticipation: ChatParticipation
  }
}
```

and (the one-to-one case):
```exo
context AuthContext {
  @jwt orgId: Int
  @jwt email: String
  @jwt role: String
}

@postgres
module UserModule {
  @access(AuthContext.role == "admin" || (AuthContext.orgId == self.orgId && AuthContext.email == self.email))
  type User {
    @pk orgId: Int
    @pk email: String
    phone: String?
    profile: Profile?
  }

  @access(AuthContext.role == "admin" || (AuthContext.orgId == self.user.orgId && AuthContext.email == self.user.email))
  type Profile {
    @pk user: User
    name: String
  }
}
```
