### PR TITLE
Execute watch hooks even for `exo build`

### DIFF
--- a/crates/cli/src/commands/deploy/aws_lambda.rs
+++ b/crates/cli/src/commands/deploy/aws_lambda.rs
@@ -43,7 +43,7 @@ impl CommandDefinition for AwsLambdaCommandDefinition {
             .arg(app_name_arg())
     }
 
-    async fn execute(&self, matches: &clap::ArgMatches, _config: &Config) -> Result<()> {
+    async fn execute(&self, matches: &clap::ArgMatches, config: &Config) -> Result<()> {
         let download_file_name = "exograph-aws-lambda-linux-2023-x86_64.zip";
         let download_url = format!("https://github.com/exograph/exograph/releases/download/v{CURRENT_VERSION}/{download_file_name}");
 
@@ -52,7 +52,7 @@ impl CommandDefinition for AwsLambdaCommandDefinition {
 
         let app_name: String = app_name_from_args(matches);
 
-        build(false).await?;
+        build(false, config).await?;
 
         let aws_lambda_dir = PathBuf::from("target/aws-lambda");
         create_dir_all(aws_lambda_dir)?;

--- a/crates/cli/src/commands/deploy/cf_worker.rs
+++ b/crates/cli/src/commands/deploy/cf_worker.rs
@@ -33,10 +33,10 @@ impl CommandDefinition for CfWorkerCommandDefinition {
             .arg(app_name_arg())
     }
 
-    async fn execute(&self, matches: &clap::ArgMatches, _config: &Config) -> Result<()> {
+    async fn execute(&self, matches: &clap::ArgMatches, config: &Config) -> Result<()> {
         let app_name: String = app_name_from_args(matches);
 
-        build(false).await?; // Build the exo_ir file
+        build(false, config).await?; // Build the exo_ir file
 
         let current_dir = std::env::current_dir()?;
         let cf_worker_dir = current_dir.join("target/cf-worker");

--- a/crates/cli/src/commands/deploy/fly.rs
+++ b/crates/cli/src/commands/deploy/fly.rs
@@ -65,13 +65,13 @@ impl CommandDefinition for FlyCommandDefinition {
 
     /// Create a fly.toml file, a Dockerfile, and build the docker image. Then provide instructions
     /// on how to deploy the app to Fly.io.
-    async fn execute(&self, matches: &clap::ArgMatches, _config: &Config) -> Result<()> {
+    async fn execute(&self, matches: &clap::ArgMatches, config: &Config) -> Result<()> {
         let app_name: String = app_name_from_args(matches);
         let envs: Option<Vec<String>> = matches.get_many("env").map(|env| env.cloned().collect());
         let env_file: Option<PathBuf> = get(matches, "env-file");
         let use_fly_db: bool = matches.get_flag("use-fly-db");
 
-        build(false).await?; // Build the exo_ir file
+        build(false, config).await?; // Build the exo_ir file
 
         let current_dir = std::env::current_dir()?;
 

--- a/crates/cli/src/util/watcher.rs
+++ b/crates/cli/src/util/watcher.rs
@@ -125,17 +125,14 @@ where
     // - if the return value is an Ok(None), this mean that we have encountered some error, but it is not necessarily
     //   unrecoverable (the watcher should not exit)
 
-    execute_before_scripts(config)?;
-
     // precompute exo-server path and exo_ir file name
     let mut server_binary = std::env::current_exe()?;
     server_binary.set_file_name("exo-server");
 
-    let build_result = build(false).await;
+    let build_result = build(false, config).await;
 
     match build_result {
         Ok(()) => {
-            execute_after_scripts(config)?;
             if let Err(e) = prestart_callback().await {
                 println!("{} {}", "Error:".red().bold(), e.to_string().red().bold());
             }


### PR DESCRIPTION
We ran watch hooks (from exo.toml) only when executing `exo dev` or `exo yolo`. Now we run these hooks even for `exo build`. This way, for example, GraphQL schema computation can be performed at build time.