### PR TITLE
Reject test files with unknown fields

### DIFF
--- a/integration-tests/captcha/tests/captcha-flow-fail-incorrect.exotest
+++ b/integration-tests/captcha/tests/captcha-flow-fail-incorrect.exotest
@@ -1,4 +1,3 @@
-exofile: "comments.exo"
 stages:
     # get a captcha challenge first
     - operation: |

--- a/integration-tests/captcha/tests/captcha-flow-fail-no-captcha.exotest
+++ b/integration-tests/captcha/tests/captcha-flow-fail-no-captcha.exotest
@@ -1,5 +1,3 @@
-exofile: "comments.exo"
-
 # post a comment
 operation: |
     mutation($comment: String!) {

--- a/integration-tests/captcha/tests/captcha-flow-pass.exotest
+++ b/integration-tests/captcha/tests/captcha-flow-pass.exotest
@@ -1,4 +1,3 @@
-exofile: "comments.exo"
 stages:
     # get a captcha challenge first
     - operation: |

--- a/integration-tests/imports/tests/create-mailing-list.exotest
+++ b/integration-tests/imports/tests/create-mailing-list.exotest
@@ -1,4 +1,3 @@
-exofile: "root.exo"
 operation: |
     mutation () {
         createMailingList(data: {

--- a/integration-tests/imports/tests/create-user.exotest
+++ b/integration-tests/imports/tests/create-user.exotest
@@ -1,4 +1,3 @@
-exofile: "root.exo"
 operation: |
     mutation () {
         createUser(data: {


### PR DESCRIPTION
The YAML loading didn't reject unknown fields. This led to silently accepting, for example, "invariant" instead of "invariants" in the tests (and led to believing that invariants were being checked).

This commit captures any extra fields during parsing and rejects the test if any extra fields are found.