### PR TITLE
Replace ubuntu-20.04 with ubuntu-22.04

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -32,7 +32,7 @@ jobs:
             deps-script: brew install protobuf postgresql@14 pgvector
             target: aarch64-apple-darwin
             bin_extension: ""
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             deps-script: |
               sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
               sudo apt-get install -y protobuf-compiler postgresql-14-pgvector
@@ -113,7 +113,7 @@ jobs:
           prerelease: true
 
   build-aws-lambda:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: amazonlinux:2023
     env:
       ARCH: aws-lambda-linux-2023-x86_64

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   # Build and publish Docker image
   build-docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         # For these target platforms
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             deps-script: |
               sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
               sudo apt-get install -y protobuf-compiler postgresql-14-pgvector


### PR DESCRIPTION
ubuntu-20.04 is scheduled to be removed next month, so we upgrade to the next LTS release, ubuntu-22.04.