### PR TITLE
Support fragments to reuse a group of fields

### DIFF
--- a/crates/builder/grammar/grammar.js
+++ b/crates/builder/grammar/grammar.js
@@ -43,6 +43,7 @@ module.exports = grammar({
     ),
     module_field: $ => choice(
       $.type,
+      $.fragment,
       $.module_method,
       $.interceptor
     ),
@@ -76,7 +77,15 @@ module.exports = grammar({
       field("name", $.term),
       field("body", $.type_body)
     ),
-    type_body: $ => seq("{", repeat(field("field", $.field)), "}"),
+    fragment: $ => seq(
+      repeat(field("annotation", $.annotation)),
+      "fragment",
+      field("name", $.term),
+      field("body", $.fragment_body)
+    ),
+    type_body: $ => seq("{", repeat(choice(field("field", $.field), field("fragment_reference", $.fragment_reference))), "}"),
+    fragment_body: $ => seq("{", repeat(field("field", $.field)), "}"),
+    fragment_reference: $ => seq("...", field("name", $.term)),
     annotation: $ => seq(
       "@",
       field("name", $.term),

--- a/crates/builder/src/parser/snapshots/access_control_function_with_paren.snap
+++ b/crates/builder/src/parser/snapshots/access_control_function_with_paren.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/builder/src/parser/converter.rs
-expression: "convert_root(parsed.root_node(),\n        r#\"\n            @postgres\n            module TestModule {\n                @access(self.concerts.some((c) => c.id == 1))\n                type Venue {\n                    concerts: Set<Concert>?\n                }\n\n                type Concert {\n                    @pk id: Int = autoIncrement()\n                    venue: Venue\n                }\n            }\n        \"#.as_bytes(),\n        file_span, Path::new(\"input.exo\")).unwrap()"
+expression: "convert_root(parsed.root_node(),\nr#\"\n            @postgres\n            module TestModule {\n                @access(self.concerts.some((c) => c.id == 1))\n                type Venue {\n                    concerts: Set<Concert>?\n                }\n\n                type Concert {\n                    @pk id: Int = autoIncrement()\n                    venue: Venue\n                }\n            }\n        \"#.as_bytes(),\nfile_span, Path :: new(\"input.exo\")).unwrap()"
 ---
 types: []
 modules:
@@ -26,6 +26,7 @@ modules:
                   - ~
             annotations: []
             default_value: ~
+        fragment_references: []
         annotations:
           - name: access
             params:
@@ -93,6 +94,7 @@ modules:
                 - ~
             annotations: []
             default_value: ~
+        fragment_references: []
         annotations: []
     methods: []
     interceptors: []

--- a/crates/builder/src/parser/snapshots/access_control_function_without_paren.snap
+++ b/crates/builder/src/parser/snapshots/access_control_function_without_paren.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/builder/src/parser/converter.rs
-expression: "convert_root(parsed.root_node(),\n        r#\"\n            @postgres\n            module TestModule {\n                @access(self.concerts.some(c => c.id == 1))\n                type Venue {\n                    concerts: Set<Concert>?\n                }\n\n                type Concert {\n                    @pk id: Int = autoIncrement()\n                    venue: Venue\n                }\n            }\n        \"#.as_bytes(),\n        file_span, Path::new(\"input.exo\")).unwrap()"
+expression: "convert_root(parsed.root_node(),\nr#\"\n            @postgres\n            module TestModule {\n                @access(self.concerts.some(c => c.id == 1))\n                type Venue {\n                    concerts: Set<Concert>?\n                }\n\n                type Concert {\n                    @pk id: Int = autoIncrement()\n                    venue: Venue\n                }\n            }\n        \"#.as_bytes(),\nfile_span, Path :: new(\"input.exo\")).unwrap()"
 ---
 types: []
 modules:
@@ -26,6 +26,7 @@ modules:
                   - ~
             annotations: []
             default_value: ~
+        fragment_references: []
         annotations:
           - name: access
             params:
@@ -93,6 +94,7 @@ modules:
                 - ~
             annotations: []
             default_value: ~
+        fragment_references: []
         annotations: []
     methods: []
     interceptors: []

--- a/crates/builder/src/parser/snapshots/bb_schema.snap
+++ b/crates/builder/src/parser/snapshots/bb_schema.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/builder/src/parser/converter.rs
-expression: "convert_root(parsed.root_node(),\n        r#\"\n            @postgres\n            module TestModule{\n                // a short comment\n                @table(\"concerts\")\n                type Concert {\n                    @pk id: Int = autoIncrement()\n                    title: String // a comment\n                    // another comment\n                    @column(\"venueid\") venue: Venue \n                    /*\n                    not_a_field: Int\n                    */\n                }\n\n                /*\n                a multiline comment\n                */\n                @table(\"venues\")\n                type Venue {\n                    @pk id: Int = autoIncrement()\n                    name: String\n                    /*here */ @column(\"venueid\") /* and here */ concerts: Set<Concert /* here too! */> \n                }\n            }\n        \"#.as_bytes(),\n        file_span, Path::new(\"input.exo\")).unwrap()"
+expression: "convert_root(parsed.root_node(),\nr#\"\n            @postgres\n            module TestModule{\n                // a short comment\n                @table(\"concerts\")\n                type Concert {\n                    @pk id: Int = autoIncrement()\n                    title: String // a comment\n                    // another comment\n                    @column(\"venueid\") venue: Venue \n                    /*\n                    not_a_field: Int\n                    */\n                }\n\n                /*\n                a multiline comment\n                */\n                @table(\"venues\")\n                type Venue {\n                    @pk id: Int = autoIncrement()\n                    name: String\n                    /*here */ @column(\"venueid\") /* and here */ concerts: Set<Concert /* here too! */> \n                }\n            }\n        \"#.as_bytes(),\nfile_span, Path :: new(\"input.exo\")).unwrap()"
 ---
 types: []
 modules:
@@ -50,6 +50,7 @@ modules:
                     - StringLiteral:
                         - venueid
             default_value: ~
+        fragment_references: []
         annotations:
           - name: table
             params:
@@ -101,6 +102,7 @@ modules:
                     - StringLiteral:
                         - venueid
             default_value: ~
+        fragment_references: []
         annotations:
           - name: table
             params:

--- a/crates/builder/src/parser/snapshots/context_schema.snap
+++ b/crates/builder/src/parser/snapshots/context_schema.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/builder/src/parser/converter.rs
-expression: "convert_root(parsed.root_node(),\n        r#\"\n            context AuthUser {\n                @jwt(\"sub\") id: Int \n                @jwt roles: Array<String> \n            }\n        \"#.as_bytes(),\n        file_span, Path::new(\"input.exo\")).unwrap()"
+expression: "convert_root(parsed.root_node(),\nr#\"\n            context AuthUser {\n                @jwt(\"sub\") id: Int \n                @jwt roles: Array<String> \n            }\n        \"#.as_bytes(),\nfile_span, Path :: new(\"input.exo\")).unwrap()"
 ---
 types:
   - name: AuthUser
@@ -35,6 +35,7 @@ types:
           - name: jwt
             params: None
         default_value: ~
+    fragment_references: []
     annotations: []
 modules: []
 imports: []

--- a/crates/builder/src/parser/snapshots/expression_precedence.snap
+++ b/crates/builder/src/parser/snapshots/expression_precedence.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/builder/src/parser/converter.rs
-expression: "convert_root(parsed.root_node(),\n        r#\"\n            @postgres\n            module TestModule{            \n                type Foo {\n                    @column(\"custom_column\") @access(!self.role == \"role_admin\" || self.role == \"role_superuser\")\n                    bar: Baz\n                }\n            }\n        \"#.as_bytes(),\n        file_span, Path::new(\"input.exo\")).unwrap()"
+expression: "convert_root(parsed.root_node(),\nr#\"\n            @postgres\n            module TestModule{            \n                type Foo {\n                    @column(\"custom_column\") @access(!self.role == \"role_admin\" || self.role == \"role_superuser\")\n                    bar: Baz\n                }\n            }\n        \"#.as_bytes(),\nfile_span, Path :: new(\"input.exo\")).unwrap()"
 ---
 types: []
 modules:
@@ -67,6 +67,7 @@ modules:
                                 - ~
                           - ~
             default_value: ~
+        fragment_references: []
         annotations: []
     methods: []
     interceptors: []

--- a/crates/builder/src/typechecker/snapshots/simple.snap
+++ b/crates/builder/src/typechecker/snapshots/simple.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/builder/src/typechecker/mod.rs
-expression: build(src).unwrap()
+expression: built
 ---
 types:
   values:
@@ -146,6 +146,7 @@ types:
               annotations:
                 annotations: {}
               default_value: ~
+          fragment_references: []
           annotations:
             annotations: {}
     - - ~
@@ -163,6 +164,7 @@ types:
               annotations:
                 annotations: {}
               default_value: ~
+          fragment_references: []
           annotations:
             annotations: {}
     - ~
@@ -351,6 +353,7 @@ modules:
                 annotations:
                   annotations: {}
                 default_value: ~
+            fragment_references: []
             annotations:
               annotations: {}
           - name: Doc
@@ -366,6 +369,7 @@ modules:
                 annotations:
                   annotations: {}
                 default_value: ~
+            fragment_references: []
             annotations:
               annotations: {}
         methods: []

--- a/crates/builder/src/typechecker/snapshots/with_array_in_operator.snap
+++ b/crates/builder/src/typechecker/snapshots/with_array_in_operator.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/builder/src/typechecker/mod.rs
-expression: build(src).unwrap()
+expression: built
 ---
 types:
   values:
@@ -59,6 +59,7 @@ types:
                     name: jwt
                     params: None
               default_value: ~
+          fragment_references: []
           annotations:
             annotations: {}
     - - ~
@@ -103,6 +104,7 @@ types:
                                           generation: ~
                               - Primitive: Boolean
               default_value: ~
+          fragment_references: []
           annotations:
             annotations: {}
     - ~
@@ -224,6 +226,7 @@ modules:
                                             generation: ~
                                 - Primitive: Boolean
                 default_value: ~
+            fragment_references: []
             annotations:
               annotations: {}
         methods: []

--- a/crates/builder/src/typechecker/snapshots/with_auth_context_use_in_field_annotation.snap
+++ b/crates/builder/src/typechecker/snapshots/with_auth_context_use_in_field_annotation.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/builder/src/typechecker/mod.rs
-expression: build(src).unwrap()
+expression: built
 ---
 types:
   values:
@@ -55,6 +55,7 @@ types:
                     name: jwt
                     params: None
               default_value: ~
+          fragment_references: []
           annotations:
             annotations: {}
     - - ~
@@ -128,6 +129,7 @@ types:
                                         generation: ~
                               - Primitive: Boolean
               default_value: ~
+          fragment_references: []
           annotations:
             annotations: {}
     - ~
@@ -278,6 +280,7 @@ modules:
                                           generation: ~
                                 - Primitive: Boolean
                 default_value: ~
+            fragment_references: []
             annotations:
               annotations: {}
         methods: []

--- a/crates/builder/src/typechecker/snapshots/with_auth_context_use_in_type_annotation.snap
+++ b/crates/builder/src/typechecker/snapshots/with_auth_context_use_in_type_annotation.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/builder/src/typechecker/mod.rs
-expression: build(src).unwrap()
+expression: built
 ---
 types:
   values:
@@ -55,6 +55,7 @@ types:
                     name: jwt
                     params: None
               default_value: ~
+          fragment_references: []
           annotations:
             annotations: {}
     - - ~
@@ -82,6 +83,7 @@ types:
               annotations:
                 annotations: {}
               default_value: ~
+          fragment_references: []
           annotations:
             annotations:
               access:
@@ -232,6 +234,7 @@ modules:
                 annotations:
                   annotations: {}
                 default_value: ~
+            fragment_references: []
             annotations:
               annotations:
                 access:

--- a/crates/builder/src/typechecker/snapshots/with_function_calls.snap
+++ b/crates/builder/src/typechecker/snapshots/with_function_calls.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/builder/src/typechecker/mod.rs
-expression: build(src).unwrap()
+expression: built
 ---
 types:
   values:
@@ -71,6 +71,7 @@ types:
                     name: jwt
                     params: None
               default_value: ~
+          fragment_references: []
           annotations:
             annotations: {}
     - - ~
@@ -119,6 +120,7 @@ types:
               annotations:
                 annotations: {}
               default_value: ~
+          fragment_references: []
           annotations:
             annotations:
               access:
@@ -409,6 +411,7 @@ types:
               annotations:
                 annotations: {}
               default_value: ~
+          fragment_references: []
           annotations:
             annotations: {}
     - ~
@@ -536,6 +539,7 @@ modules:
                 annotations:
                   annotations: {}
                 default_value: ~
+            fragment_references: []
             annotations:
               annotations:
                 access:
@@ -824,6 +828,7 @@ modules:
                 annotations:
                   annotations: {}
                 default_value: ~
+            fragment_references: []
             annotations:
               annotations: {}
         methods: []

--- a/crates/core-subsystem/core-model-builder/src/ast/ast_types.rs
+++ b/crates/core-subsystem/core-model-builder/src/ast/ast_types.rs
@@ -69,6 +69,7 @@ pub struct AstModel<T: NodeTypedness> {
     pub name: String,
     pub kind: AstModelKind,
     pub fields: Vec<AstField<T>>,
+    pub fragment_references: Vec<AstFragmentReference<T>>,
     pub annotations: T::Annotations,
     #[serde(skip_serializing)]
     #[serde(skip_deserializing)]
@@ -77,6 +78,22 @@ pub struct AstModel<T: NodeTypedness> {
 }
 
 impl<T: NodeTypedness> Display for AstModel<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.name.as_str())
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct AstFragmentReference<T: NodeTypedness> {
+    pub name: String,
+    pub typ: T::Type,
+    #[serde(skip_serializing)]
+    #[serde(skip_deserializing)]
+    #[serde(default = "default_span")]
+    pub span: Span,
+}
+
+impl<T: NodeTypedness> Display for AstFragmentReference<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.name.as_str())
     }
@@ -140,8 +157,9 @@ pub struct AstInterceptor<T: NodeTypedness> {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum AstModelKind {
-    Type,    // a type in a module (with semantics assigned by each module plugin)
-    Context, // defines contextual type some information extracted from the request
+    Type,     // a type in a module (with semantics assigned by each module plugin)
+    Context,  // defines contextual type some information extracted from the request
+    Fragment, // a fragment in a module
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/crates/deno-subsystem/deno-graphql-builder/src/module_skeleton_generator.rs
+++ b/crates/deno-subsystem/deno-graphql-builder/src/module_skeleton_generator.rs
@@ -541,6 +541,7 @@ mod tests {
                     span,
                 },
             ],
+            fragment_references: vec![],
             annotations: Default::default(),
             span,
         }
@@ -580,6 +581,7 @@ mod tests {
                     span,
                 },
             ],
+            fragment_references: vec![],
             annotations: Default::default(),
             span,
         }

--- a/crates/postgres-subsystem/postgres-core-builder/src/resolved_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/resolved_builder.rs
@@ -240,8 +240,51 @@ fn resolve_composite_type_fields(
     typechecked_system: &TypecheckedSystem,
     errors: &mut Vec<Diagnostic>,
 ) -> Vec<ResolvedField> {
+    let fragment_fields = ct
+        .fragment_references
+        .iter()
+        .flat_map(|fragment_reference| {
+            let fragment_type = typechecked_system
+                .types
+                .get_by_key(&fragment_reference.name);
+            match &fragment_type {
+                Some(Type::Composite(ft)) => ft.fields.clone(),
+                Some(_) => {
+                    errors.push(Diagnostic {
+                        level: Level::Error,
+                        message: format!(
+                            "Fragment type {} is not a composite type",
+                            fragment_reference.name
+                        ),
+                        code: Some("C000".to_string()),
+                        spans: vec![SpanLabel {
+                            span: fragment_reference.span,
+                            style: SpanStyle::Primary,
+                            label: None,
+                        }],
+                    });
+                    vec![]
+                }
+                None => {
+                    errors.push(Diagnostic {
+                        level: Level::Error,
+                        message: format!("Fragment type {} not found", fragment_reference.name),
+                        code: Some("C000".to_string()),
+                        spans: vec![SpanLabel {
+                            span: fragment_reference.span,
+                            style: SpanStyle::Primary,
+                            label: None,
+                        }],
+                    });
+                    vec![]
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+
     ct.fields
         .iter()
+        .chain(fragment_fields.iter())
         .flat_map(|field| {
             let update_sync = field.annotations.contains("update");
             let readonly = field.annotations.contains("readonly");

--- a/integration-tests/fragment/src/index.exo
+++ b/integration-tests/fragment/src/index.exo
@@ -1,0 +1,13 @@
+@postgres
+module TodoDatabase {
+  @access(true)
+  type Todo {
+    @pk id: Int = autoIncrement()
+    ...TodoFragment
+  }
+
+  fragment TodoFragment {
+    completed: Boolean
+    title: String
+  }
+}

--- a/integration-tests/fragment/tests/basic-query.exotest
+++ b/integration-tests/fragment/tests/basic-query.exotest
@@ -1,0 +1,35 @@
+operation: |
+  query {
+      todos(orderBy: {title: ASC}) {
+          id
+          title
+          completed
+      }
+  }
+response: |
+  {
+    "data": {
+      "todos": [
+        {
+          "id": $.t1id,
+          "title": "T1",
+          "completed": true
+        },
+        {
+          "id": $.t2id,
+          "title": "T2",
+          "completed": false
+        },
+        {
+          "id": $.t3id,
+          "title": "T3",
+          "completed": true
+        },
+        {
+          "id": $.t4id,
+          "title": "T4",
+          "completed": false
+        }
+      ]
+    }
+  }

--- a/integration-tests/fragment/tests/init.gql
+++ b/integration-tests/fragment/tests/init.gql
@@ -1,0 +1,15 @@
+operation: |
+    mutation {
+        t1: createTodo(data: {title: "T1", completed: true}) {
+            id @bind(name: "t1id")
+        }
+        t2: createTodo(data: {title: "T2", completed: false}) {
+            id @bind(name: "t2id")
+        }
+        t3: createTodo(data: {title: "T3", completed: true}) {
+            id @bind(name: "t3id")
+        }
+        t4: createTodo(data: {title: "T4", completed: false}) {
+            id @bind(name: "t4id")
+        }
+    }


### PR DESCRIPTION
If multiple types use the same set of fields, this helps to define those fields as a fragment and slice those fields in other types such as the following:

```exo
@postgres
module TodoDatabase {
  @access(true)
  type Todo {
    @pk id: Int = autoIncrement()
    ...TodoFragment
  }

  fragment TodoFragment {
    completed: Boolean
    title: String
  }
}
```