### PR TITLE
Implement short-circuit access control

### DIFF
--- a/crates/deno-subsystem/deno-graphql-resolver/src/access_solver.rs
+++ b/crates/deno-subsystem/deno-graphql-resolver/src/access_solver.rs
@@ -52,6 +52,14 @@ impl AccessPredicate for ModuleAccessPredicateWrapper {
     fn or(self, other: Self) -> Self {
         ModuleAccessPredicateWrapper((self.0.into() || other.0.into()).into())
     }
+
+    fn is_true(&self) -> bool {
+        matches!(self.0, ModuleAccessPredicate::True)
+    }
+
+    fn is_false(&self) -> bool {
+        matches!(self.0, ModuleAccessPredicate::False)
+    }
 }
 
 #[async_trait]

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/access/access_op.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/access/access_op.rs
@@ -27,4 +27,12 @@ impl AccessPredicate for AbstractPredicateWrapper {
     fn or(self, other: Self) -> Self {
         AbstractPredicateWrapper(AbstractPredicate::or(self.0, other.0))
     }
+
+    fn is_false(&self) -> bool {
+        self.0.is_false()
+    }
+
+    fn is_true(&self) -> bool {
+        self.0.is_true()
+    }
 }

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/access/database_solver.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/access/database_solver.rs
@@ -59,6 +59,14 @@ impl AccessPredicate for AbstractPredicateWrapper {
     fn or(self, other: Self) -> Self {
         Self(AbstractPredicate::or(self.0, other.0))
     }
+
+    fn is_true(&self) -> bool {
+        self.0.is_true()
+    }
+
+    fn is_false(&self) -> bool {
+        self.0.is_false()
+    }
 }
 
 #[derive(Debug)]

--- a/docs/docs/postgres/access-control.md
+++ b/docs/docs/postgres/access-control.md
@@ -158,6 +158,12 @@ You can use `in` to check if the value is in a set of values. This works for any
 
 You can combine expressions with the logical operators `&&`, `||`, and `!`. For example, you can use `AuthContext.role == "admin" || AuthContext.role == "manager"` to check if the user's role is either "admin" or "manager". Similarly, you can use`EnvContext.isDevelopment && CaptchaContext.isValid` to ascertain that the captcha has been validated and that the app is in development mode.
 
+:::tip
+Like most programming languages, Exograph's access control expressions use the short-circuit evaluation strategy. For example, if the left operand of an `&&` evaluates to `false`, the right operand is not evaluated. Similarly, if the left operand of an `||` evaluates to `true`, the right operand is not evaluated. If the left operand returns a residue (such as `self.published` or `self.owner.id == AuthContext.id`), the evaluator can't short-circuit the evaluation, since it can't definitively determine the result of the expression.
+
+Therefore, you can make the access control evaluation more efficient by ordering the operands such that you put the operands that do not return residues first. For example, you should put the rule that checks for a role first, and then check for other conditions. Within such expressions, you should put the fastest to evaluate operands first. Typically, context sourced from JWT, header, and cookies are the cheapest to evaluate. Context sourced from a [processed value](/core-concept/context#processed-value) may be more expensive to evaluate depending on the complexity of the processing logic.
+:::
+
 You may use parentheses to group expressions. For example, you can use `(AuthContext.role == "admin" || AuthContext.role == "manager") && CaptchaContext.isValid` to check if the user's role is either "admin" or "manager" and that the captcha is valid.
 
 ## Examples

--- a/libs/exo-sql/src/asql/predicate.rs
+++ b/libs/exo-sql/src/asql/predicate.rs
@@ -47,4 +47,12 @@ impl AbstractPredicate {
             AbstractPredicate::Not(p) => p.column_paths(),
         }
     }
+
+    pub fn is_true(&self) -> bool {
+        matches!(self, AbstractPredicate::True)
+    }
+
+    pub fn is_false(&self) -> bool {
+        matches!(self, AbstractPredicate::False)
+    }
 }


### PR DESCRIPTION
If the left side of a logical expression is definite true (for an `||`) or false (for an `&&`), the right side of the expression is not evaluated.