### PR TITLE
Consider the --allow-destructive-changes flag

### DIFF
--- a/crates/cli/src/commands/schema/migrate.rs
+++ b/crates/cli/src/commands/schema/migrate.rs
@@ -78,12 +78,10 @@ impl CommandDefinition for MigrateCommandDefinition {
                 .await?;
 
         if apply_to_database {
-            if migrations.has_destructive_changes() {
-                Err(anyhow!("Migration contains destructive changes"))
-            } else {
-                migrations.apply(&db_client, false).await?;
-                Ok(())
-            }
+            migrations
+                .apply(&db_client, allow_destructive_changes)
+                .await?;
+            Ok(())
         } else {
             let mut buffer: Box<dyn io::Write> = open_file_for_output(output.as_deref())?;
             migrations.write(&mut buffer, allow_destructive_changes)?;


### PR DESCRIPTION
When applying changes to the database, we had ignored the --allow-destructive-changes flag (by issuing an error for any destructive changes)

```
> exo schema migrate --allow-destructive-changes --apply-to-database
Error: Migration contains destructive changes
```

This commit removes the check in the migrate command and passes the flag along to the `Migration::apply` method, which correctly uses it.

Fixes #1479