### PR TITLE
Use the default value if any when evaluating access control expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6908,6 +6908,7 @@ dependencies = [
  "futures",
  "http 1.1.0",
  "indexmap 2.7.0",
+ "maybe-owned",
  "postgres-builder",
  "postgres-core-model",
  "postgres-core-resolver",

--- a/crates/postgres-subsystem/postgres-core-builder/src/access/snapshots/postgres_core_builder__access__precheck_builder__tests__direct_field.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/access/snapshots/postgres_core_builder__access__precheck_builder__tests__direct_field.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/postgres-subsystem/postgres-core-builder/src/access/precheck_builder.rs
-assertion_line: 640
 expression: selection
 ---
 Path:
@@ -12,7 +11,8 @@ Path:
           column_index: 0
     field_path:
       Normal:
-        - id
+        - - id
+        - AutoIncrement
   - Plain:
       type_id:
         Primitive:

--- a/crates/postgres-subsystem/postgres-core-builder/src/access/snapshots/postgres_core_builder__access__precheck_builder__tests__hof_call.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/access/snapshots/postgres_core_builder__access__precheck_builder__tests__hof_call.snap
@@ -26,7 +26,8 @@ Function:
           _phantom: ~
     field_path:
       Normal:
-        - issues
+        - - issues
+        - ~
   - name: some
     parameter_name: i
     expr:
@@ -41,7 +42,8 @@ Function:
                       column_index: 1
                 field_path:
                   Normal:
-                    - title
+                    - - title
+                    - ~
               - i
           - Common:
               ContextSelection:

--- a/crates/postgres-subsystem/postgres-core-builder/src/access/snapshots/postgres_core_builder__access__precheck_builder__tests__hof_call_predicate.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/access/snapshots/postgres_core_builder__access__precheck_builder__tests__hof_call_predicate.snap
@@ -28,7 +28,8 @@ RelationalOp:
                 _phantom: ~
           field_path:
             Normal:
-              - issues
+              - - issues
+              - ~
         - name: some
           parameter_name: i
           expr:
@@ -43,7 +44,8 @@ RelationalOp:
                             column_index: 1
                       field_path:
                         Normal:
-                          - title
+                          - - title
+                          - ~
                     - i
                 - Common:
                     ContextSelection:

--- a/crates/postgres-subsystem/postgres-core-builder/src/access/snapshots/postgres_core_builder__access__precheck_builder__tests__many_to_one_non_pk_field.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/access/snapshots/postgres_core_builder__access__precheck_builder__tests__many_to_one_non_pk_field.snap
@@ -33,6 +33,7 @@ Path:
       Pk:
         lead:
           - assignee
+        lead_default: ~
         pk_fields:
           - id
   - Plain:

--- a/crates/postgres-subsystem/postgres-core-builder/src/access/snapshots/postgres_core_builder__access__precheck_builder__tests__many_to_one_pk_field.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/access/snapshots/postgres_core_builder__access__precheck_builder__tests__many_to_one_pk_field.snap
@@ -31,8 +31,9 @@ Path:
           column_index: 0
     field_path:
       Normal:
-        - assignee
-        - id
+        - - assignee
+          - id
+        - AutoIncrement
   - Plain:
       type_id:
         Primitive:

--- a/crates/postgres-subsystem/postgres-core-builder/src/access/snapshots/postgres_core_builder__access__precheck_builder__tests__many_to_one_predicate.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/access/snapshots/postgres_core_builder__access__precheck_builder__tests__many_to_one_predicate.snap
@@ -35,6 +35,7 @@ RelationalOp:
             Pk:
               lead:
                 - assignee
+              lead_default: ~
               pk_fields:
                 - id
         - ~

--- a/crates/postgres-subsystem/postgres-graphql-resolver/Cargo.toml
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/Cargo.toml
@@ -14,6 +14,7 @@ futures.workspace = true
 indexmap.workspace = true
 serde_json = { workspace = true, features = ["preserve_order"] }
 tokio.workspace = true
+maybe-owned.workspace = true
 
 exo-sql = { path = "../../../libs/exo-sql" }
 exo-env = { path = "../../../libs/exo-env" }

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/create_data_param_mapper.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/create_data_param_mapper.rs
@@ -117,7 +117,7 @@ async fn map_single<'a>(
         request_context,
         Some(&AccessInput {
             value: argument,
-            ignore_missing_value: false,
+            ignore_missing_value: true,
             aliases: HashMap::new(),
         }),
     )

--- a/integration-tests/field-access/with-residue/tests/mutation/create-with-disallowed.exotest
+++ b/integration-tests/field-access/with-residue/tests/mutation/create-with-disallowed.exotest
@@ -6,17 +6,20 @@ operation: |
           name
           age
           email
+          authId
       }
   }
 auth: |
   {
     "sub": 6
   }
-invariant: |
+invariants:
   - path: ../system-state.gql
 response: |
   {
-    "data": {
-      "createPerson": null
-    }
+    "errors": [
+      {
+        "message": "Not authorized"
+      }
+    ]
   }

--- a/integration-tests/field-access/with-residue/tests/mutation/create-without-email-allowed.exotest
+++ b/integration-tests/field-access/with-residue/tests/mutation/create-without-email-allowed.exotest
@@ -12,8 +12,6 @@ auth: |
   {
     "sub": 6
   }
-invariant: |
-  - path: ../system-state.gql
 response: |
   {
     "data": {

--- a/integration-tests/field-access/with-residue/tests/mutation/update-with-disallowed.exotest
+++ b/integration-tests/field-access/with-residue/tests/mutation/update-with-disallowed.exotest
@@ -14,9 +14,9 @@ variable: |
   }
 auth: |
   {
-    "sub": 2
+    "sub": $.p2id
   }
-invariant: |
+invariants:
   - path: ../system-state.gql
 response: |
   {

--- a/integration-tests/field-access/with-residue/tests/mutation/update-without-disallowed.exotest
+++ b/integration-tests/field-access/with-residue/tests/mutation/update-without-disallowed.exotest
@@ -1,4 +1,4 @@
-# self.person.id != auth.sub, but email is not specified, so it is allowed to create
+# self.person.id != auth.sub, but email is not specified, so it is allowed to update
 # However, the selection must not include email.
 operation: |
   mutation updatePerson($id: Int!) {
@@ -16,8 +16,6 @@ auth: |
   {
     "sub": $.p2id
   }
-invariant: |
-  - path: ../system-state.gql
 response: |
   {
     "data": {

--- a/integration-tests/field-access/with-residue/tests/system-state.gql
+++ b/integration-tests/field-access/with-residue/tests/system-state.gql
@@ -1,10 +1,11 @@
 operation: |
     query {
-        people {
+        people @unordered {
             id
             name
             age
             email
+            authId
         }
     }
 auth: |


### PR DESCRIPTION
We now carry the default value through in the IR and use it for any values missing from the input.