### PR TITLE
Support version compatibility check in config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,6 +1288,7 @@ dependencies = [
  "rand",
  "reqwest",
  "rexpect",
+ "semver 1.0.25",
  "serde",
  "serde_json",
  "tempfile",
@@ -7812,7 +7813,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.22",
+ "semver 1.0.25",
 ]
 
 [[package]]
@@ -8068,9 +8069,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 dependencies = [
  "serde",
 ]
@@ -9977,7 +9978,7 @@ dependencies = [
  "regex",
  "regex-syntax 0.6.29",
  "rustc-hash 1.1.0",
- "semver 1.0.22",
+ "semver 1.0.25",
  "serde",
  "serde_json",
  "smallbitvec",
@@ -10704,7 +10705,7 @@ dependencies = [
  "bitflags 2.5.0",
  "hashbrown 0.14.5",
  "indexmap 2.7.0",
- "semver 1.0.22",
+ "semver 1.0.25",
  "serde",
 ]
 
@@ -10761,7 +10762,7 @@ dependencies = [
  "pulley-interpreter",
  "rayon",
  "rustix",
- "semver 1.0.22",
+ "semver 1.0.25",
  "serde",
  "serde_derive",
  "serde_json",
@@ -10877,7 +10878,7 @@ dependencies = [
  "object 0.36.1",
  "postcard",
  "rustc-demangle",
- "semver 1.0.22",
+ "semver 1.0.25",
  "serde",
  "serde_derive",
  "smallvec",
@@ -11586,7 +11587,7 @@ dependencies = [
  "id-arena",
  "indexmap 2.7.0",
  "log",
- "semver 1.0.22",
+ "semver 1.0.25",
  "serde",
  "serde_derive",
  "serde_json",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -32,6 +32,7 @@ indicatif = "0.17.9"
 tempfile.workspace = true
 which.workspace = true
 toml = { version = "0.8.19", features = ["parse"] }
+semver = "1.0.25"
 
 exo-sql = { path = "../../libs/exo-sql", features = ["pool"] }
 builder = { path = "../builder" }

--- a/crates/cli/src/config/loader.rs
+++ b/crates/cli/src/config/loader.rs
@@ -1,15 +1,63 @@
 use std::path::Path;
 
 use anyhow::{anyhow, Result};
+use semver::VersionReq;
 
 use crate::config::model::Config;
+
+use serde::Deserialize;
+
+use super::model::WatchConfig;
+
+#[derive(Deserialize, Debug, PartialEq, Default)]
+pub struct ConfigSer {
+    #[serde(rename = "tool-version")]
+    pub tool_version: Option<String>,
+    pub watch: Option<WatchConfigSer>,
+}
+
+#[derive(Deserialize, Debug, PartialEq, Default)]
+pub struct WatchConfigSer {
+    pub before: Option<Vec<String>>,
+    pub after: Option<Vec<String>>,
+}
+
+impl TryFrom<ConfigSer> for Config {
+    type Error = anyhow::Error;
+
+    fn try_from(config: ConfigSer) -> Result<Self, Self::Error> {
+        Ok(Config {
+            tool_version: config
+                .tool_version
+                .map(|v| VersionReq::parse(&v).map_err(|_| anyhow!("Invalid version: {}", v)))
+                .transpose()?,
+            watch: config
+                .watch
+                .map(WatchConfig::try_from)
+                .transpose()?
+                .unwrap_or_default(),
+        })
+    }
+}
+
+impl TryFrom<WatchConfigSer> for WatchConfig {
+    type Error = anyhow::Error;
+
+    fn try_from(config: WatchConfigSer) -> Result<Self, Self::Error> {
+        Ok(WatchConfig {
+            before: config.before.unwrap_or_default(),
+            after: config.after.unwrap_or_default(),
+        })
+    }
+}
 
 fn load_config_from_file(path: &Path) -> Result<Config> {
     let toml_str = std::fs::read_to_string(path)
         .map_err(|e| anyhow!("Failed to read file '{}': {}", path.display(), e))?;
-    let config: Config = toml::from_str(&toml_str)
+    let config: ConfigSer = toml::from_str(&toml_str)
         .map_err(|e| anyhow!("Failed to parse TOML file '{}': {}", path.display(), e))?;
-    Ok(config)
+
+    config.try_into()
 }
 
 pub fn load_config() -> Result<Config> {
@@ -19,7 +67,11 @@ pub fn load_config() -> Result<Config> {
         return Ok(Config::default());
     }
 
-    load_config_from_file(config_path)
+    let config = load_config_from_file(config_path)?;
+
+    config.assert_tool_version()?;
+
+    Ok(config)
 }
 
 #[cfg(test)]
@@ -31,7 +83,13 @@ mod tests {
     #[test]
     fn test_load_config() {
         let config = load_test_config("empty").unwrap();
-        assert_eq!(config, Config { watch: None });
+        assert_eq!(
+            config,
+            Config {
+                tool_version: None,
+                watch: WatchConfig::default()
+            }
+        );
     }
 
     fn load_test_config(name: &str) -> Result<Config> {
@@ -47,16 +105,11 @@ mod tests {
         assert_eq!(
             config,
             Config {
-                watch: Some(WatchConfig {
-                    before: Some(vec![
-                        "echo 'before1'".to_string(),
-                        "echo 'before2'".to_string()
-                    ]),
-                    after: Some(vec![
-                        "echo 'after1'".to_string(),
-                        "echo 'after2'".to_string()
-                    ])
-                })
+                tool_version: None,
+                watch: WatchConfig {
+                    before: vec!["echo 'before1'".to_string(), "echo 'before2'".to_string()],
+                    after: vec!["echo 'after1'".to_string(), "echo 'after2'".to_string()]
+                }
             }
         );
     }
@@ -67,13 +120,23 @@ mod tests {
         assert_eq!(
             config,
             Config {
-                watch: Some(WatchConfig {
-                    before: None,
-                    after: Some(vec![
-                        "echo 'after1'".to_string(),
-                        "echo 'after2'".to_string()
-                    ])
-                })
+                tool_version: None,
+                watch: WatchConfig {
+                    before: vec![],
+                    after: vec!["echo 'after1'".to_string(), "echo 'after2'".to_string()]
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn test_load_config_with_version() {
+        let config = load_test_config("version").unwrap();
+        assert_eq!(
+            config,
+            Config {
+                tool_version: Some(VersionReq::parse("0.11.1").unwrap()),
+                watch: WatchConfig::default()
             }
         );
     }

--- a/crates/cli/src/config/test-configs/version.toml
+++ b/crates/cli/src/config/test-configs/version.toml
@@ -1,0 +1,1 @@
+tool-version = "0.11.1"

--- a/crates/cli/src/util/watcher.rs
+++ b/crates/cli/src/util/watcher.rs
@@ -164,20 +164,14 @@ where
 }
 
 pub fn execute_before_scripts(config: &Config) -> Result<()> {
-    if let Some(watch) = &config.watch {
-        if let Some(before) = &watch.before {
-            execute_scripts(before)?;
-        }
-    }
+    execute_scripts(&config.watch.before)?;
+
     Ok(())
 }
 
 pub fn execute_after_scripts(config: &Config) -> Result<()> {
-    if let Some(watch) = &config.watch {
-        if let Some(after) = &watch.after {
-            execute_scripts(after)?;
-        }
-    }
+    execute_scripts(&config.watch.after)?;
+
     Ok(())
 }
 

--- a/docs/docs/cli-reference/config.md
+++ b/docs/docs/cli-reference/config.md
@@ -1,0 +1,59 @@
+---
+sidebar_position: 3
+---
+
+# Configuration
+
+Exograph developers tooling can be configured using an `exo.toml` file in the root directory of your project. Here is an example configuration file:
+
+```toml
+[tool-version]
+version = "0.11.1"
+
+[watch]
+before = ["echo 'before1'", "echo 'before2'"]
+after = [
+  "exo graphql schema --output ../web/.gen/graphql/schema.graphql", 
+  "exo schema migrate --allow-destructive-changes -o migrations/current.sql"
+]
+```
+
+You can express the content in an [alternative TOML format](https://toml.io/en/v1.0.0), if you prefer. For example, the above configuration can be expressed as:
+
+```toml
+tool-version = "0.11.1"
+
+watch.before = [
+  "echo 'before1'",
+  "echo 'before2'"
+]
+
+watch.after = [
+  "exo graphql schema --output ../web/.gen/graphql/schema.graphql",
+  "exo schema migrate --allow-destructive-changes -o migrations/current.sql"
+]
+```
+
+The configuration file supports the `tool-version` and `watch` keys.
+
+## `tool-version`
+
+The `tool-version` specifies the required version of the Exograph CLI using as much specificity as you want. Here are some examples (along with the accepted Exograph CLI versions):
+
+| Specification                     | Description                                           |
+|-----------------------------------|-------------------------------------------------------|
+| `tool-version = "0.11.1"`         | Higher than 0.11.1, lower than 0.12.0 |
+| `tool-version = "1.2.3"`          | Higher than 1.2.3, lower than 2.0.0 |
+| `tool-version = "1.2"`            | Higher than 1.2.0, lower than 1.3.0 |
+| `tool-version = "1"`              | Higher than 1.0.0, lower than 2.0.0 |
+| `tool-version = ">=0.11.1"`       | Higher than or equal to 0.11.1 |
+| `tool-version = "<0.11.1"`        | Lower than 0.11.1 |
+| `tool-version = "=0.11.1"`        | Exactly 0.11.1 |
+
+:::tip Recommendation
+Until Exograph reaches version 1.0, we recommend the exact version specification (e.g. `tool-version = "=0.11.1"`) or the minimal version with a patch version   (e.g. `tool-version = "0.11.1"`).
+:::
+
+## `watch`
+
+The `watch` key is used to specify the commands to run when the configuration changes. The `before` key is a list of commands to run before building the model (through either the `exo build` command or as a part of the `exo dev` or `exo yolo` commands). The `after` key is a list of commands to run after the model has been built.


### PR DESCRIPTION
This adds a new key, `tool-version,` to express version requirements. For example,

```toml
tool-version = "=0.11.1"
```

will enforce that the Exograph cli version must be exactly "0.11.1".

We support all the standard server requirement expressions, such as `0.1.1`, `=0.1.1`, `1`, `>= 1`, and so on. For more information, see the docs for the `server` crate (https://docs.rs/semver/1.0.25/semver).