### PR TITLE
Fix precedence between logical operators

### DIFF
--- a/crates/builder/src/parser/converter.rs
+++ b/crates/builder/src/parser/converter.rs
@@ -845,6 +845,54 @@ mod tests {
     }
 
     #[multiplatform_test]
+    fn logical_op_precedence() {
+        // Should parse as `a || (b && c)`
+        parsing_test!(
+            r#"
+            @postgres
+            module TestModule {
+                @access(a || b && c)
+                type Foo {
+                }
+            }
+        "#,
+            "logical_op_precedence"
+        );
+    }
+
+    #[multiplatform_test]
+    fn logical_not_precedence_logical() {
+        // Should parse as `(!a) || b`
+        parsing_test!(
+            r#"
+            @postgres
+            module TestModule {       
+                @access(!a || b)
+                type Foo {
+                }
+            }
+        "#,
+            "logical_not_precedence_logical"
+        );
+    }
+
+    #[multiplatform_test]
+    fn logical_not_precedence_relational() {
+        // Should parse as `(!a) == b`
+        parsing_test!(
+            r#"
+            @postgres
+            module TestModule{            
+                @access(!a == b)
+                type Foo {
+                }
+            }
+        "#,
+            "logical_not_precedence_relational"
+        );
+    }
+
+    #[multiplatform_test]
     fn bb_schema() {
         parsing_test!(
             r#"

--- a/crates/builder/src/parser/snapshots/logical_not_precedence_logical.snap
+++ b/crates/builder/src/parser/snapshots/logical_not_precedence_logical.snap
@@ -1,0 +1,43 @@
+---
+source: crates/builder/src/parser/converter.rs
+expression: "convert_root(parsed.root_node(),\nr#\"\n            @postgres\n            module TestModule {       \n                @access(!a || b)\n                type Foo {\n                }\n            }\n        \"#.as_bytes(),\nfile_span, Path :: new(\"input.exo\")).unwrap()"
+---
+types: []
+modules:
+  - name: TestModule
+    annotations:
+      - name: postgres
+        params: None
+    types:
+      - name: Foo
+        kind: Type
+        fields: []
+        fragment_references: []
+        annotations:
+          - name: access
+            params:
+              Single:
+                - LogicalOp:
+                    Or:
+                      - LogicalOp:
+                          Not:
+                            - FieldSelection:
+                                Single:
+                                  - Identifier:
+                                      - a
+                                      - ~
+                                  - ~
+                            - ~
+                      - FieldSelection:
+                          Single:
+                            - Identifier:
+                                - b
+                                - ~
+                            - ~
+                      - ~
+        doc_comments: ~
+    methods: []
+    interceptors: []
+    base_exofile: input.exo
+    doc_comments: ~
+imports: []

--- a/crates/builder/src/parser/snapshots/logical_not_precedence_relational.snap
+++ b/crates/builder/src/parser/snapshots/logical_not_precedence_relational.snap
@@ -1,0 +1,43 @@
+---
+source: crates/builder/src/parser/converter.rs
+expression: "convert_root(parsed.root_node(),\nr#\"\n            @postgres\n            module TestModule{            \n                @access(!a == b)\n                type Foo {\n                }\n            }\n        \"#.as_bytes(),\nfile_span, Path :: new(\"input.exo\")).unwrap()"
+---
+types: []
+modules:
+  - name: TestModule
+    annotations:
+      - name: postgres
+        params: None
+    types:
+      - name: Foo
+        kind: Type
+        fields: []
+        fragment_references: []
+        annotations:
+          - name: access
+            params:
+              Single:
+                - RelationalOp:
+                    Eq:
+                      - LogicalOp:
+                          Not:
+                            - FieldSelection:
+                                Single:
+                                  - Identifier:
+                                      - a
+                                      - ~
+                                  - ~
+                            - ~
+                      - FieldSelection:
+                          Single:
+                            - Identifier:
+                                - b
+                                - ~
+                            - ~
+                      - ~
+        doc_comments: ~
+    methods: []
+    interceptors: []
+    base_exofile: input.exo
+    doc_comments: ~
+imports: []

--- a/crates/builder/src/parser/snapshots/logical_op_precedence.snap
+++ b/crates/builder/src/parser/snapshots/logical_op_precedence.snap
@@ -1,0 +1,49 @@
+---
+source: crates/builder/src/parser/converter.rs
+expression: "convert_root(parsed.root_node(),\nr#\"\n            @postgres\n            module TestModule {\n                @access(a || b && c)\n                type Foo {\n                }\n            }\n        \"#.as_bytes(),\nfile_span, Path :: new(\"input.exo\")).unwrap()"
+---
+types: []
+modules:
+  - name: TestModule
+    annotations:
+      - name: postgres
+        params: None
+    types:
+      - name: Foo
+        kind: Type
+        fields: []
+        fragment_references: []
+        annotations:
+          - name: access
+            params:
+              Single:
+                - LogicalOp:
+                    Or:
+                      - FieldSelection:
+                          Single:
+                            - Identifier:
+                                - a
+                                - ~
+                            - ~
+                      - LogicalOp:
+                          And:
+                            - FieldSelection:
+                                Single:
+                                  - Identifier:
+                                      - b
+                                      - ~
+                                  - ~
+                            - FieldSelection:
+                                Single:
+                                  - Identifier:
+                                      - c
+                                      - ~
+                                  - ~
+                            - ~
+                      - ~
+        doc_comments: ~
+    methods: []
+    interceptors: []
+    base_exofile: input.exo
+    doc_comments: ~
+imports: []

--- a/crates/builder/src/typechecker/snapshots/with_function_calls.snap
+++ b/crates/builder/src/typechecker/snapshots/with_function_calls.snap
@@ -160,31 +160,31 @@ types:
                                   - du
                                 expr:
                                   LogicalOp:
-                                    And:
+                                    Or:
+                                      - RelationalOp:
+                                          Eq:
+                                            - FieldSelection:
+                                                Select:
+                                                  - Single:
+                                                      - Identifier:
+                                                          - AuthContext
+                                                          - Reference:
+                                                              index: 16
+                                                              generation: ~
+                                                      - Reference:
+                                                          index: 16
+                                                          generation: ~
+                                                  - Identifier:
+                                                      - role
+                                                      - Defer
+                                                  - Reference:
+                                                      index: 4
+                                                      generation: ~
+                                            - StringLiteral:
+                                                - admin
+                                            - Primitive: Boolean
                                       - LogicalOp:
-                                          Or:
-                                            - RelationalOp:
-                                                Eq:
-                                                  - FieldSelection:
-                                                      Select:
-                                                        - Single:
-                                                            - Identifier:
-                                                                - AuthContext
-                                                                - Reference:
-                                                                    index: 16
-                                                                    generation: ~
-                                                            - Reference:
-                                                                index: 16
-                                                                generation: ~
-                                                        - Identifier:
-                                                            - role
-                                                            - Defer
-                                                        - Reference:
-                                                            index: 4
-                                                            generation: ~
-                                                  - StringLiteral:
-                                                      - admin
-                                                  - Primitive: Boolean
+                                          And:
                                             - RelationalOp:
                                                 Eq:
                                                   - FieldSelection:
@@ -222,24 +222,24 @@ types:
                                                             index: 4
                                                             generation: ~
                                                   - Primitive: Boolean
+                                            - FieldSelection:
+                                                Select:
+                                                  - Single:
+                                                      - Identifier:
+                                                          - du
+                                                          - Reference:
+                                                              index: 18
+                                                              generation: ~
+                                                      - Reference:
+                                                          index: 18
+                                                          generation: ~
+                                                  - Identifier:
+                                                      - write
+                                                      - Defer
+                                                  - Reference:
+                                                      index: 0
+                                                      generation: ~
                                             - Primitive: Boolean
-                                      - FieldSelection:
-                                          Select:
-                                            - Single:
-                                                - Identifier:
-                                                    - du
-                                                    - Reference:
-                                                        index: 18
-                                                        generation: ~
-                                                - Reference:
-                                                    index: 18
-                                                    generation: ~
-                                            - Identifier:
-                                                - write
-                                                - Defer
-                                            - Reference:
-                                                index: 0
-                                                generation: ~
                                       - Primitive: Boolean
                                 typ:
                                   Primitive: Boolean
@@ -271,31 +271,31 @@ types:
                                   - du
                                 expr:
                                   LogicalOp:
-                                    And:
+                                    Or:
+                                      - RelationalOp:
+                                          Eq:
+                                            - FieldSelection:
+                                                Select:
+                                                  - Single:
+                                                      - Identifier:
+                                                          - AuthContext
+                                                          - Reference:
+                                                              index: 16
+                                                              generation: ~
+                                                      - Reference:
+                                                          index: 16
+                                                          generation: ~
+                                                  - Identifier:
+                                                      - role
+                                                      - Defer
+                                                  - Reference:
+                                                      index: 4
+                                                      generation: ~
+                                            - StringLiteral:
+                                                - admin
+                                            - Primitive: Boolean
                                       - LogicalOp:
-                                          Or:
-                                            - RelationalOp:
-                                                Eq:
-                                                  - FieldSelection:
-                                                      Select:
-                                                        - Single:
-                                                            - Identifier:
-                                                                - AuthContext
-                                                                - Reference:
-                                                                    index: 16
-                                                                    generation: ~
-                                                            - Reference:
-                                                                index: 16
-                                                                generation: ~
-                                                        - Identifier:
-                                                            - role
-                                                            - Defer
-                                                        - Reference:
-                                                            index: 4
-                                                            generation: ~
-                                                  - StringLiteral:
-                                                      - admin
-                                                  - Primitive: Boolean
+                                          And:
                                             - RelationalOp:
                                                 Eq:
                                                   - FieldSelection:
@@ -333,24 +333,24 @@ types:
                                                             index: 4
                                                             generation: ~
                                                   - Primitive: Boolean
+                                            - FieldSelection:
+                                                Select:
+                                                  - Single:
+                                                      - Identifier:
+                                                          - du
+                                                          - Reference:
+                                                              index: 18
+                                                              generation: ~
+                                                      - Reference:
+                                                          index: 18
+                                                          generation: ~
+                                                  - Identifier:
+                                                      - read
+                                                      - Defer
+                                                  - Reference:
+                                                      index: 0
+                                                      generation: ~
                                             - Primitive: Boolean
-                                      - FieldSelection:
-                                          Select:
-                                            - Single:
-                                                - Identifier:
-                                                    - du
-                                                    - Reference:
-                                                        index: 18
-                                                        generation: ~
-                                                - Reference:
-                                                    index: 18
-                                                    generation: ~
-                                            - Identifier:
-                                                - read
-                                                - Defer
-                                            - Reference:
-                                                index: 0
-                                                generation: ~
                                       - Primitive: Boolean
                                 typ:
                                   Primitive: Boolean
@@ -589,31 +589,31 @@ modules:
                                     - du
                                   expr:
                                     LogicalOp:
-                                      And:
+                                      Or:
+                                        - RelationalOp:
+                                            Eq:
+                                              - FieldSelection:
+                                                  Select:
+                                                    - Single:
+                                                        - Identifier:
+                                                            - AuthContext
+                                                            - Reference:
+                                                                index: 16
+                                                                generation: ~
+                                                        - Reference:
+                                                            index: 16
+                                                            generation: ~
+                                                    - Identifier:
+                                                        - role
+                                                        - Defer
+                                                    - Reference:
+                                                        index: 4
+                                                        generation: ~
+                                              - StringLiteral:
+                                                  - admin
+                                              - Primitive: Boolean
                                         - LogicalOp:
-                                            Or:
-                                              - RelationalOp:
-                                                  Eq:
-                                                    - FieldSelection:
-                                                        Select:
-                                                          - Single:
-                                                              - Identifier:
-                                                                  - AuthContext
-                                                                  - Reference:
-                                                                      index: 16
-                                                                      generation: ~
-                                                              - Reference:
-                                                                  index: 16
-                                                                  generation: ~
-                                                          - Identifier:
-                                                              - role
-                                                              - Defer
-                                                          - Reference:
-                                                              index: 4
-                                                              generation: ~
-                                                    - StringLiteral:
-                                                        - admin
-                                                    - Primitive: Boolean
+                                            And:
                                               - RelationalOp:
                                                   Eq:
                                                     - FieldSelection:
@@ -651,24 +651,24 @@ modules:
                                                               index: 4
                                                               generation: ~
                                                     - Primitive: Boolean
+                                              - FieldSelection:
+                                                  Select:
+                                                    - Single:
+                                                        - Identifier:
+                                                            - du
+                                                            - Reference:
+                                                                index: 18
+                                                                generation: ~
+                                                        - Reference:
+                                                            index: 18
+                                                            generation: ~
+                                                    - Identifier:
+                                                        - write
+                                                        - Defer
+                                                    - Reference:
+                                                        index: 0
+                                                        generation: ~
                                               - Primitive: Boolean
-                                        - FieldSelection:
-                                            Select:
-                                              - Single:
-                                                  - Identifier:
-                                                      - du
-                                                      - Reference:
-                                                          index: 18
-                                                          generation: ~
-                                                  - Reference:
-                                                      index: 18
-                                                      generation: ~
-                                              - Identifier:
-                                                  - write
-                                                  - Defer
-                                              - Reference:
-                                                  index: 0
-                                                  generation: ~
                                         - Primitive: Boolean
                                   typ:
                                     Primitive: Boolean
@@ -700,31 +700,31 @@ modules:
                                     - du
                                   expr:
                                     LogicalOp:
-                                      And:
+                                      Or:
+                                        - RelationalOp:
+                                            Eq:
+                                              - FieldSelection:
+                                                  Select:
+                                                    - Single:
+                                                        - Identifier:
+                                                            - AuthContext
+                                                            - Reference:
+                                                                index: 16
+                                                                generation: ~
+                                                        - Reference:
+                                                            index: 16
+                                                            generation: ~
+                                                    - Identifier:
+                                                        - role
+                                                        - Defer
+                                                    - Reference:
+                                                        index: 4
+                                                        generation: ~
+                                              - StringLiteral:
+                                                  - admin
+                                              - Primitive: Boolean
                                         - LogicalOp:
-                                            Or:
-                                              - RelationalOp:
-                                                  Eq:
-                                                    - FieldSelection:
-                                                        Select:
-                                                          - Single:
-                                                              - Identifier:
-                                                                  - AuthContext
-                                                                  - Reference:
-                                                                      index: 16
-                                                                      generation: ~
-                                                              - Reference:
-                                                                  index: 16
-                                                                  generation: ~
-                                                          - Identifier:
-                                                              - role
-                                                              - Defer
-                                                          - Reference:
-                                                              index: 4
-                                                              generation: ~
-                                                    - StringLiteral:
-                                                        - admin
-                                                    - Primitive: Boolean
+                                            And:
                                               - RelationalOp:
                                                   Eq:
                                                     - FieldSelection:
@@ -762,24 +762,24 @@ modules:
                                                               index: 4
                                                               generation: ~
                                                     - Primitive: Boolean
+                                              - FieldSelection:
+                                                  Select:
+                                                    - Single:
+                                                        - Identifier:
+                                                            - du
+                                                            - Reference:
+                                                                index: 18
+                                                                generation: ~
+                                                        - Reference:
+                                                            index: 18
+                                                            generation: ~
+                                                    - Identifier:
+                                                        - read
+                                                        - Defer
+                                                    - Reference:
+                                                        index: 0
+                                                        generation: ~
                                               - Primitive: Boolean
-                                        - FieldSelection:
-                                            Select:
-                                              - Single:
-                                                  - Identifier:
-                                                      - du
-                                                      - Reference:
-                                                          index: 18
-                                                          generation: ~
-                                                  - Reference:
-                                                      index: 18
-                                                      generation: ~
-                                              - Identifier:
-                                                  - read
-                                                  - Defer
-                                              - Reference:
-                                                  index: 0
-                                                  generation: ~
                                         - Primitive: Boolean
                                   typ:
                                     Primitive: Boolean


### PR DESCRIPTION
In access expressions, we now parse to match the precedence rules in most languages such as Rust, C, JavaScript. For example, we now parse `a || b && c` as `a || (b && c)`.