### PR TITLE
Update base image in docker files

### DIFF
--- a/crates/cli/src/commands/templates/Dockerfile.fly.builder
+++ b/crates/cli/src/commands/templates/Dockerfile.fly.builder
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 FROM flyio/flyctl:latest as flyio
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update; apt-get install -y ca-certificates jq
 

--- a/docker/Dockerfile.cli-server.ci
+++ b/docker/Dockerfile.cli-server.ci
@@ -1,7 +1,7 @@
-# We must use "debian:bullseye*" (and not "debian:buster") as the base runtime image to match the libc version used while building the binaries
+# We must use "debian:bookworm*" (and not "debian:buster") as the base runtime image to match the libc version used while building the binaries
 
 ## Create a builder image with exograph release binaries
-FROM debian:bullseye-slim as builder
+FROM debian:bookworm-slim as builder
 
 RUN apt-get update && apt-get -y install unzip
 
@@ -11,7 +11,7 @@ RUN unzip ./exograph-x86_64-unknown-linux-gnu.zip
 
 
 ## Build the runtime image with just the binary we need for both the cli and the server
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ### Install ca-certificates and tzdata (needed to establish TLS connections and set the timezone)
 RUN apt-get update \

--- a/docker/Dockerfile.cli.ci
+++ b/docker/Dockerfile.cli.ci
@@ -1,7 +1,7 @@
-# We must use "debian:bullseye*" (and not "debian:buster") as the base runtime image to match the libc version used while building the binaries
+# We must use "debian:bookworm*" (and not "debian:buster") as the base runtime image to match the libc version used while building the binaries
 
 ## Create a builder image with exograph release binaries
-FROM debian:bullseye-slim as builder
+FROM debian:bookworm-slim as builder
 
 RUN apt-get update && apt-get -y install unzip
 
@@ -11,7 +11,7 @@ RUN unzip ./exograph-x86_64-unknown-linux-gnu.zip
 
 
 ## Build the runtime image with just the binary we need for the cli
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ### Install ca-certificates and tzdata (needed to establish TLS connections and set the timezone)
 RUN apt-get update \

--- a/docker/Dockerfile.dev.ci
+++ b/docker/Dockerfile.dev.ci
@@ -1,7 +1,7 @@
-# We must use "debian:bullseye*" (and not "debian:buster") as the base runtime image to match the libc version used while building the binaries
+# We must use "debian:bookworm*" (and not "debian:buster") as the base runtime image to match the libc version used while building the binaries
 
 ## Create a builder image with exograph release binaries
-FROM debian:bullseye-slim as builder
+FROM debian:bookworm-slim as builder
 
 RUN apt-get update && apt-get -y install unzip
 
@@ -11,7 +11,7 @@ RUN unzip ./exograph-x86_64-unknown-linux-gnu.zip
 
 
 ## Build the runtime image with just the binaries we need
-FROM postgres:bullseye
+FROM postgres:bookworm
 
 ### Install ca-certificates and tzdata (needed to establish TLS connections and set the timezone)
 RUN apt-get update \

--- a/docker/Dockerfile.server.ci
+++ b/docker/Dockerfile.server.ci
@@ -1,7 +1,7 @@
-# We must use "debian:bullseye*" (and not "debian:buster") as the base runtime image to match the libc version used while building the binaries
+# We must use "debian:bookworm*" (and not "debian:buster") as the base runtime image to match the libc version used while building the binaries
 
 ## Create a builder image with exograph release binaries
-FROM debian:bullseye-slim as builder
+FROM debian:bookworm-slim as builder
 
 RUN apt-get update && apt-get -y install unzip
 
@@ -11,7 +11,7 @@ RUN unzip ./exograph-x86_64-unknown-linux-gnu.zip
 
 
 ## Build the runtime image with just the binary we need for the server
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ### Install ca-certificates and tzdata (needed to establish TLS connections and set the timezone)
 RUN apt-get update \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -10,8 +10,8 @@ buildType="$1" # "release" or "debug"
 # TODO: Resolve the openssl issues and then "RUNTIME_IMAGE=debian:buster-slim"
 
 ## DEFAULTS ##
-BUILD_IMAGE=rust:1.81.0-bullseye # image to build Exograph with
-RUNTIME_IMAGE=rust:1.81.0-slim-bullseye # image to use when actually running Exograph
+BUILD_IMAGE=rust:1.81.0-bookworm # image to build Exograph with
+RUNTIME_IMAGE=rust:1.81.0-slim-bookworm # image to use when actually running Exograph
 DEPENDENCY_STYLE=deb # how to install or setup dependencies
 TAG_SUFFIX="" # docker tag suffix
 


### PR DESCRIPTION
Since we switched to 22.04 in https://github.com/exograph/exograph/pull/1497, this change updates base image for docker to match it.