### PR TITLE
Support invariants in integration tests

### DIFF
--- a/crates/testing/src/model/mod.rs
+++ b/crates/testing/src/model/mod.rs
@@ -51,4 +51,10 @@ pub struct ApiOperation {
     pub headers: Option<String>, // stringified
 
     pub expected_response: Option<String>, // stringified
+    pub invariants: Vec<ApiOperationInvariant>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ApiOperationInvariant {
+    pub operation: ApiOperation,
 }

--- a/integration-tests/create-access-residue/tests/invalid-creation-different-user.exotest
+++ b/integration-tests/create-access-residue/tests/invalid-creation-different-user.exotest
@@ -1,3 +1,5 @@
+invariants:
+  - path: system-state.gql
 operation: |
   mutation($uId: Int!) {
       createIssue(data: {title: "I-new", assignee: {id: $uId}}) {

--- a/integration-tests/create-access-residue/tests/invalid-creation-non-developer-assignment.exotest
+++ b/integration-tests/create-access-residue/tests/invalid-creation-non-developer-assignment.exotest
@@ -1,3 +1,5 @@
+invariants:
+  - path: system-state.gql
 operation: |
   mutation($uId: Int!) {
       createIssue(data: {title: "I-new", assignee: {id: $uId}}) {

--- a/integration-tests/create-access-residue/tests/invalid-update-non-developer-assignment.exotest
+++ b/integration-tests/create-access-residue/tests/invalid-update-non-developer-assignment.exotest
@@ -1,3 +1,5 @@
+invariants:
+  - path: system-state.gql
 operation: |
   mutation($issueId: Int!, $uId: Int!) {
       updateIssue(id: $issueId, data: {title: "I1-updated", assignee: {id: $uId}}) {

--- a/integration-tests/create-access-residue/tests/system-state.gql
+++ b/integration-tests/create-access-residue/tests/system-state.gql
@@ -1,0 +1,25 @@
+operation: |
+  query {
+    issues {
+      id
+      title
+      assignee {
+        id
+        name
+        position
+      }
+    }
+    employees {
+      id
+      name
+      position
+      issues {
+        id
+        title
+      }
+    }
+  }
+auth: |
+  {
+    "role": "admin"
+  }


### PR DESCRIPTION
We often want to ensure that the system remains in the same state as before the operation, especially when testing access control rejection with mutations. While this can be done using multi-stage tests, it gets cumbersome.

We now support invariants and operations executed before and after the test.

```
invariants:
  - path: system-state.gql
operation: |
  mutation {
      createProduct(data: {name: "P1", price: 100}) {
          id
      }
  }
auth: |
  {
      "role": "user"
  }
...
```

The format for the invariant file is the same as the init files.