### PR TITLE
Refactor db introspection queries

### DIFF
--- a/libs/exo-sql/src/schema/function_spec.rs
+++ b/libs/exo-sql/src/schema/function_spec.rs
@@ -12,7 +12,7 @@ pub struct FunctionSpec {
 }
 
 const FUNCTIONS_QUERY: &str = r#"
-select routine_name, routine_definition, external_language from information_schema.routines where routine_name like 'exograph%'
+SELECT routine_name, routine_definition, external_language FROM information_schema.routines WHERE routine_name like 'exograph%'
 "#;
 
 impl FunctionSpec {

--- a/libs/exo-sql/src/schema/spec.rs
+++ b/libs/exo-sql/src/schema/spec.rs
@@ -37,7 +37,7 @@ impl MigrationScopeMatches {
 
     pub fn matches(&self, table_name: &PhysicalTableName) -> bool {
         self.0.iter().any(|(schema_pattern, table_pattern)| {
-            schema_pattern.matches(table_name.schema.as_deref().unwrap_or("public"))
+            schema_pattern.matches(&table_name.schema_name())
                 && table_pattern.matches(&table_name.name)
         })
     }

--- a/libs/exo-sql/src/sql/physical_table.rs
+++ b/libs/exo-sql/src/sql/physical_table.rs
@@ -59,6 +59,13 @@ impl PhysicalTableName {
             None => format!("\"{}\"", self.name),
         }
     }
+
+    pub fn schema_name(&self) -> String {
+        match self.schema {
+            Some(ref schema) => schema.to_string(),
+            None => "public".to_string(),
+        }
+    }
 }
 
 /// A physical table in the database such as "concerts" or "users".


### PR DESCRIPTION
- Consistently use table and schema names for queries. No more `::regclass` (which doesn't work as cleanly with table/schema names that have a capital letter in them)
- Consolidate all SQL queries at the top of each file.