### PR TITLE
fix: Make access control expression that point to a relation work

### DIFF
--- a/integration-tests/access-null-field-check/schema-tests/introspection.expected.graphql
+++ b/integration-tests/access-null-field-check/schema-tests/introspection.expected.graphql
@@ -1,0 +1,231 @@
+type IntAgg {
+  min: Int
+  max: Int
+  sum: Int
+  avg: Float
+  count: Int
+}
+
+input IntFilter {
+  eq: Int
+  neq: Int
+  lt: Int
+  lte: Int
+  gt: Int
+  gte: Int
+}
+
+type Issue {
+  id: Int!
+  title: String!
+  assignee: User
+}
+
+"""An aggregate for the `Issue` type."""
+type IssueAgg {
+  id: IntAgg
+  title: StringAgg
+}
+
+input IssueCreationInput {
+  title: String!
+  assignee: UserReferenceInput
+}
+
+input IssueCreationInputFromUser {
+  title: String!
+}
+
+"""
+Predicate for the `Issue` type parameter. 
+If a field is omitted, no filter is applied for that field.
+To check a field against null, use a `<field name>: null` filter
+"""
+input IssueFilter {
+  id: IntFilter
+  title: StringFilter
+  assignee: UserFilter
+  and: [IssueFilter!]
+  or: [IssueFilter!]
+  not: IssueFilter
+}
+
+input IssueOrdering {
+  id: Ordering
+  title: Ordering
+  assignee: [UserOrdering!]
+}
+
+input IssueReferenceInput {
+  id: Int!
+}
+
+input IssueUpdateInput {
+  id: Int
+  title: String
+  assignee: UserReferenceInput
+}
+
+input IssueUpdateInputFromUser {
+  create: [IssueCreationInputFromUser!]
+  update: [IssueUpdateInputFromUserNested!]
+  delete: [IssueReferenceInput!]
+}
+
+input IssueUpdateInputFromUserNested {
+  id: Int!
+  title: String
+}
+
+enum Ordering {
+  ASC
+  DESC
+}
+
+type StringAgg {
+  min: String
+  max: String
+  count: Int
+}
+
+input StringFilter {
+  eq: String
+  neq: String
+  lt: String
+  lte: String
+  gt: String
+  gte: String
+  like: String
+  ilike: String
+  startsWith: String
+  endsWith: String
+}
+
+type User {
+  id: Int!
+  name: String!
+  assignedIssues(where: IssueFilter, orderBy: [IssueOrdering!], limit: Int, offset: Int): [Issue!]
+  assignedIssuesAgg(where: IssueFilter): IssueAgg
+}
+
+"""An aggregate for the `User` type."""
+type UserAgg {
+  id: IntAgg
+  name: StringAgg
+}
+
+input UserCreationInput {
+  name: String!
+  assignedIssues: [IssueCreationInputFromUser!]
+}
+
+"""
+Predicate for the `User` type parameter. 
+If a field is omitted, no filter is applied for that field.
+To check a field against null, use a `<field name>: null` filter
+"""
+input UserFilter {
+  id: IntFilter
+  name: StringFilter
+  assignedIssues: IssueFilter
+  and: [UserFilter!]
+  or: [UserFilter!]
+  not: UserFilter
+}
+
+input UserOrdering {
+  id: Ordering
+  name: Ordering
+}
+
+input UserReferenceInput {
+  id: Int!
+}
+
+input UserUpdateInput {
+  id: Int
+  name: String
+  assignedIssues: IssueUpdateInputFromUser
+}
+
+type Query {
+  """Get a single `Issue` given primary key fields"""
+  issue(id: Int!): Issue
+
+  """
+  Get multiple `Issue`s given the provided `where` filter, order by, limit, and offset
+  """
+  issues(where: IssueFilter, orderBy: [IssueOrdering!], limit: Int, offset: Int): [Issue!]!
+
+  """
+  Get the aggregate value of the selected fields over all `Issue`s given the provided `where` filter
+  """
+  issuesAgg(where: IssueFilter): IssueAgg!
+
+  """Get a single `User` given primary key fields"""
+  user(id: Int!): User
+
+  """
+  Get multiple `User`s given the provided `where` filter, order by, limit, and offset
+  """
+  users(where: UserFilter, orderBy: [UserOrdering!], limit: Int, offset: Int): [User!]!
+
+  """
+  Get the aggregate value of the selected fields over all `User`s given the provided `where` filter
+  """
+  usersAgg(where: UserFilter): UserAgg!
+}
+
+type Mutation {
+  """
+  Create a new Issue. Check the `IssueCreationInput` type for the expected shape of the data.
+  """
+  createIssue(data: IssueCreationInput!): Issue!
+
+  """
+  Create multiple Issues. Check the `IssueCreationInput` type for the expected shape of the data.
+  """
+  createIssues(data: [IssueCreationInput!]!): [Issue!]!
+
+  """
+  Create a new User. Check the `UserCreationInput` type for the expected shape of the data.
+  """
+  createUser(data: UserCreationInput!): User!
+
+  """
+  Create multiple Users. Check the `UserCreationInput` type for the expected shape of the data.
+  """
+  createUsers(data: [UserCreationInput!]!): [User!]!
+
+  """Delete the Issue with the provided primary key."""
+  deleteIssue(id: Int!): Issue
+
+  """Delete multiple Issues matching the provided `where` filter."""
+  deleteIssues(where: IssueFilter): [Issue!]!
+
+  """Delete the User with the provided primary key."""
+  deleteUser(id: Int!): User
+
+  """Delete multiple Users matching the provided `where` filter."""
+  deleteUsers(where: UserFilter): [User!]!
+
+  """
+  Update the Issue with the provided primary key with the provided data. Any fields not provided will remain unchanged.
+  """
+  updateIssue(id: Int!, data: IssueUpdateInput!): Issue
+
+  """
+  Update multiple Issues matching the provided `where` filter with the provided data. Any fields not provided will remain unchanged.
+  """
+  updateIssues(where: IssueFilter, data: IssueUpdateInput!): [Issue!]!
+
+  """
+  Update the User with the provided primary key with the provided data. Any fields not provided will remain unchanged.
+  """
+  updateUser(id: Int!, data: UserUpdateInput!): User
+
+  """
+  Update multiple Users matching the provided `where` filter with the provided data. Any fields not provided will remain unchanged.
+  """
+  updateUsers(where: UserFilter, data: UserUpdateInput!): [User!]!
+}

--- a/integration-tests/access-null-field-check/src/index.exo
+++ b/integration-tests/access-null-field-check/src/index.exo
@@ -1,0 +1,22 @@
+context AuthContext {
+  @jwt("sub") id: Int?
+  @jwt role: String
+}
+
+@postgres
+module JiraClone {
+  @access(true)
+  type User {
+    @pk id: Int = autoIncrement()
+    name: String
+    assignedIssues: Set<Issue>?
+  }
+
+  // Note the leaf path point to a relation without completing the chain
+  @access((self.assignee != null && AuthContext.role == "user") || AuthContext.role == "admin")
+  type Issue {
+    @pk id: Int = autoIncrement()
+    title: String
+    assignee: User?
+  }
+}

--- a/integration-tests/access-null-field-check/tests/init.gql
+++ b/integration-tests/access-null-field-check/tests/init.gql
@@ -1,0 +1,35 @@
+stages:
+    - operation: |
+        mutation {
+            user1: createUser(data: {name: "user1"}) {
+                id @bind(name: "user1Id")
+            }
+            user2: createUser(data: {name: "user2"}) {
+                id @bind(name: "user2Id")
+            }
+        }  
+      auth: |
+        {
+            "role": "admin"
+        }
+    - operation: |
+        mutation($user1Id: Int!, $user2Id: Int!) {
+            issue1: createIssue(data: {title: "issue1", assignee: {id: $user1Id}}) {
+                id
+            }
+            issue2: createIssue(data: {title: "issue2", assignee: {id: $user2Id}}) {
+                id
+            }
+            unassignedIssue: createIssue(data: {title: "unassigned issue"}) {
+                id
+            }
+        }
+      variable: |
+        {
+            "user1Id": $.user1Id,
+            "user2Id": $.user2Id
+        }
+      auth: |
+        {
+            "role": "admin"
+        }        

--- a/integration-tests/access-null-field-check/tests/query-admin-user.exotest
+++ b/integration-tests/access-null-field-check/tests/query-admin-user.exotest
@@ -1,0 +1,31 @@
+operation: |
+  query {
+    issues {
+      id
+      title
+    }
+  }
+auth: |
+  {
+      "role": "admin"
+  }   
+response: |
+  {
+    "data": {
+      "issues": [
+        {
+          "id": 1,
+          "title": "issue1"
+        },
+        {
+          "id": 2,
+          "title": "issue2"
+        },
+        {
+          "id": 3,
+          "title": "unassigned issue"
+        }
+      ]
+    }
+  }
+

--- a/integration-tests/access-null-field-check/tests/query-auth-user.exotest
+++ b/integration-tests/access-null-field-check/tests/query-auth-user.exotest
@@ -1,0 +1,28 @@
+operation: |
+  query {
+    assignedIssues: issues {
+      id
+      title
+    }
+    
+  }
+auth: |
+  {
+    "sub": 2,
+    "role": "user"
+  }   
+response: |
+  {
+    "data": {
+      "assignedIssues": [
+        {
+          "id": 1,
+          "title": "issue1"
+        },
+        {
+          "id": 2,
+          "title": "issue2"
+        }
+      ]
+    }
+  }

--- a/integration-tests/access-null-field-check/tests/query-non-user copy.exotest
+++ b/integration-tests/access-null-field-check/tests/query-non-user copy.exotest
@@ -1,0 +1,22 @@
+operation: |
+  query {
+    issues {
+      id
+      title
+    }
+    
+  }
+auth: |
+  {
+    "sub": 2,
+    "role": "non-user"
+  }   
+response: |
+  {
+    "errors": [
+      {
+        "message": "Not authorized"
+      }
+    ]
+  }
+


### PR DESCRIPTION
This supports expressions such as `self.user != null` (note `user` point to a relation and not to a scalar).