### PR TITLE
Upgrade sqlparser to use the upstream version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7556,6 +7556,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "recursive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0786a43debb760f491b1bc0269fe5e84155353c67482b9e60d0cfb596054b43e"
+dependencies = [
+ "recursive-proc-macro-impl",
+ "stacker",
+]
+
+[[package]]
+name = "recursive-proc-macro-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
+dependencies = [
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8715,10 +8735,12 @@ checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "sqlparser"
-version = "0.53.0"
-source = "git+https://github.com/exograph/datafusion-sqlparser-rs.git?branch=optional-columns-foreign-reference#de8858305a1ba77de495091d0cb313b8133c519a"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4521174166bac1ff04fe16ef4524c70144cd29682a45978978ca3d7f4e0be11"
 dependencies = [
  "log",
+ "recursive",
 ]
 
 [[package]]

--- a/crates/postgres-subsystem/postgres-core-model/Cargo.toml
+++ b/crates/postgres-subsystem/postgres-core-model/Cargo.toml
@@ -20,7 +20,7 @@ tokio.workspace = true
 wasm-bindgen-test.workspace = true
 bincode.workspace = true
 exo-sql = { path = "../../../libs/exo-sql", features = ["bigdecimal"] }
-sqlparser = { git = "https://github.com/exograph/datafusion-sqlparser-rs.git", branch = "optional-columns-foreign-reference" }
+sqlparser = "0.55.0"
 colored.workspace = true
 
 common = { path = "../../common", features = ["test-support"] }


### PR DESCRIPTION
Since our fork is merged into the mainstream, we no longer need to depend on the fork.

[1] https://github.com/apache/datafusion-sqlparser-rs/commit/77b5bd6fa8b85b22cb712d9995d2512b5b74038c
[2] https://github.com/apache/datafusion-sqlparser-rs/commit/7dbf31b5875c4643dee493367203d4f29e7f1033
[3] https://github.com/apache/datafusion-sqlparser-rs/commit/6523dabcf886c69be58ca8e486683fb6e02e0f16