### PR TITLE
Report a runtime error for missing functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2210,6 +2210,7 @@ dependencies = [
  "test-log",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/deno-subsystem/deno-graphql-resolver/Cargo.toml
+++ b/crates/deno-subsystem/deno-graphql-resolver/Cargo.toml
@@ -17,7 +17,7 @@ futures.workspace = true
 serde_json = { workspace = true, features = ["preserve_order"] }
 thiserror.workspace = true
 tokio.workspace = true
-
+tracing.workspace = true
 exo-deno = { path = "../../../libs/exo-deno" }
 core-plugin-interface = { path = "../../core-subsystem/core-plugin-interface" }
 deno-graphql-model = { path = "../deno-graphql-model" }

--- a/crates/deno-subsystem/deno-graphql-resolver/src/resolver.rs
+++ b/crates/deno-subsystem/deno-graphql-resolver/src/resolver.rs
@@ -172,10 +172,13 @@ impl From<DenoExecutionError> for SubsystemResolutionError {
     fn from(e: DenoExecutionError) -> Self {
         match e {
             DenoExecutionError::Authorization => SubsystemResolutionError::Authorization,
-            _ => SubsystemResolutionError::UserDisplayError(
-                e.user_error_message()
-                    .unwrap_or_else(|| "Internal server error".to_string()),
-            ),
+            _ => {
+                tracing::error!("Error while resolving operation: {e}");
+                SubsystemResolutionError::UserDisplayError(
+                    e.user_error_message()
+                        .unwrap_or_else(|| "Internal server error".to_string()),
+                )
+            }
         }
     }
 }

--- a/libs/exo-deno/src/deno_error.rs
+++ b/libs/exo-deno/src/deno_error.rs
@@ -37,9 +37,9 @@ pub enum DenoError {
 
 #[derive(Error, Debug)]
 pub enum DenoDiagnosticError {
-    #[error("Missing shim {0}")]
+    #[error("Missing shim `{0}`")]
     MissingShim(String),
-    #[error("No function named {0} exported from {1}")]
+    #[error("No function named `{0}` exported from {1}")]
     MissingFunction(String, String), // (function name, module name)
 
     #[error("{0}")]


### PR DESCRIPTION
If a Deno module doesn't export a function bound to a query or mutation, we return an `Internal server error`, but wihout any tracing.

Now, it will produce an error pointing to the root clause (still making sure that the end use sees only `Internal server error`:

```
2025-02-28T21:02:20.448450Z ERROR deno_graphql_resolver::resolver: Error while resolving operation: No function named `add` exported from `<path to>/src/arithmetic.js`
```

Fixes #1511