### PR TITLE
Move the precheck execution responsibility to exo-sql

### DIFF
--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/abstract_operation_resolver.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/abstract_operation_resolver.rs
@@ -18,7 +18,7 @@ use postgres_core_resolver::postgres_execution_error::PostgresExecutionError;
 use super::PostgresSubsystemResolver;
 
 pub async fn resolve_operation<'e>(
-    op: &AbstractOperation,
+    op: AbstractOperation,
     precheck_queries: Vec<AbstractSelect>,
     subsystem_resolver: &'e PostgresSubsystemResolver,
     request_context: &'e RequestContext<'e>,
@@ -35,7 +35,7 @@ pub async fn resolve_operation<'e>(
         let rows = subsystem_resolver
             .executor
             .execute(
-                &AbstractOperation::Select(precheck_query),
+                AbstractOperation::Select(precheck_query),
                 &mut tx,
                 &subsystem_resolver.subsystem.core_subsystem.database,
             )

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/abstract_operation_resolver.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/abstract_operation_resolver.rs
@@ -7,7 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use exo_sql::{AbstractOperation, AbstractSelect};
+use exo_sql::database_error::DatabaseError;
+use exo_sql::AbstractOperation;
 
 use common::context::RequestContext;
 use core_plugin_interface::core_resolver::{QueryResponse, QueryResponseBody};
@@ -19,7 +20,6 @@ use super::PostgresSubsystemResolver;
 
 pub async fn resolve_operation<'e>(
     op: AbstractOperation,
-    precheck_queries: Vec<AbstractSelect>,
     subsystem_resolver: &'e PostgresSubsystemResolver,
     request_context: &'e RequestContext<'e>,
 ) -> Result<QueryResponse, PostgresExecutionError> {
@@ -29,38 +29,20 @@ pub async fn resolve_operation<'e>(
         .try_lock()
         .unwrap();
 
-    let mut precheck_result = true;
-
-    for precheck_query in precheck_queries {
-        let rows = subsystem_resolver
-            .executor
-            .execute(
-                AbstractOperation::Select(precheck_query),
-                &mut tx,
-                &subsystem_resolver.subsystem.core_subsystem.database,
-            )
-            .await
-            .map_err(PostgresExecutionError::Postgres)?;
-
-        if rows.len() != 1 {
-            precheck_result = false;
-            break;
-        }
-    }
-
-    if !precheck_result {
-        return Err(PostgresExecutionError::Authorization);
-    }
-
-    let mut result = subsystem_resolver
+    let result = subsystem_resolver
         .executor
         .execute(
             op,
             &mut tx,
             &subsystem_resolver.subsystem.core_subsystem.database,
         )
-        .await
-        .map_err(PostgresExecutionError::Postgres)?;
+        .await;
+
+    if let Err(DatabaseError::Precheck(_)) = result {
+        return Err(PostgresExecutionError::Authorization);
+    }
+
+    let mut result = result.map_err(PostgresExecutionError::Postgres)?;
 
     let body = if result.len() == 1 {
         let string_result = extractor(result.swap_remove(0))?;

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/operation_resolver.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/operation_resolver.rs
@@ -10,7 +10,7 @@
 use async_trait::async_trait;
 use common::context::RequestContext;
 use core_plugin_interface::core_resolver::validation::field::ValidatedField;
-use exo_sql::{AbstractOperation, AbstractPredicate, AbstractSelect};
+use exo_sql::{AbstractOperation, AbstractSelect};
 use postgres_graphql_model::subsystem::PostgresGraphQLSubsystem;
 
 use postgres_core_resolver::postgres_execution_error::PostgresExecutionError;
@@ -25,14 +25,6 @@ pub trait OperationSelectionResolver {
     ) -> Result<AbstractSelect, PostgresExecutionError>;
 }
 
-pub struct OperationResolution<O> {
-    /// The precheck predicates to be executed before the operation is executed.
-    /// Each predicate must return a single row to indicate passing the precheck (in other words, returning zero rows indicates failure).
-    pub precheck_predicates: Vec<AbstractPredicate>,
-    /// The operation to be executed if the precheck passes
-    pub operation: O,
-}
-
 #[async_trait]
 pub trait OperationResolver {
     async fn resolve<'a>(
@@ -40,7 +32,7 @@ pub trait OperationResolver {
         field: &'a ValidatedField,
         request_context: &'a RequestContext<'a>,
         subsystem: &'a PostgresGraphQLSubsystem,
-    ) -> Result<OperationResolution<AbstractOperation>, PostgresExecutionError>;
+    ) -> Result<AbstractOperation, PostgresExecutionError>;
 }
 
 #[async_trait]
@@ -50,12 +42,9 @@ impl<T: OperationSelectionResolver + Send + Sync> OperationResolver for T {
         field: &'a ValidatedField,
         request_context: &'a RequestContext<'a>,
         subsystem: &'a PostgresGraphQLSubsystem,
-    ) -> Result<OperationResolution<AbstractOperation>, PostgresExecutionError> {
+    ) -> Result<AbstractOperation, PostgresExecutionError> {
         self.resolve_select(field, request_context, subsystem)
             .await
-            .map(|select| OperationResolution {
-                precheck_predicates: vec![],
-                operation: AbstractOperation::Select(select),
-            })
+            .map(AbstractOperation::Select)
     }
 }

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/resolver.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/resolver.rs
@@ -104,13 +104,8 @@ impl SubsystemGraphQLResolver for PostgresSubsystemResolver {
                     .collect::<Result<Vec<_>, _>>()?;
 
                 Ok(Some(
-                    resolve_operation(
-                        &operation.operation,
-                        precheck_queries,
-                        self,
-                        request_context,
-                    )
-                    .await?,
+                    resolve_operation(operation.operation, precheck_queries, self, request_context)
+                        .await?,
                 ))
             }
             Some(Err(e)) => Err(e.into()),

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/resolver.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/resolver.rs
@@ -24,10 +24,7 @@ use core_plugin_interface::{
     },
     interception::InterceptorIndex,
 };
-use exo_sql::{
-    AbstractPredicate, AbstractSelect, AliasedSelectionElement, ColumnPath, DatabaseExecutor,
-    SelectionElement,
-};
+use exo_sql::DatabaseExecutor;
 use postgres_core_resolver::postgres_execution_error::PostgresExecutionError;
 use postgres_graphql_model::subsystem::PostgresGraphQLSubsystem;
 
@@ -90,24 +87,9 @@ impl SubsystemGraphQLResolver for PostgresSubsystemResolver {
         };
 
         match operation {
-            Some(Ok(operation)) => {
-                let precheck_queries = operation
-                    .precheck_predicates
-                    .into_iter()
-                    .filter_map(|p| {
-                        if p == AbstractPredicate::True {
-                            None
-                        } else {
-                            Some(create_precheck_query(p))
-                        }
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
-
-                Ok(Some(
-                    resolve_operation(operation.operation, precheck_queries, self, request_context)
-                        .await?,
-                ))
-            }
+            Some(Ok(operation)) => Ok(Some(
+                resolve_operation(operation, self, request_context).await?,
+            )),
             Some(Err(e)) => Err(e.into()),
             None => Ok(None),
         }
@@ -134,47 +116,4 @@ impl SubsystemGraphQLResolver for PostgresSubsystemResolver {
     fn schema_types(&self) -> Vec<TypeDefinition> {
         self.subsystem.schema_types()
     }
-}
-
-fn create_precheck_query(
-    predicate: AbstractPredicate,
-) -> Result<AbstractSelect, PostgresExecutionError> {
-    let lead_table_ids: Vec<_> = predicate
-        .column_paths()
-        .iter()
-        .filter_map(|path| match path {
-            ColumnPath::Physical(physical_path) => Some(physical_path.lead_table_id()),
-            _ => None,
-        })
-        .collect();
-
-    let lead_table_id = match &lead_table_ids[..] {
-        [table_id] => table_id,
-        [lead_table_id, rest @ ..] => {
-            if rest.iter().all(|table_id| table_id == lead_table_id) {
-                lead_table_id
-            } else {
-                return Err(PostgresExecutionError::Generic(
-                    "Access predicates with multiple lead table ids are not supported".to_string(),
-                ));
-            }
-        }
-        [] => {
-            return Err(PostgresExecutionError::Generic(
-                "Access predicates with no lead table ids are not supported".to_string(),
-            ))
-        }
-    };
-
-    Ok(AbstractSelect {
-        table_id: *lead_table_id,
-        selection: exo_sql::Selection::Seq(vec![AliasedSelectionElement::new(
-            "access_predicate".to_string(),
-            SelectionElement::Constant("true".to_string()),
-        )]),
-        predicate,
-        order_by: None,
-        offset: None,
-        limit: None,
-    })
 }

--- a/crates/postgres-subsystem/postgres-rest-resolver/src/resolver.rs
+++ b/crates/postgres-subsystem/postgres-rest-resolver/src/resolver.rs
@@ -52,7 +52,7 @@ impl SubsystemRestResolver for PostgresSubsystemRestResolver {
             let mut result = self
                 .executor
                 .execute(
-                    &operation,
+                    operation,
                     &mut tx,
                     &self.subsystem.core_subsystem.as_ref().database,
                 )

--- a/libs/exo-sql/src/asql/database_executor.rs
+++ b/libs/exo-sql/src/asql/database_executor.rs
@@ -34,7 +34,7 @@ impl DatabaseExecutor {
     /// Currently makes a hard assumption on Postgres implementation, but this could be made more generic.
     pub async fn execute(
         &self,
-        operation: &AbstractOperation,
+        operation: AbstractOperation,
         tx_holder: &mut TransactionHolder,
         database: &Database,
     ) -> Result<TransactionStepResult, DatabaseError> {

--- a/libs/exo-sql/src/asql/delete.rs
+++ b/libs/exo-sql/src/asql/delete.rs
@@ -20,4 +20,7 @@ pub struct AbstractDelete {
     pub predicate: AbstractPredicate,
     /// The selection to return
     pub selection: AbstractSelect,
+
+    /// The precheck predicates to run before deleting
+    pub precheck_predicates: Vec<AbstractPredicate>,
 }

--- a/libs/exo-sql/src/asql/insert.rs
+++ b/libs/exo-sql/src/asql/insert.rs
@@ -46,10 +46,10 @@ pub struct InsertionRow {
 impl InsertionRow {
     /// Partitions the elements into two groups: those that are inserted into
     /// the table itself, and those that are inserted into nested tables.
-    pub fn partition_self_and_nested(&self) -> (Vec<&ColumnValuePair>, Vec<&NestedInsertion>) {
+    pub fn partition_self_and_nested(self) -> (Vec<ColumnValuePair>, Vec<NestedInsertion>) {
         let mut self_elems = Vec::new();
         let mut nested_elems = Vec::new();
-        for elem in &self.elems {
+        for elem in self.elems {
             match elem {
                 InsertionElement::SelfInsert(pair) => self_elems.push(pair),
                 InsertionElement::NestedInsert(nested) => nested_elems.push(nested),

--- a/libs/exo-sql/src/asql/insert.rs
+++ b/libs/exo-sql/src/asql/insert.rs
@@ -25,7 +25,7 @@
 
 use super::select::AbstractSelect;
 use crate::sql::column::Column;
-use crate::{ColumnId, OneToManyId, TableId};
+use crate::{AbstractPredicate, ColumnId, OneToManyId, TableId};
 
 #[derive(Debug)]
 pub struct AbstractInsert {
@@ -35,6 +35,8 @@ pub struct AbstractInsert {
     pub rows: Vec<InsertionRow>,
     /// The selection to return
     pub selection: AbstractSelect,
+    /// Check to run before inserting (if the resulting select returns 1 row, then the precheck passes)
+    pub precheck_predicates: Vec<AbstractPredicate>,
 }
 
 /// A logical row to be inserted (see `InsertionElement` for more details).
@@ -64,6 +66,7 @@ pub struct NestedInsertion {
     /// The relation with the parent element (the self_pk_column_id is the parent table's pk column and the self_column_id is the column in the table being inserted that refers to the the parent table)
     pub relation_id: OneToManyId,
     pub insertions: Vec<InsertionRow>,
+    pub precheck_predicates: Vec<AbstractPredicate>,
 }
 
 /// A pair of column and value to be inserted into the table.

--- a/libs/exo-sql/src/asql/update.rs
+++ b/libs/exo-sql/src/asql/update.rs
@@ -75,6 +75,9 @@ pub struct AbstractUpdate {
 
     /// The selection to return
     pub selection: AbstractSelect,
+
+    /// Check to run before inserting (if the resulting select returns 1 row, then the precheck passes)
+    pub precheck_predicates: Vec<AbstractPredicate>,
 }
 
 /// In our example, the `update: [{id: 100, artist: {id: 10}, rank: 2}, {id: 101, artist: {id: 10}, role: "accompanying"}]` part

--- a/libs/exo-sql/src/database_error.rs
+++ b/libs/exo-sql/src/database_error.rs
@@ -40,6 +40,9 @@ pub enum DatabaseError {
     #[error("{0}")]
     BoxedError(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
 
+    #[error("Precheck: {0}")]
+    Precheck(String),
+
     #[error("{0}")]
     Generic(String),
 }

--- a/libs/exo-sql/src/sql/update.rs
+++ b/libs/exo-sql/src/sql/update.rs
@@ -85,7 +85,7 @@ pub struct TemplateUpdate<'a> {
     pub table: &'a PhysicalTable,
     pub predicate: ConcretePredicate,
     pub nesting_relation: OneToMany,
-    pub column_values: Vec<(&'a PhysicalColumn, &'a Column)>,
+    pub column_values: Vec<(&'a PhysicalColumn, Column)>,
     pub returning: Vec<Column>,
 }
 
@@ -106,7 +106,7 @@ impl<'a> TemplateUpdate<'a> {
                     .column_values
                     .iter()
                     .map(|(physical_col, col)| {
-                        let resolved_col = (*col).into();
+                        let resolved_col = col.into();
                         (*physical_col, resolved_col)
                     })
                     .collect();

--- a/libs/exo-sql/src/transform/pg/delete/cte_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/delete/cte_strategy.rs
@@ -39,7 +39,7 @@ impl DeleteStrategy for CteStrategy {
 
     fn update_transaction_script<'a>(
         &self,
-        abstract_delete: &'a AbstractDelete,
+        abstract_delete: AbstractDelete,
         database: &'a Database,
         transformer: &Postgres,
         transaction_script: &mut TransactionScript<'a>,
@@ -53,7 +53,7 @@ impl DeleteStrategy for CteStrategy {
 }
 
 fn to_delete<'a>(
-    abstract_delete: &'a AbstractDelete,
+    abstract_delete: AbstractDelete,
     database: &'a Database,
     transformer: &Postgres,
 ) -> WithQuery<'a> {
@@ -92,7 +92,7 @@ fn to_delete<'a>(
     );
 
     // The select (often a json aggregation)
-    let select = transformer.to_select(&abstract_delete.selection, database);
+    let select = transformer.to_select(abstract_delete.selection, database);
 
     // A WITH query that uses the `root_delete` as a CTE and then selects from it.
     // `WITH "concerts" AS <the delete above> <the select above>`. For example:
@@ -147,7 +147,7 @@ mod tests {
                     predicate: Predicate::True,
                 };
 
-                let delete = to_delete(&adelete, &database, &Postgres {});
+                let delete = to_delete(adelete, &database, &Postgres {});
                 assert_binding!(
                     delete.to_sql(&database),
                     r#"WITH "concerts" AS (DELETE FROM "concerts" RETURNING *) SELECT "concerts"."id" FROM "concerts""#
@@ -187,7 +187,7 @@ mod tests {
                     predicate,
                 };
 
-                let delete = to_delete(&adelete, &database, &Postgres {});
+                let delete = to_delete(adelete, &database, &Postgres {});
 
                 assert_binding!(
                     delete.to_sql(&database),
@@ -233,7 +233,7 @@ mod tests {
                     predicate,
                 };
 
-                let delete = to_delete(&adelete, &database, &Postgres {});
+                let delete = to_delete(adelete, &database, &Postgres {});
 
                 assert_binding!(
                     delete.to_sql(&database),

--- a/libs/exo-sql/src/transform/pg/delete/delete_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/delete/delete_strategy.rs
@@ -21,7 +21,7 @@ pub(crate) trait DeleteStrategy {
 
     fn update_transaction_script<'a>(
         &self,
-        abstract_delete: &'a AbstractDelete,
+        abstract_delete: AbstractDelete,
         database: &'a Database,
         transformer: &Postgres,
         transaction_script: &mut TransactionScript<'a>,

--- a/libs/exo-sql/src/transform/pg/delete/delete_strategy_chain.rs
+++ b/libs/exo-sql/src/transform/pg/delete/delete_strategy_chain.rs
@@ -30,7 +30,7 @@ impl<'s> DeleteStrategyChain<'s> {
     /// `TransactionScript` with steps to execute.
     pub fn update_transaction_script<'a>(
         &self,
-        abstract_delete: &'a AbstractDelete,
+        abstract_delete: AbstractDelete,
         database: &'a Database,
         transformer: &Postgres,
         transaction_script: &mut TransactionScript<'a>,
@@ -38,7 +38,7 @@ impl<'s> DeleteStrategyChain<'s> {
         let strategy = self
             .strategies
             .iter()
-            .find(|s| s.suitable(abstract_delete, database))
+            .find(|s| s.suitable(&abstract_delete, database))
             .unwrap();
 
         debug!("Using deletion strategy: {}", strategy.id());

--- a/libs/exo-sql/src/transform/pg/delete/delete_transformer.rs
+++ b/libs/exo-sql/src/transform/pg/delete/delete_transformer.rs
@@ -19,7 +19,7 @@ use super::delete_strategy_chain::DeleteStrategyChain;
 impl DeleteTransformer for Postgres {
     fn update_transaction_script<'a>(
         &self,
-        abstract_delete: &'a AbstractDelete,
+        abstract_delete: AbstractDelete,
         database: &'a Database,
         transaction_script: &mut TransactionScript<'a>,
     ) {

--- a/libs/exo-sql/src/transform/pg/insert/insert_transformer.rs
+++ b/libs/exo-sql/src/transform/pg/insert/insert_transformer.rs
@@ -32,7 +32,7 @@ use crate::{
 impl InsertTransformer for Postgres {
     fn update_transaction_script<'a>(
         &self,
-        abstract_insert: &'a AbstractInsert,
+        abstract_insert: AbstractInsert,
         parent_step: Option<(TransactionStepId, Vec<ColumnId>)>,
         database: &'a Database,
         transaction_script: &mut TransactionScript<'a>,

--- a/libs/exo-sql/src/transform/pg/insert/insertion_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/insert/insertion_strategy.rs
@@ -23,7 +23,7 @@ pub(crate) trait InsertionStrategy {
 
     fn update_transaction_script<'a>(
         &self,
-        abstract_insert: &'a AbstractInsert,
+        abstract_insert: AbstractInsert,
         parent_step: Option<(TransactionStepId, Vec<ColumnId>)>,
         database: &'a Database,
         transformer: &Postgres,

--- a/libs/exo-sql/src/transform/pg/insert/insertion_strategy_chain.rs
+++ b/libs/exo-sql/src/transform/pg/insert/insertion_strategy_chain.rs
@@ -35,7 +35,7 @@ impl<'s> InsertionStrategyChain<'s> {
     /// `TransactionScript` to execute.
     pub fn update_transaction_script<'a>(
         &self,
-        abstract_insert: &'a AbstractInsert,
+        abstract_insert: AbstractInsert,
         parent_step: Option<(TransactionStepId, Vec<ColumnId>)>,
         database: &'a Database,
         transformer: &Postgres,
@@ -44,7 +44,7 @@ impl<'s> InsertionStrategyChain<'s> {
         let strategy = self
             .strategies
             .iter()
-            .find(|s| s.suitable(abstract_insert, database))
+            .find(|s| s.suitable(&abstract_insert, database))
             .unwrap();
 
         debug!("Using insertion strategy: {}", strategy.id());

--- a/libs/exo-sql/src/transform/pg/mod.rs
+++ b/libs/exo-sql/src/transform/pg/mod.rs
@@ -12,6 +12,8 @@ mod insert;
 mod select;
 mod update;
 
+mod precheck;
+
 mod order_by_transformer;
 mod predicate_transformer;
 

--- a/libs/exo-sql/src/transform/pg/precheck.rs
+++ b/libs/exo-sql/src/transform/pg/precheck.rs
@@ -1,0 +1,80 @@
+use crate::{
+    database_error::DatabaseError,
+    sql::transaction::{TransactionScript, TransactionStep},
+    AbstractPredicate, AbstractSelect, AliasedSelectionElement, ColumnPath, Database, Selection,
+    SelectionElement,
+};
+
+use crate::transform::transformer::SelectTransformer;
+
+pub fn add_precheck_queries(
+    precheck_predicates: Vec<AbstractPredicate>,
+    database: &Database,
+    transformer: &impl SelectTransformer,
+    transaction_script: &mut TransactionScript,
+) {
+    let precheck_queries = compute_precheck_queries(precheck_predicates).unwrap();
+
+    for precheck_query in precheck_queries {
+        let precheck_select = transformer.to_select(precheck_query, database);
+        transaction_script.add_step(TransactionStep::Precheck(precheck_select));
+    }
+}
+
+fn compute_precheck_queries(
+    predicates: Vec<AbstractPredicate>,
+) -> Result<Vec<AbstractSelect>, DatabaseError> {
+    let precheck_queries: Result<Vec<_>, _> =
+        predicates.into_iter().map(compute_precheck_query).collect();
+
+    let precheck_queries = precheck_queries?;
+
+    Ok(precheck_queries.into_iter().flatten().collect())
+}
+
+fn compute_precheck_query(
+    predicate: AbstractPredicate,
+) -> Result<Option<AbstractSelect>, DatabaseError> {
+    if predicate == AbstractPredicate::True {
+        return Ok(None);
+    }
+
+    let lead_table_ids: Vec<_> = predicate
+        .column_paths()
+        .iter()
+        .filter_map(|path| match path {
+            ColumnPath::Physical(physical_path) => Some(physical_path.lead_table_id()),
+            _ => None,
+        })
+        .collect();
+
+    let lead_table_id = match &lead_table_ids[..] {
+        [table_id] => table_id,
+        [lead_table_id, rest @ ..] => {
+            if rest.iter().all(|table_id| table_id == lead_table_id) {
+                lead_table_id
+            } else {
+                return Err(DatabaseError::Precheck(
+                    "Access predicates with multiple lead table ids are not supported".to_string(),
+                ));
+            }
+        }
+        [] => {
+            return Err(DatabaseError::Precheck(
+                "Access predicates with no lead table ids are not supported".to_string(),
+            ))
+        }
+    };
+
+    Ok(Some(AbstractSelect {
+        table_id: *lead_table_id,
+        selection: Selection::Seq(vec![AliasedSelectionElement::new(
+            "access_predicate".to_string(),
+            SelectionElement::Constant("true".to_string()),
+        )]),
+        predicate: predicate.clone(),
+        order_by: None,
+        offset: None,
+        limit: None,
+    }))
+}

--- a/libs/exo-sql/src/transform/pg/predicate_transformer.rs
+++ b/libs/exo-sql/src/transform/pg/predicate_transformer.rs
@@ -205,7 +205,7 @@ fn form_subselect(
     };
 
     let select = select_transformer.compute_select(
-        &abstract_select,
+        abstract_select,
         &SelectionLevel::TopLevel,
         true, // allow duplicate rows to be returned since this is going to be used as a part of `IN`
         database,

--- a/libs/exo-sql/src/transform/pg/select/plain_subquery_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/select/plain_subquery_strategy.rs
@@ -105,7 +105,7 @@ impl SelectionStrategy for PlainSubqueryStrategy {
 
         nest_subselect(
             inner_select,
-            &abstract_select.selection,
+            abstract_select.selection,
             selection_level,
             alias_info,
             transformer,

--- a/libs/exo-sql/src/transform/pg/select/select_transformer.rs
+++ b/libs/exo-sql/src/transform/pg/select/select_transformer.rs
@@ -111,13 +111,13 @@ impl SelectTransformer for Postgres {
         name = "SelectTransformer::to_select for Postgres"
         skip(self, database)
         )]
-    fn to_select<'a>(&self, abstract_select: &AbstractSelect, database: &'a Database) -> Select {
+    fn to_select<'a>(&self, abstract_select: AbstractSelect, database: &'a Database) -> Select {
         self.compute_select(abstract_select, &SelectionLevel::TopLevel, false, database)
     }
 
     fn to_transaction_script<'a>(
         &self,
-        abstract_select: &'a AbstractSelect,
+        abstract_select: AbstractSelect,
         database: &'a Database,
     ) -> TransactionScript<'a> {
         let select = self.to_select(abstract_select, database);
@@ -134,7 +134,7 @@ impl Postgres {
     /// control over whether duplicate rows are allowed.
     pub fn compute_select(
         &self,
-        abstract_select: &AbstractSelect,
+        abstract_select: AbstractSelect,
         selection_level: &SelectionLevel,
         allow_duplicate_rows: bool,
         database: &Database,
@@ -193,7 +193,7 @@ mod tests {
                     limit: None,
                 };
 
-                let select = Postgres {}.to_select(&aselect, &database);
+                let select = Postgres {}.to_select(aselect, &database);
                 assert_binding!(
                     select.to_sql(&database),
                     r#"SELECT "concerts"."id" FROM "concerts""#
@@ -228,7 +228,7 @@ mod tests {
                     limit: None,
                 };
 
-                let select = Postgres {}.to_select(&aselect, &database);
+                let select = Postgres {}.to_select(aselect, &database);
                 assert_binding!(
                     select.to_sql(&database),
                     r#"SELECT "concerts"."id" FROM "concerts" WHERE "concerts"."id" = $1"#,
@@ -262,7 +262,7 @@ mod tests {
                     limit: None,
                 };
 
-                let select = Postgres {}.to_select(&aselect, &database);
+                let select = Postgres {}.to_select(aselect, &database);
                 assert_binding!(
                     select.to_sql(&database),
                     r#"SELECT COALESCE(json_agg(json_build_object('id', "concerts"."id")), '[]'::json)::text FROM "concerts""#
@@ -330,7 +330,7 @@ mod tests {
                     limit: None,
                 };
 
-                let select = Postgres {}.to_select(&aselect, &database);
+                let select = Postgres {}.to_select(aselect, &database);
                 assert_binding!(
                     select.to_sql(&database),
                     r#"SELECT COALESCE(json_agg(json_build_object('id', "concerts"."id", 'venue', (SELECT json_build_object('id', "venues"."id") FROM "venues" WHERE "venues"."id" = "concerts"."venue_id"))), '[]'::json)::text FROM "concerts""#
@@ -392,7 +392,7 @@ mod tests {
                     limit: None,
                 };
 
-                let select = Postgres {}.to_select(&aselect, &database);
+                let select = Postgres {}.to_select(aselect, &database);
                 assert_binding!(
                     select.to_sql(&database),
                     r#"SELECT COALESCE(json_agg(json_build_object('id', "venues"."id", 'concerts', (SELECT COALESCE(json_agg(json_build_object('id', "concerts"."id")), '[]'::json) FROM "concerts" WHERE "venues"."id" = "concerts"."venue_id"))), '[]'::json)::text FROM "venues""#
@@ -462,7 +462,7 @@ mod tests {
                     limit: None,
                 };
 
-                let select = Postgres {}.to_select(&aselect, &database);
+                let select = Postgres {}.to_select(aselect, &database);
                 assert_binding!(
                     select.to_sql(&database),
                     r#"SELECT COALESCE(json_agg(json_build_object('id', "venues"."id", 'concerts', (SELECT COALESCE(json_agg(json_build_object('id', "concerts"."id")), '[]'::json) FROM "concerts" LEFT JOIN "venues" AS "venues$venues" ON "concerts"."venue_id" = "venues$venues"."id" WHERE ("venues$venues"."id" = $1 AND "venues"."id" = "concerts"."venue_id")))), '[]'::json)::text FROM "venues""#,
@@ -510,7 +510,7 @@ mod tests {
                     limit: None,
                 };
 
-                let select = Postgres {}.to_select(&aselect, &database);
+                let select = Postgres {}.to_select(aselect, &database);
                 assert_binding!(
                     select.to_sql(&database),
                     r#"SELECT COALESCE(json_agg(json_build_object('id', "concerts"."id")), '[]'::json)::text FROM "concerts" LEFT JOIN "venues" ON "concerts"."venue_id" = "venues"."id" WHERE "venues"."name" = $1"#,
@@ -547,7 +547,7 @@ mod tests {
                     limit: None,
                 };
 
-                let select = Postgres {}.to_select(&aselect, &database);
+                let select = Postgres {}.to_select(aselect, &database);
                 assert_binding!(
                     select.to_sql(&database),
                     r#"SELECT "concerts"."id" FROM "concerts" ORDER BY "concerts"."name" ASC"#
@@ -584,7 +584,7 @@ mod tests {
                     limit: Some(Limit(20)),
                 };
 
-                let select = Postgres {}.to_select(&aselect, &database);
+                let select = Postgres {}.to_select(aselect, &database);
                 assert_binding!(
                     select.to_sql(&database),
                     r#"SELECT "concerts"."id" FROM "concerts" WHERE "concerts"."name" = $1 LIMIT $2 OFFSET $3"#,
@@ -627,7 +627,7 @@ mod tests {
                     limit: None,
                 };
 
-                let select = Postgres {}.to_select(&aselect, &database);
+                let select = Postgres {}.to_select(aselect, &database);
                 assert_binding!(
                     select.to_sql(&database),
                     r#"SELECT "concerts"."id" FROM "concerts" LEFT JOIN "venues" ON "concerts"."venue_id" = "venues"."id" ORDER BY "venues"."name" ASC"#

--- a/libs/exo-sql/src/transform/pg/select/selection.rs
+++ b/libs/exo-sql/src/transform/pg/select/selection.rs
@@ -23,14 +23,14 @@ pub enum SelectionSQL {
 
 impl Selection {
     pub fn to_sql(
-        &self,
+        self,
         selection_level: &SelectionLevel,
         select_transformer: &Postgres,
         database: &Database,
     ) -> SelectionSQL {
         match self {
             Selection::Seq(seq) => SelectionSQL::Seq(
-                seq.iter()
+                seq.into_iter()
                     .map(
                         |AliasedSelectionElement {
                              alias: _alias,
@@ -43,7 +43,7 @@ impl Selection {
             ),
             Selection::Json(seq, cardinality) => {
                 let object_elems = seq
-                    .iter()
+                    .into_iter()
                     .map(|AliasedSelectionElement { alias, column }| {
                         JsonObjectElement::new(
                             alias.clone(),
@@ -65,7 +65,7 @@ impl Selection {
     }
 
     pub fn selection_aggregate(
-        &self,
+        self,
         selection_level: &SelectionLevel,
         select_transformer: &Postgres,
         database: &Database,
@@ -79,18 +79,18 @@ impl Selection {
 
 impl SelectionElement {
     pub fn to_sql(
-        &self,
+        self,
         selection_level: &SelectionLevel,
         transformer: &Postgres,
         database: &Database,
     ) -> Column {
         match self {
-            SelectionElement::Physical(column_id) => Column::physical(*column_id, None),
+            SelectionElement::Physical(column_id) => Column::physical(column_id, None),
             SelectionElement::Function(function) => Column::Function(function.clone()),
             SelectionElement::Constant(s) => Column::Constant(s.clone()),
             SelectionElement::Object(elements) => {
                 let elements = elements
-                    .iter()
+                    .into_iter()
                     .map(|(alias, column)| {
                         JsonObjectElement::new(
                             alias.to_owned(),
@@ -101,7 +101,7 @@ impl SelectionElement {
                 Column::JsonObject(JsonObject(elements))
             }
             SelectionElement::SubSelect(relation_id, select) => {
-                let new_selection_level = selection_level.with_relation_id(*relation_id);
+                let new_selection_level = selection_level.with_relation_id(relation_id);
                 Column::SubSelect(Box::new(transformer.compute_select(
                     select,
                     &new_selection_level,

--- a/libs/exo-sql/src/transform/pg/select/selection_context.rs
+++ b/libs/exo-sql/src/transform/pg/select/selection_context.rs
@@ -15,7 +15,7 @@ use crate::{
 /// A context for the selection transformation to avoid repeating the same work
 /// by each strategy.
 pub(crate) struct SelectionContext<'c> {
-    pub abstract_select: &'c AbstractSelect,
+    pub abstract_select: AbstractSelect,
     pub has_a_one_to_many_predicate: bool,
     pub predicate_column_paths: Vec<PhysicalColumnPath>,
     pub order_by_column_paths: Vec<PhysicalColumnPath>,
@@ -27,7 +27,7 @@ pub(crate) struct SelectionContext<'c> {
 impl<'c> SelectionContext<'c> {
     pub fn new(
         database: &Database,
-        abstract_select: &'c AbstractSelect,
+        abstract_select: AbstractSelect,
         selection_level: &'c SelectionLevel,
         allow_duplicate_rows: bool,
         transformer: &'c Postgres,

--- a/libs/exo-sql/src/transform/pg/select/selection_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/select/selection_strategy.rs
@@ -77,7 +77,7 @@ pub(super) fn compute_inner_select(
 /// Compute a nested version of the given inner select, with the given selection applied.
 pub(super) fn nest_subselect(
     inner_select: Select,
-    selection: &Selection,
+    selection: Selection,
     selection_level: &SelectionLevel,
     alias: (String, PhysicalTableName),
     transformer: &Postgres,

--- a/libs/exo-sql/src/transform/pg/select/subquery_with_in_predicate_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/select/subquery_with_in_predicate_strategy.rs
@@ -162,7 +162,7 @@ impl SelectionStrategy for SubqueryWithInPredicateStrategy {
 
         nest_subselect(
             inner_select,
-            &abstract_select.selection,
+            abstract_select.selection,
             selection_level,
             alias_info,
             transformer,

--- a/libs/exo-sql/src/transform/pg/update/cte_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/update/cte_strategy.rs
@@ -7,7 +7,7 @@ use crate::{
         transaction::{ConcreteTransactionStep, TransactionScript, TransactionStep},
     },
     transform::{
-        pg::{selection_level::SelectionLevel, Postgres},
+        pg::{precheck::add_precheck_queries, selection_level::SelectionLevel, Postgres},
         transformer::{PredicateTransformer, SelectTransformer},
     },
     AbstractUpdate, Column, Database, PhysicalColumn,
@@ -47,6 +47,13 @@ impl UpdateStrategy for CteStrategy {
         transformer: &Postgres,
         transaction_script: &mut TransactionScript<'a>,
     ) {
+        add_precheck_queries(
+            abstract_update.precheck_predicates,
+            database,
+            transformer,
+            transaction_script,
+        );
+
         let table = database.get_table(abstract_update.table_id);
 
         let column_values: Vec<(&'a PhysicalColumn, MaybeOwned<'a, Column>)> = abstract_update

--- a/libs/exo-sql/src/transform/pg/update/cte_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/update/cte_strategy.rs
@@ -42,7 +42,7 @@ impl UpdateStrategy for CteStrategy {
 
     fn update_transaction_script<'a>(
         &self,
-        abstract_update: &'a AbstractUpdate,
+        abstract_update: AbstractUpdate,
         database: &'a Database,
         transformer: &Postgres,
         transaction_script: &mut TransactionScript<'a>,
@@ -51,7 +51,7 @@ impl UpdateStrategy for CteStrategy {
 
         let column_values: Vec<(&'a PhysicalColumn, MaybeOwned<'a, Column>)> = abstract_update
             .column_values
-            .iter()
+            .into_iter()
             .map(|(col_id, v)| (col_id.get_column(database), v.into()))
             .collect();
 
@@ -68,7 +68,7 @@ impl UpdateStrategy for CteStrategy {
             vec![Column::Star(None).into()],
         ));
 
-        let select = transformer.to_select(&abstract_update.selection, database);
+        let select = transformer.to_select(abstract_update.selection, database);
 
         let table_name = &database.get_table(abstract_update.table_id).name;
 

--- a/libs/exo-sql/src/transform/pg/update/multi_statement_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/update/multi_statement_strategy.rs
@@ -22,7 +22,10 @@ use crate::{
         },
         update::TemplateUpdate,
     },
-    transform::transformer::{InsertTransformer, PredicateTransformer},
+    transform::{
+        pg::precheck::add_precheck_queries,
+        transformer::{InsertTransformer, PredicateTransformer},
+    },
     ColumnId, NestedAbstractDelete, NestedAbstractInsert, NestedAbstractInsertSet,
     NestedAbstractUpdate, PhysicalColumn, Predicate, SQLParamContainer,
 };
@@ -75,6 +78,13 @@ impl UpdateStrategy for MultiStatementStrategy {
         transformer: &Postgres,
         transaction_script: &mut TransactionScript<'a>,
     ) {
+        add_precheck_queries(
+            abstract_update.precheck_predicates,
+            database,
+            transformer,
+            transaction_script,
+        );
+
         let predicate = transformer.to_predicate(
             &abstract_update.predicate,
             &SelectionLevel::TopLevel,
@@ -374,6 +384,7 @@ mod tests {
                         offset: None,
                         limit: None,
                     },
+                    precheck_predicates: vec![],
                 };
 
                 let update =
@@ -429,6 +440,7 @@ mod tests {
                         nested_updates: vec![],
                         nested_inserts: vec![],
                         nested_deletes: vec![],
+                        precheck_predicates: vec![],
                     },
                 };
 
@@ -459,6 +471,7 @@ mod tests {
                         offset: None,
                         limit: None,
                     },
+                    precheck_predicates: vec![],
                 };
 
                 let update =

--- a/libs/exo-sql/src/transform/pg/update/multi_statement_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/update/multi_statement_strategy.rs
@@ -70,7 +70,7 @@ impl UpdateStrategy for MultiStatementStrategy {
     /// ```
     fn update_transaction_script<'a>(
         &self,
-        abstract_update: &'a AbstractUpdate,
+        abstract_update: AbstractUpdate,
         database: &'a Database,
         transformer: &Postgres,
         transaction_script: &mut TransactionScript<'a>,
@@ -110,8 +110,8 @@ impl UpdateStrategy for MultiStatementStrategy {
         } else {
             let column_id_values: Vec<(ColumnId, MaybeOwned<'a, Column>)> = abstract_update
                 .column_values
-                .iter()
-                .map(|(c, v)| (*c, v.into()))
+                .into_iter()
+                .map(|(c, v)| (c, v.into()))
                 .collect();
 
             let column_values = column_id_values
@@ -131,7 +131,7 @@ impl UpdateStrategy for MultiStatementStrategy {
 
         abstract_update
             .nested_updates
-            .iter()
+            .into_iter()
             .for_each(|nested_update| {
                 // Create a template update operation and bind it to the root step
                 let update_op = TemplateTransactionStep {
@@ -142,13 +142,13 @@ impl UpdateStrategy for MultiStatementStrategy {
                 let _ = transaction_script.add_step(TransactionStep::Template(update_op));
             });
 
-        abstract_update.nested_inserts.iter().for_each(
+        abstract_update.nested_inserts.into_iter().for_each(
             |NestedAbstractInsertSet {
                  ops,
                  filter_predicate,
              }| {
                 let filter_step_predicate = transformer.to_predicate(
-                    filter_predicate,
+                    &filter_predicate,
                     &SelectionLevel::TopLevel,
                     false,
                     database,
@@ -175,7 +175,7 @@ impl UpdateStrategy for MultiStatementStrategy {
 
         abstract_update
             .nested_deletes
-            .iter()
+            .into_iter()
             .for_each(|nested_delete| {
                 let delete_op = TemplateTransactionStep {
                     operation: delete_op(nested_delete, transformer, database),
@@ -185,7 +185,7 @@ impl UpdateStrategy for MultiStatementStrategy {
                 let _ = transaction_script.add_step(TransactionStep::Template(delete_op));
             });
 
-        let select = transformer.to_select(&abstract_update.selection, database);
+        let select = transformer.to_select(abstract_update.selection, database);
 
         let table_id = abstract_update.table_id;
 
@@ -248,14 +248,14 @@ impl UpdateStrategy for MultiStatementStrategy {
 }
 
 fn update_op<'a>(
-    nested_update: &'a NestedAbstractUpdate,
+    nested_update: NestedAbstractUpdate,
     predicate_transformer: &impl PredicateTransformer,
     database: &'a Database,
 ) -> TemplateSQLOperation<'a> {
-    let column_values: Vec<(&PhysicalColumn, &Column)> = nested_update
+    let column_values: Vec<(&PhysicalColumn, Column)> = nested_update
         .update
         .column_values
-        .iter()
+        .into_iter()
         .map(|(col_id, col)| (col_id.get_column(database), col))
         .collect();
 
@@ -274,7 +274,7 @@ fn update_op<'a>(
 }
 
 fn add_insert_steps<'a>(
-    nested_insert: &'a NestedAbstractInsert,
+    nested_insert: NestedAbstractInsert,
     parent_step_id: TransactionStepId,
     database: &'a Database,
     transformer: &Postgres,
@@ -294,7 +294,7 @@ fn add_insert_steps<'a>(
 }
 
 fn delete_op<'a>(
-    nested_delete: &'a NestedAbstractDelete,
+    nested_delete: NestedAbstractDelete,
     predicate_transformer: &impl PredicateTransformer,
     database: &'a Database,
 ) -> TemplateSQLOperation<'a> {
@@ -377,7 +377,7 @@ mod tests {
                 };
 
                 let update =
-                    UpdateTransformer::to_transaction_script(&Postgres {}, &abs_update, &database);
+                    UpdateTransformer::to_transaction_script(&Postgres {}, abs_update, &database);
 
                 // TODO: Add a proper assertion here (ideally, we can get a digest of the transaction script and assert on it)
                 println!("{update:#?}");
@@ -462,7 +462,7 @@ mod tests {
                 };
 
                 let update =
-                    UpdateTransformer::to_transaction_script(&Postgres {}, &abs_update, &database);
+                    UpdateTransformer::to_transaction_script(&Postgres {}, abs_update, &database);
 
                 // TODO: Add a proper assertion here (ideally, we can get a digest of the transaction script and assert on it)
                 println!("{update:#?}");

--- a/libs/exo-sql/src/transform/pg/update/update_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/update/update_strategy.rs
@@ -21,7 +21,7 @@ pub(crate) trait UpdateStrategy {
 
     fn update_transaction_script<'a>(
         &self,
-        abstract_update: &'a AbstractUpdate,
+        abstract_update: AbstractUpdate,
         database: &'a Database,
         transformer: &Postgres,
         transaction_script: &mut TransactionScript<'a>,

--- a/libs/exo-sql/src/transform/pg/update/update_strategy_chain.rs
+++ b/libs/exo-sql/src/transform/pg/update/update_strategy_chain.rs
@@ -33,7 +33,7 @@ impl<'s> UpdateStrategyChain<'s> {
     /// `TransactionScript` with steps to execute.
     pub fn update_transaction_script<'a>(
         &self,
-        abstract_update: &'a AbstractUpdate,
+        abstract_update: AbstractUpdate,
         database: &'a Database,
         transformer: &Postgres,
         transaction_script: &mut TransactionScript<'a>,
@@ -41,7 +41,7 @@ impl<'s> UpdateStrategyChain<'s> {
         let strategy = self
             .strategies
             .iter()
-            .find(|s| s.suitable(abstract_update, database))
+            .find(|s| s.suitable(&abstract_update, database))
             .unwrap();
 
         debug!("Using update strategy: {}", strategy.id());

--- a/libs/exo-sql/src/transform/pg/update/update_transformer.rs
+++ b/libs/exo-sql/src/transform/pg/update/update_transformer.rs
@@ -43,7 +43,7 @@ impl UpdateTransformer for Postgres {
         )]
     fn update_transaction_script<'a>(
         &self,
-        abstract_update: &'a AbstractUpdate,
+        abstract_update: AbstractUpdate,
         database: &'a Database,
         transaction_script: &mut TransactionScript<'a>,
     ) {

--- a/libs/exo-sql/src/transform/transformer.rs
+++ b/libs/exo-sql/src/transform/transformer.rs
@@ -30,7 +30,7 @@ pub trait OperationTransformer {
     fn to_transaction_script<'a>(
         &self,
         database: &'a Database,
-        abstract_operation: &'a AbstractOperation,
+        abstract_operation: AbstractOperation,
     ) -> TransactionScript<'a>;
 }
 
@@ -38,7 +38,7 @@ impl OperationTransformer for Postgres {
     fn to_transaction_script<'a>(
         &self,
         database: &'a Database,
-        abstract_operation: &'a AbstractOperation,
+        abstract_operation: AbstractOperation,
     ) -> TransactionScript<'a> {
         match abstract_operation {
             AbstractOperation::Select(select) => {
@@ -58,11 +58,11 @@ impl OperationTransformer for Postgres {
 }
 
 pub trait SelectTransformer {
-    fn to_select(&self, abstract_select: &AbstractSelect, database: &Database) -> Select;
+    fn to_select(&self, abstract_select: AbstractSelect, database: &Database) -> Select;
 
     fn to_transaction_script<'a>(
         &self,
-        abstract_select: &'a AbstractSelect,
+        abstract_select: AbstractSelect,
         database: &'a Database,
     ) -> TransactionScript<'a>;
 }
@@ -74,7 +74,7 @@ pub trait DeleteTransformer {
         )]
     fn to_transaction_script<'a>(
         &self,
-        abstract_delete: &'a AbstractDelete,
+        abstract_delete: AbstractDelete,
         database: &'a Database,
     ) -> TransactionScript<'a> {
         let mut transaction_script = TransactionScript::default();
@@ -86,7 +86,7 @@ pub trait DeleteTransformer {
 
     fn update_transaction_script<'a>(
         &self,
-        abstract_delete: &'a AbstractDelete,
+        abstract_delete: AbstractDelete,
         database: &'a Database,
         transaction_script: &mut TransactionScript<'a>,
     );
@@ -99,7 +99,7 @@ pub trait InsertTransformer {
         )]
     fn to_transaction_script<'a>(
         &self,
-        abstract_insert: &'a AbstractInsert,
+        abstract_insert: AbstractInsert,
         parent_step: Option<(TransactionStepId, Vec<ColumnId>)>,
         database: &'a Database,
     ) -> TransactionScript<'a> {
@@ -117,7 +117,7 @@ pub trait InsertTransformer {
 
     fn update_transaction_script<'a>(
         &self,
-        abstract_insert: &'a AbstractInsert,
+        abstract_insert: AbstractInsert,
         parent_step: Option<(TransactionStepId, Vec<ColumnId>)>,
         database: &'a Database,
         transaction_script: &mut TransactionScript<'a>,
@@ -131,7 +131,7 @@ pub trait UpdateTransformer {
         )]
     fn to_transaction_script<'a>(
         &self,
-        abstract_update: &'a AbstractUpdate,
+        abstract_update: AbstractUpdate,
         database: &'a Database,
     ) -> TransactionScript<'a> {
         let mut transaction_script = TransactionScript::default();
@@ -143,7 +143,7 @@ pub trait UpdateTransformer {
 
     fn update_transaction_script<'a>(
         &self,
-        abstract_update: &'a AbstractUpdate,
+        abstract_update: AbstractUpdate,
         database: &'a Database,
         transaction_script: &mut TransactionScript<'a>,
     );


### PR DESCRIPTION
This allows exo-sql to optimize (for example, by using a CTE).