### PR TITLE
Speed up the verification in the dev mode

### DIFF
--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -82,7 +82,8 @@ impl CommandDefinition for DevCommandDefinition {
             let db_client = util::open_database(None).await?;
 
             loop {
-                let database = util::extract_postgres_database(&model, None, false).await?;
+                // Pass true as use_ir to use the IR model, since we just built the model in the watcher
+                let database = util::extract_postgres_database(&model, None, true).await?;
                 let verification_result = Migration::verify(&db_client, &database, &migration_scope).await;
 
                 match verification_result {


### PR DESCRIPTION
By reusiing the exo_ir that is already up-to-date, we save the cost of building just for verification