### PR TITLE
Cleanup database servers created during tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3730,6 +3730,7 @@ version = "0.12.3"
 dependencies = [
  "bytes",
  "chrono",
+ "ctor",
  "deadpool-postgres",
  "exo-sql",
  "futures",

--- a/libs/exo-sql/Cargo.toml
+++ b/libs/exo-sql/Cargo.toml
@@ -18,7 +18,7 @@ postgres-url = ["tokio-postgres/runtime"]
 testing = ["which", "tempfile"]
 pool = ["deadpool-postgres"]
 bigdecimal = ["pg_bigdecimal"]
-test-support = []
+test-support = ["ctor"]
 
 [dependencies]
 bytes.workspace = true
@@ -57,6 +57,8 @@ tempfile = { workspace = true, optional = true }
 urlencoding = "2.1.2"
 
 serde_json.workspace = true
+
+ctor = { workspace = true, optional = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies.tokio-postgres]
 workspace = true

--- a/libs/exo-sql/src/testing/test_support.rs
+++ b/libs/exo-sql/src/testing/test_support.rs
@@ -2,7 +2,8 @@
 
 use std::future::Future;
 use std::sync::LazyLock;
-use tokio::sync::Mutex;
+use std::sync::Mutex;
+use std::sync::PoisonError;
 
 use crate::sql::connect::database_client::DatabaseClient;
 use crate::testing::db::{
@@ -19,13 +20,26 @@ static DATABASE_SERVER: LazyLock<Mutex<Box<dyn EphemeralDatabaseServer + Send + 
         )
     });
 
+#[ctor::dtor]
+fn cleanup() {
+    let database_server = DATABASE_SERVER
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
+
+    database_server.cleanup();
+}
+
+// We need Mutex, whose value can be accessed from non-async code (the cleanup function above).
+// Thus we can't use tokio::sync::Mutex here.
+// TODO: Find a better way to handle this.
+#[allow(clippy::await_holding_lock)]
 pub async fn with_client<Fut, T>(f: impl FnOnce(DatabaseClient) -> Fut) -> T
 where
     Fut: Future<Output = T>,
 {
     let database_name = generate_random_string();
 
-    let database_server = DATABASE_SERVER.lock().await;
+    let database_server = DATABASE_SERVER.lock().unwrap();
     let database_server = database_server.as_ref();
 
     let database = database_server.create_database(&database_name).unwrap();


### PR DESCRIPTION
Since we used a static for the global database server instance (docker or local), upon process exit (i.e. unit test completion), the container remained hanging.

We now use `ctor::dtor` to drop any databases created