### PR TITLE
Rename `PhysicalTableName` to `SchemaObjectName`

### DIFF
--- a/crates/cli/src/commands/schema/import/table_processor.rs
+++ b/crates/cli/src/commands/schema/import/table_processor.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use exo_sql::{
     schema::{database_spec::DatabaseSpec, table_spec::TableSpec},
-    PhysicalTableName,
+    SchemaObjectName,
 };
 
 use super::{processor::INDENT, ImportContext, ModelProcessor};
@@ -62,7 +62,7 @@ impl ModelProcessor<DatabaseSpec> for TableSpec {
 fn write_references(
     writer: &mut (dyn std::io::Write + Send),
     context: &ImportContext,
-    table_name: &PhysicalTableName,
+    table_name: &SchemaObjectName,
 ) -> Result<()> {
     for (table_name, column, _) in context.referenced_columns(table_name) {
         let model_name = context.model_name(&table_name);

--- a/crates/postgres-subsystem/postgres-core-builder/src/resolved_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/resolved_builder.rs
@@ -41,7 +41,7 @@ use core_model_builder::{
         Typed,
     },
 };
-use exo_sql::{PhysicalTableName, VectorDistanceFunction};
+use exo_sql::{SchemaObjectName, VectorDistanceFunction};
 
 use heck::ToSnakeCase;
 
@@ -137,7 +137,7 @@ fn resolve(
                     ResolvedType::Enum(ResolvedEnumType {
                         name: et.name.clone(),
                         fields: et.fields.iter().map(|f| f.name.clone()).collect(),
-                        enum_name: PhysicalTableName::new(
+                        enum_name: SchemaObjectName::new(
                             et.name.to_snake_case(),
                             module_schema_name.as_deref(),
                         ),
@@ -236,7 +236,7 @@ fn resolve_composite_type(
                 plural_name: plural_name.clone(),
                 representation,
                 fields: resolved_fields,
-                table_name: PhysicalTableName {
+                table_name: SchemaObjectName {
                     name: table_name,
                     schema: schema_name,
                 },
@@ -376,10 +376,10 @@ fn resolve_field_default_type(
                         // Split the sequence name by '.' and use the last part as the sequence name
                         match sequence_name.split('.').collect::<Vec<&str>>()[..] {
                             [schema, name] => ResolvedFieldDefault::AutoIncrement(Some(
-                                PhysicalTableName::new(name.to_string(), Some(schema)),
+                                SchemaObjectName::new(name.to_string(), Some(schema)),
                             )),
                             [name] => ResolvedFieldDefault::AutoIncrement(Some(
-                                PhysicalTableName::new(name.to_string(), None),
+                                SchemaObjectName::new(name.to_string(), None),
                             )),
                             _ => {
                                 errors.push(Diagnostic {

--- a/crates/postgres-subsystem/postgres-core-builder/src/resolved_type.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/resolved_type.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use codemap::Span;
-use exo_sql::{PhysicalTableName, VectorDistanceFunction};
+use exo_sql::{SchemaObjectName, VectorDistanceFunction};
 use postgres_core_model::types::EntityRepresentation;
 use serde::{Deserialize, Serialize};
 
@@ -44,7 +44,7 @@ pub enum ResolvedType {
 pub struct ResolvedEnumType {
     pub name: String,
     pub fields: Vec<String>,
-    pub enum_name: PhysicalTableName,
+    pub enum_name: SchemaObjectName,
     pub doc_comments: Option<String>,
     #[serde(skip_serializing)]
     #[serde(skip_deserializing)]
@@ -59,7 +59,7 @@ pub struct ResolvedCompositeType {
     pub representation: EntityRepresentation,
 
     pub fields: Vec<ResolvedField>,
-    pub table_name: PhysicalTableName,
+    pub table_name: SchemaObjectName,
     pub access: ResolvedAccess,
     pub doc_comments: Option<String>,
     #[serde(skip_serializing)]
@@ -197,7 +197,7 @@ impl ResolvedCompositeType {
 pub enum ResolvedFieldDefault {
     Value(Box<AstExpr<Typed>>),
     PostgresFunction(String),
-    AutoIncrement(Option<PhysicalTableName>),
+    AutoIncrement(Option<SchemaObjectName>),
 }
 
 impl ResolvedType {

--- a/crates/postgres-subsystem/postgres-core-model/src/types.rs
+++ b/crates/postgres-subsystem/postgres-core-model/src/types.rs
@@ -21,7 +21,7 @@ use core_model::{
 
 use crate::access::Access;
 
-use exo_sql::{PhysicalTable, PhysicalTableName};
+use exo_sql::{PhysicalTable, SchemaObjectName};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
@@ -153,7 +153,7 @@ pub enum PostgresFieldDefaultValue {
     Static(Val),
     Dynamic(ContextSelection),
     Function(String), // Postgres function name such as `now()`
-    AutoIncrement(Option<PhysicalTableName>),
+    AutoIncrement(Option<SchemaObjectName>),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/access/database_solver.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/access/database_solver.rs
@@ -17,7 +17,7 @@ mod tests {
 
     use exo_env::MapEnvironment;
     use exo_sql::{
-        AbstractPredicate, ColumnPath, PhysicalColumnPath, PhysicalTableName, SQLParamContainer,
+        AbstractPredicate, ColumnPath, PhysicalColumnPath, SQLParamContainer, SchemaObjectName,
     };
     use postgres_core_model::access::DatabaseAccessPrimitiveExpression;
     use postgres_graphql_model::subsystem::PostgresGraphQLSubsystem;
@@ -90,7 +90,7 @@ mod tests {
         let database = &postgres_subsystem.core_subsystem.database;
 
         let article_table_id = database
-            .get_table_id(&PhysicalTableName::new("articles", None))
+            .get_table_id(&SchemaObjectName::new("articles", None))
             .unwrap();
 
         let get_column_id = |column_name: &str| {

--- a/libs/exo-sql/src/lib.rs
+++ b/libs/exo-sql/src/lib.rs
@@ -73,9 +73,10 @@ pub use sql::{
     offset::Offset,
     order::Ordering,
     physical_column::{ColumnId, FloatBits, IntBits, PhysicalColumn, PhysicalColumnType},
-    physical_table::{PhysicalEnum, PhysicalIndex, PhysicalTable, PhysicalTableName},
+    physical_table::{PhysicalEnum, PhysicalIndex, PhysicalTable},
     predicate::{CaseSensitivity, NumericComparator, ParamEquality, Predicate},
     relation::{ManyToOne, ManyToOneId, OneToMany, OneToManyId, RelationColumnPair, RelationId},
+    schema_object::SchemaObjectName,
     vector::{VectorDistanceFunction, DEFAULT_VECTOR_SIZE},
     SQLBytes, SQLParam, SQLParamContainer,
 };

--- a/libs/exo-sql/src/schema/constraint.rs
+++ b/libs/exo-sql/src/schema/constraint.rs
@@ -13,7 +13,7 @@ use lazy_static::lazy_static;
 use regex::Regex;
 
 use crate::{
-    database_error::DatabaseError, sql::connect::database_client::DatabaseClient, PhysicalTableName,
+    database_error::DatabaseError, sql::connect::database_client::DatabaseClient, SchemaObjectName,
 };
 
 pub(super) struct PrimaryKeyConstraint {
@@ -29,7 +29,7 @@ pub(super) struct ForeignKeyConstraintColumnPair {
 pub(super) struct ForeignKeyConstraint {
     pub(super) constraint_name: String,
     pub(super) column_pairs: Vec<ForeignKeyConstraintColumnPair>,
-    pub(super) foreign_table: PhysicalTableName,
+    pub(super) foreign_table: SchemaObjectName,
 }
 
 #[derive(Debug)]
@@ -74,7 +74,7 @@ WHERE
 impl Constraints {
     pub(super) async fn from_live_db(
         client: &DatabaseClient,
-        table_name: &PhysicalTableName,
+        table_name: &SchemaObjectName,
     ) -> Result<Constraints, DatabaseError> {
         // Get a list of constraints in the table (primary key and foreign key constraints)
         let constraints = client
@@ -119,7 +119,7 @@ impl Constraints {
             .iter()
             .filter(|(contype, _, _, _, _)| *contype == 'f')
             .map(|(_, conname, condef, foreign_table, foreign_schema)| {
-                let foreign_table = PhysicalTableName {
+                let foreign_table = SchemaObjectName {
                     name: foreign_table.clone().unwrap(),
                     schema: match foreign_schema {
                         Some(schema) if schema != "public" => Some(schema.to_string()),

--- a/libs/exo-sql/src/schema/database_spec.rs
+++ b/libs/exo-sql/src/schema/database_spec.rs
@@ -13,7 +13,7 @@ use crate::{
     database_error::DatabaseError,
     schema::column_spec::ColumnSpec,
     sql::{connect::database_client::DatabaseClient, relation::RelationColumnPair},
-    Database, ManyToOne, PhysicalColumn, PhysicalIndex, PhysicalTable, PhysicalTableName, TableId,
+    Database, ManyToOne, PhysicalColumn, PhysicalIndex, PhysicalTable, SchemaObjectName, TableId,
 };
 
 use super::{
@@ -68,7 +68,7 @@ impl DatabaseSpec {
     }
 
     // Explicitly required sequences for this database spec.
-    pub fn required_sequences(&self, scope: &MigrationScopeMatches) -> HashSet<PhysicalTableName> {
+    pub fn required_sequences(&self, scope: &MigrationScopeMatches) -> HashSet<SchemaObjectName> {
         self.tables
             .iter()
             .filter(|table| scope.matches(&table.name) && table.managed)
@@ -281,7 +281,7 @@ impl DatabaseSpec {
                 .map_err(DatabaseError::Delegate)?
             {
                 let enum_name: String = enum_row.get("enum_name");
-                let enum_name = PhysicalTableName::new_with_schema_name(enum_name, schema_name);
+                let enum_name = SchemaObjectName::new_with_schema_name(enum_name, schema_name);
 
                 let mut enum_ = EnumSpec::from_live_db_enum(client, enum_name).await?;
 
@@ -305,7 +305,7 @@ impl DatabaseSpec {
                 .map_err(DatabaseError::Delegate)?
             {
                 let table_name: String = table_row.get("table_name");
-                let table_name = PhysicalTableName::new_with_schema_name(table_name, &schema_name);
+                let table_name = SchemaObjectName::new_with_schema_name(table_name, &schema_name);
 
                 let mut table =
                     TableSpec::from_live_db_table(client, table_name, &column_attributes).await?;
@@ -320,7 +320,7 @@ impl DatabaseSpec {
                 .map_err(DatabaseError::Delegate)?
             {
                 let view_name: String = view_row.get("view_name");
-                let table_name = PhysicalTableName::new_with_schema_name(view_name, &schema_name);
+                let table_name = SchemaObjectName::new_with_schema_name(view_name, &schema_name);
 
                 let mut table =
                     TableSpec::from_live_db_materialized_view(client, table_name, &enums).await?;
@@ -335,7 +335,7 @@ impl DatabaseSpec {
                 .map_err(DatabaseError::Delegate)?
             {
                 let sequence_name: String = sequence_row.get("sequence_name");
-                sequences.push(PhysicalTableName::new_with_schema_name(
+                sequences.push(SchemaObjectName::new_with_schema_name(
                     sequence_name,
                     &schema_name,
                 ));
@@ -426,7 +426,7 @@ mod tests {
             "CREATE TABLE users (id SERIAL PRIMARY KEY, name VARCHAR(255), email VARCHAR)",
             DatabaseSpec::new(
                 vec![TableSpec::new(
-                    PhysicalTableName {
+                    SchemaObjectName {
                         name: "users".into(),
                         schema: None,
                     },
@@ -480,7 +480,7 @@ mod tests {
             "CREATE TABLE users (complete BOOLEAN)",
             DatabaseSpec::new(
                 vec![TableSpec::new(
-                    PhysicalTableName {
+                    SchemaObjectName {
                         name: "users".into(),
                         schema: None,
                     },
@@ -511,7 +511,7 @@ mod tests {
             "CREATE TABLE items (precision_and_scale NUMERIC(10, 2), just_precision NUMERIC(20), no_precision_and_scale NUMERIC)",
             DatabaseSpec::new(
                 vec![TableSpec::new(
-                    PhysicalTableName {
+                    SchemaObjectName {
                         name: "items".into(),
                         schema: None,
                     },

--- a/libs/exo-sql/src/schema/enum_spec.rs
+++ b/libs/exo-sql/src/schema/enum_spec.rs
@@ -9,7 +9,7 @@
 
 use crate::database_error::DatabaseError;
 use crate::sql::connect::database_client::DatabaseClient;
-use crate::PhysicalTableName;
+use crate::SchemaObjectName;
 
 use super::issue::WithIssues;
 use super::op::SchemaOp;
@@ -20,12 +20,12 @@ const ENUM_VARIANTS_QUERY: &str = "SELECT e.enumlabel AS enum_value FROM pg_type
 
 #[derive(Debug)]
 pub struct EnumSpec {
-    pub name: PhysicalTableName,
+    pub name: SchemaObjectName,
     pub variants: Vec<String>,
 }
 
 impl EnumSpec {
-    pub fn new(name: PhysicalTableName, variants: Vec<String>) -> Self {
+    pub fn new(name: SchemaObjectName, variants: Vec<String>) -> Self {
         Self { name, variants }
     }
 
@@ -35,7 +35,7 @@ impl EnumSpec {
 
     pub(super) async fn from_live_db_enum(
         client: &DatabaseClient,
-        name: PhysicalTableName,
+        name: SchemaObjectName,
     ) -> Result<WithIssues<EnumSpec>, DatabaseError> {
         let mut variants = Vec::new();
 

--- a/libs/exo-sql/src/schema/index_spec.rs
+++ b/libs/exo-sql/src/schema/index_spec.rs
@@ -12,8 +12,8 @@ use std::collections::HashSet;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    database_error::DatabaseError, sql::connect::database_client::DatabaseClient,
-    PhysicalTableName, VectorDistanceFunction,
+    database_error::DatabaseError, sql::connect::database_client::DatabaseClient, SchemaObjectName,
+    VectorDistanceFunction,
 };
 
 use super::{column_spec::ColumnSpec, issue::WithIssues, op::SchemaOp, table_spec::TableSpec};
@@ -90,7 +90,7 @@ impl IndexSpec {
 
     pub async fn from_live_db(
         client: &DatabaseClient,
-        table_name: &PhysicalTableName,
+        table_name: &SchemaObjectName,
         columns: &[ColumnSpec],
     ) -> Result<WithIssues<Vec<IndexSpec>>, DatabaseError> {
         let indices = client
@@ -171,7 +171,7 @@ impl IndexSpec {
         ]
     }
 
-    pub fn creation_sql(&self, table_name: &PhysicalTableName) -> String {
+    pub fn creation_sql(&self, table_name: &SchemaObjectName) -> String {
         let sorted_columns = {
             let mut columns = self.columns.iter().collect::<Vec<_>>();
             columns.sort();

--- a/libs/exo-sql/src/schema/op.rs
+++ b/libs/exo-sql/src/schema/op.rs
@@ -11,7 +11,7 @@ use std::collections::HashSet;
 
 use crate::{
     schema::{constraint::sorted_comma_list, index_spec::IndexSpec},
-    PhysicalTableName,
+    SchemaObjectName,
 };
 
 use super::{
@@ -34,10 +34,10 @@ pub enum SchemaOp<'a> {
     },
 
     CreateSequence {
-        sequence: PhysicalTableName,
+        sequence: SchemaObjectName,
     },
     DeleteSequence {
-        sequence: PhysicalTableName,
+        sequence: SchemaObjectName,
     },
 
     CreateTable {

--- a/libs/exo-sql/src/schema/spec.rs
+++ b/libs/exo-sql/src/schema/spec.rs
@@ -14,7 +14,7 @@ use std::{
 
 use wildmatch::WildMatch;
 
-use crate::PhysicalTableName;
+use crate::SchemaObjectName;
 
 use super::{database_spec::DatabaseSpec, op::SchemaOp};
 
@@ -38,7 +38,7 @@ impl MigrationScopeMatches {
         Self(vec![(NameMatching::new("*"), NameMatching::new("*"))])
     }
 
-    pub fn matches(&self, table_name: &PhysicalTableName) -> bool {
+    pub fn matches(&self, table_name: &SchemaObjectName) -> bool {
         self.0.iter().any(|(schema_pattern, table_pattern)| {
             schema_pattern.matches(&table_name.schema_name())
                 && table_pattern.matches(&table_name.name)

--- a/libs/exo-sql/src/schema/table_spec.rs
+++ b/libs/exo-sql/src/schema/table_spec.rs
@@ -12,7 +12,7 @@ use std::collections::{HashMap, HashSet};
 use crate::database_error::DatabaseError;
 use crate::schema::constraint::ForeignKeyConstraintColumnPair;
 use crate::sql::connect::database_client::DatabaseClient;
-use crate::{PhysicalTable, PhysicalTableName};
+use crate::{PhysicalTable, SchemaObjectName};
 
 use super::column_spec::{ColumnAttribute, ColumnReferenceSpec, ColumnSpec, ColumnTypeSpec};
 use super::constraint::{sorted_comma_list, Constraints};
@@ -32,7 +32,7 @@ const MATERIALIZED_VIEW_COLUMNS_QUERY: &str = r#"
 
 #[derive(Debug)]
 pub struct TableSpec {
-    pub name: PhysicalTableName,
+    pub name: SchemaObjectName,
     pub columns: Vec<ColumnSpec>,
     pub indices: Vec<IndexSpec>,
     pub triggers: Vec<TriggerSpec>,
@@ -41,7 +41,7 @@ pub struct TableSpec {
 
 impl TableSpec {
     pub fn new(
-        name: PhysicalTableName,
+        name: SchemaObjectName,
         columns: Vec<ColumnSpec>,
         indices: Vec<IndexSpec>,
         triggers: Vec<TriggerSpec>,
@@ -87,8 +87,8 @@ impl TableSpec {
 
     pub(super) async fn from_live_db_table(
         client: &DatabaseClient,
-        table_name: PhysicalTableName,
-        column_attributes: &HashMap<PhysicalTableName, HashMap<String, ColumnAttribute>>,
+        table_name: SchemaObjectName,
+        column_attributes: &HashMap<SchemaObjectName, HashMap<String, ColumnAttribute>>,
     ) -> Result<WithIssues<TableSpec>, DatabaseError> {
         // Query to get a list of columns in the table
 
@@ -210,7 +210,7 @@ impl TableSpec {
 
     pub(super) async fn from_live_db_materialized_view(
         client: &DatabaseClient,
-        table_name: PhysicalTableName,
+        table_name: SchemaObjectName,
         enums: &Vec<EnumSpec>,
     ) -> Result<WithIssues<TableSpec>, DatabaseError> {
         let issues = Vec::new();

--- a/libs/exo-sql/src/schema/test_helper.rs
+++ b/libs/exo-sql/src/schema/test_helper.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use crate::PhysicalTableName;
+use crate::SchemaObjectName;
 
 use super::column_spec::{
     ColumnAutoincrement, ColumnDefault, ColumnReferenceSpec, ColumnSpec, ColumnTypeSpec,
@@ -28,7 +28,7 @@ pub fn pk_reference_column(
     ColumnSpec {
         name: name.into(),
         typ: ColumnTypeSpec::ColumnReference(ColumnReferenceSpec {
-            foreign_table_name: PhysicalTableName::new(
+            foreign_table_name: SchemaObjectName::new(
                 foreign_table_name,
                 foreign_table_schema_name,
             ),

--- a/libs/exo-sql/src/schema/trigger_spec.rs
+++ b/libs/exo-sql/src/schema/trigger_spec.rs
@@ -1,7 +1,7 @@
 use std::{str::FromStr, vec};
 
 use crate::{
-    database_error::DatabaseError, sql::connect::database_client::DatabaseClient, PhysicalTableName,
+    database_error::DatabaseError, sql::connect::database_client::DatabaseClient, SchemaObjectName,
 };
 
 use super::{issue::WithIssues, op::SchemaOp};
@@ -118,7 +118,7 @@ pub struct TriggerSpec {
     pub timing: TriggerTiming,
     pub orientation: TriggerOrientation,
     pub event: TriggerEvent,
-    pub table: PhysicalTableName,
+    pub table: SchemaObjectName,
 }
 
 impl TriggerSpec {
@@ -128,7 +128,7 @@ impl TriggerSpec {
         timing: TriggerTiming,
         orientation: TriggerOrientation,
         event: TriggerEvent,
-        table: PhysicalTableName,
+        table: SchemaObjectName,
     ) -> Self {
         Self {
             name,
@@ -142,7 +142,7 @@ impl TriggerSpec {
 
     pub async fn from_live_db(
         client: &DatabaseClient,
-        table_name: &PhysicalTableName,
+        table_name: &SchemaObjectName,
     ) -> Result<WithIssues<Vec<TriggerSpec>>, DatabaseError> {
         let triggers = client
             .query(TRIGGERS_QUERY, &[&table_name.fully_qualified_name()])
@@ -163,7 +163,7 @@ impl TriggerSpec {
                     timing_string.parse()?,
                     orientation_string.parse()?,
                     event_string.parse()?,
-                    PhysicalTableName::new(table_name, Some(&table_schema)),
+                    SchemaObjectName::new(table_name, Some(&table_schema)),
                 ))
             })
             .collect::<Result<Vec<_>, DatabaseError>>()?;

--- a/libs/exo-sql/src/sql/column.rs
+++ b/libs/exo-sql/src/sql/column.rs
@@ -9,7 +9,7 @@
 
 use maybe_owned::MaybeOwned;
 
-use crate::{ColumnId, Database, ParamEquality, PhysicalTableName, Predicate};
+use crate::{ColumnId, Database, ParamEquality, Predicate, SchemaObjectName};
 
 use super::{
     function::Function, json_agg::JsonAgg, json_object::JsonObject, select::Select,
@@ -54,7 +54,7 @@ pub enum Column {
     /// have a query return __typename set to a constant value
     Constant(String),
     /// All columns of a table. If the table is `None` should translate to `*`, else  `"table_name".*` or "schema"."table_name".*
-    Star(Option<PhysicalTableName>),
+    Star(Option<SchemaObjectName>),
     /// A null value
     Null,
     /// A function applied to a column. For example, `count(id)` or `lower(first_name)`.

--- a/libs/exo-sql/src/sql/cte.rs
+++ b/libs/exo-sql/src/sql/cte.rs
@@ -10,7 +10,7 @@
 use crate::Database;
 
 use super::{
-    physical_table::PhysicalTableName, select::Select, sql_operation::SQLOperation,
+    schema_object::SchemaObjectName, select::Select, sql_operation::SQLOperation,
     ExpressionBuilder, SQLBuilder,
 };
 
@@ -29,13 +29,13 @@ pub struct CteExpression<'a> {
     /// The name of the expression
     pub name: String,
     /// The name of the table that this operation stands for. This allows us to substitute the table name in the select statement of `WithQuery`.
-    pub table_name: Option<PhysicalTableName>,
+    pub table_name: Option<SchemaObjectName>,
     /// The SQL operation to be bound to the name
     pub operation: SQLOperation<'a>,
 }
 
 impl<'a> CteExpression<'a> {
-    pub fn new_auto_name(table_name: &PhysicalTableName, operation: SQLOperation<'a>) -> Self {
+    pub fn new_auto_name(table_name: &SchemaObjectName, operation: SQLOperation<'a>) -> Self {
         Self {
             name: table_name.synthetic_name(),
             table_name: Some(table_name.clone()),

--- a/libs/exo-sql/src/sql/database.rs
+++ b/libs/exo-sql/src/sql/database.rs
@@ -9,7 +9,7 @@
 
 use std::fmt::{Debug, Formatter};
 
-use crate::{ColumnId, ManyToOne, PhysicalColumn, PhysicalTable, PhysicalTableName};
+use crate::{ColumnId, ManyToOne, PhysicalColumn, PhysicalTable, SchemaObjectName};
 
 use serde::{Deserialize, Serialize};
 use typed_generational_arena::{Arena, IgnoreGeneration, Index};
@@ -65,7 +65,7 @@ impl Database {
         self.enums.insert(enum_)
     }
 
-    pub fn get_table_id(&self, table_name: &PhysicalTableName) -> Option<TableId> {
+    pub fn get_table_id(&self, table_name: &SchemaObjectName) -> Option<TableId> {
         self.tables.iter().find_map(|(id, table)| {
             if &table.name == table_name {
                 Some(id)
@@ -75,7 +75,7 @@ impl Database {
         })
     }
 
-    pub fn get_enum_id(&self, enum_name: &PhysicalTableName) -> Option<EnumId> {
+    pub fn get_enum_id(&self, enum_name: &SchemaObjectName) -> Option<EnumId> {
         self.enums.iter().find_map(|(id, enum_)| {
             if &enum_.name == enum_name {
                 Some(id)

--- a/libs/exo-sql/src/sql/join.rs
+++ b/libs/exo-sql/src/sql/join.rs
@@ -51,7 +51,7 @@ impl ExpressionBuilder for LeftJoin {
 mod tests {
     use super::*;
     use crate::schema::test_helper::{int_column, pk_column, pk_reference_column};
-    use crate::PhysicalTableName;
+    use crate::SchemaObjectName;
     use crate::{
         schema::{database_spec::DatabaseSpec, table_spec::TableSpec},
         Column,
@@ -64,7 +64,7 @@ mod tests {
         let database = DatabaseSpec::new(
             vec![
                 TableSpec::new(
-                    PhysicalTableName::new("concerts", None),
+                    SchemaObjectName::new("concerts", None),
                     vec![
                         pk_column("id"),
                         pk_reference_column("venue_id", "venues", None),
@@ -74,7 +74,7 @@ mod tests {
                     true,
                 ),
                 TableSpec::new(
-                    PhysicalTableName::new("venues", None),
+                    SchemaObjectName::new("venues", None),
                     vec![pk_column("id"), int_column("capacity")],
                     vec![],
                     vec![],
@@ -87,10 +87,10 @@ mod tests {
         .to_database();
 
         let concert_physical_table_id = database
-            .get_table_id(&PhysicalTableName::new("concerts", None))
+            .get_table_id(&SchemaObjectName::new("concerts", None))
             .unwrap();
         let venue_physical_table_id = database
-            .get_table_id(&PhysicalTableName::new("venues", None))
+            .get_table_id(&SchemaObjectName::new("venues", None))
             .unwrap();
 
         let join_predicate = ConcretePredicate::Eq(

--- a/libs/exo-sql/src/sql/mod.rs
+++ b/libs/exo-sql/src/sql/mod.rs
@@ -25,8 +25,8 @@ pub mod order;
 pub mod physical_column;
 pub mod predicate;
 pub mod relation;
+pub mod schema_object;
 pub mod vector;
-
 pub use sql_bytes::SQLBytes;
 pub use sql_param::SQLParam;
 pub use sql_param_container::SQLParamContainer;

--- a/libs/exo-sql/src/sql/order.rs
+++ b/libs/exo-sql/src/sql/order.rs
@@ -109,7 +109,7 @@ mod test {
     use super::*;
     use crate::schema::test_helper::{int_column, pk_column, string_column};
     use crate::schema::{database_spec::DatabaseSpec, table_spec::TableSpec};
-    use crate::PhysicalTableName;
+    use crate::SchemaObjectName;
 
     use multiplatform_test::multiplatform_test;
 
@@ -117,7 +117,7 @@ mod test {
     fn single() {
         let database = DatabaseSpec::new(
             vec![TableSpec::new(
-                PhysicalTableName::new("people", None),
+                SchemaObjectName::new("people", None),
                 vec![pk_column("id"), int_column("age")],
                 vec![],
                 vec![],
@@ -129,7 +129,7 @@ mod test {
         .to_database();
 
         let people_table_id = database
-            .get_table_id(&PhysicalTableName::new("people", None))
+            .get_table_id(&SchemaObjectName::new("people", None))
             .unwrap();
 
         let age_col = database.get_column_id(people_table_id, "age").unwrap();
@@ -146,7 +146,7 @@ mod test {
     fn multiple() {
         let database = DatabaseSpec::new(
             vec![TableSpec::new(
-                PhysicalTableName::new("people", None),
+                SchemaObjectName::new("people", None),
                 vec![pk_column("id"), string_column("name"), int_column("age")],
                 vec![],
                 vec![],
@@ -158,7 +158,7 @@ mod test {
         .to_database();
 
         let table_id = database
-            .get_table_id(&PhysicalTableName::new("people", None))
+            .get_table_id(&SchemaObjectName::new("people", None))
             .unwrap();
 
         let name_col = database.get_column_id(table_id, "name").unwrap();

--- a/libs/exo-sql/src/sql/physical_column.rs
+++ b/libs/exo-sql/src/sql/physical_column.rs
@@ -10,7 +10,7 @@
 use crate::{
     database_error::DatabaseError,
     schema::column_spec::{ColumnAutoincrement, ColumnDefault},
-    Database, ManyToOneId, OneToManyId, PhysicalTableName, TableId,
+    Database, ManyToOneId, OneToManyId, SchemaObjectName, TableId,
 };
 
 use super::{ExpressionBuilder, SQLBuilder};
@@ -59,11 +59,11 @@ impl std::fmt::Debug for PhysicalColumn {
 }
 
 impl PhysicalColumn {
-    pub fn get_table_name(&self, database: &Database) -> PhysicalTableName {
+    pub fn get_table_name(&self, database: &Database) -> SchemaObjectName {
         database.get_table(self.table_id).name.clone()
     }
 
-    pub fn get_sequence_name(&self) -> Option<PhysicalTableName> {
+    pub fn get_sequence_name(&self) -> Option<SchemaObjectName> {
         match &self.default_value {
             Some(ColumnDefault::Autoincrement(ColumnAutoincrement::Sequence { name })) => {
                 Some(name.clone())
@@ -117,7 +117,7 @@ pub enum PhysicalColumnType {
         scale: Option<usize>,
     },
     Enum {
-        enum_name: PhysicalTableName,
+        enum_name: SchemaObjectName,
     },
 }
 

--- a/libs/exo-sql/src/sql/physical_table.rs
+++ b/libs/exo-sql/src/sql/physical_table.rs
@@ -7,119 +7,23 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::{cmp::Ordering, collections::HashSet, hash::Hash};
+use std::collections::HashSet;
 
 use crate::{schema::index_spec::IndexKind, Database};
 
 use super::{
     column::Column, delete::Delete, insert::Insert, physical_column::PhysicalColumn,
-    predicate::ConcretePredicate, update::Update, ExpressionBuilder, SQLBuilder,
+    predicate::ConcretePredicate, schema_object::SchemaObjectName, update::Update,
+    ExpressionBuilder, SQLBuilder,
 };
 
 use maybe_owned::MaybeOwned;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, Eq, Clone)]
-pub struct PhysicalTableName {
-    /// The name of the table.
-    pub name: String,
-    /// The schema of the table.
-    pub schema: Option<String>,
-}
-
-impl PartialOrd for PhysicalTableName {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for PhysicalTableName {
-    fn cmp(&self, other: &Self) -> Ordering {
-        (&self.name, self.schema.as_deref()).cmp(&(&other.name, other.schema.as_deref()))
-    }
-}
-
-impl PartialEq for PhysicalTableName {
-    fn eq(&self, other: &Self) -> bool {
-        self.name == other.name
-            && match (self.schema.as_deref(), other.schema.as_deref()) {
-                (Some(s1), Some(s2)) => s1 == s2,
-                (None, None) | (Some("public"), None) | (None, Some("public")) => true,
-                _ => false,
-            }
-    }
-}
-
-impl Hash for PhysicalTableName {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.name.hash(state);
-        match &self.schema {
-            Some(schema) if schema != "public" => schema.hash(state),
-            _ => (),
-        }
-    }
-}
-
-impl PhysicalTableName {
-    pub fn new(name: impl Into<String>, schema: Option<&str>) -> Self {
-        Self {
-            name: name.into(),
-            schema: match schema {
-                Some(schema) if schema != "public" => Some(schema.to_string()),
-                _ => None,
-            },
-        }
-    }
-
-    pub fn new_with_schema_name(name: impl Into<String>, schema_name: impl Into<String>) -> Self {
-        let schema_name = schema_name.into();
-
-        Self {
-            name: name.into(),
-            schema: match schema_name.as_str() {
-                "public" => None,
-                _ => Some(schema_name),
-            },
-        }
-    }
-
-    pub fn fully_qualified_name(&self) -> String {
-        self.fully_qualified_name_with_sep(".")
-    }
-
-    pub fn fully_qualified_name_with_sep(&self, sep: &str) -> String {
-        match &self.schema {
-            Some(schema) => format!("{}{}{}", schema, sep, self.name),
-            None => self.name.to_owned(),
-        }
-    }
-
-    pub(crate) fn synthetic_name(&self) -> String {
-        match &self.schema {
-            Some(schema) => format!("{}#{}", schema, self.name),
-            None => self.name.to_owned(),
-        }
-    }
-
-    pub fn sql_name(&self) -> String {
-        match self.schema {
-            Some(ref schema) => format!("\"{}\".\"{}\"", schema, self.name),
-            None => format!("\"{}\"", self.name),
-        }
-    }
-
-    pub fn schema_name(&self) -> String {
-        match self.schema {
-            Some(ref schema) => schema.to_string(),
-            None => "public".to_string(),
-        }
-    }
-}
-
 /// A physical table in the database such as "concerts" or "users".
 #[derive(Serialize, Deserialize, PartialEq, Eq)]
 pub struct PhysicalTable {
-    pub name: PhysicalTableName,
+    pub name: SchemaObjectName,
     /// The columns of the table.
     // concerts.venue_id: (venues.id, "int", "venue_id_table")
     pub columns: Vec<PhysicalColumn>,
@@ -132,7 +36,7 @@ pub struct PhysicalTable {
 /// A physical enum in the database such as "Priority" with variants "LOW", "MEDIUM", "HIGH".
 #[derive(Serialize, Deserialize, PartialEq, Eq)]
 pub struct PhysicalEnum {
-    pub name: PhysicalTableName,
+    pub name: SchemaObjectName,
     pub variants: Vec<String>,
 }
 
@@ -168,7 +72,7 @@ impl PhysicalTable {
         self.columns.iter().filter(|column| column.is_pk).collect()
     }
 
-    pub fn get_sequence_names(&self) -> Vec<PhysicalTableName> {
+    pub fn get_sequence_names(&self) -> Vec<SchemaObjectName> {
         self.columns
             .iter()
             .flat_map(|column| column.get_sequence_name())

--- a/libs/exo-sql/src/sql/predicate.rs
+++ b/libs/exo-sql/src/sql/predicate.rs
@@ -322,7 +322,7 @@ mod tests {
     use crate::schema::table_spec::TableSpec;
     use crate::schema::test_helper::{int_column, json_column, pk_column, string_column};
     use crate::{schema::database_spec::DatabaseSpec, sql::SQLParamContainer};
-    use crate::{ColumnId, PhysicalTableName};
+    use crate::{ColumnId, SchemaObjectName};
     use multiplatform_test::multiplatform_test;
 
     use super::*;
@@ -343,7 +343,7 @@ mod tests {
     fn eq_predicate() {
         let database = DatabaseSpec::new(
             vec![TableSpec::new(
-                PhysicalTableName::new("people", None),
+                SchemaObjectName::new("people", None),
                 vec![pk_column("id"), int_column("age")],
                 vec![],
                 vec![],
@@ -355,7 +355,7 @@ mod tests {
         .to_database();
 
         let people_table_id = database
-            .get_table_id(&PhysicalTableName::new("people", None))
+            .get_table_id(&SchemaObjectName::new("people", None))
             .unwrap();
         let age_column_id = database.get_column_id(people_table_id, "age").unwrap();
 
@@ -371,7 +371,7 @@ mod tests {
     fn and_predicate() {
         let database = DatabaseSpec::new(
             vec![TableSpec::new(
-                PhysicalTableName::new("people", None),
+                SchemaObjectName::new("people", None),
                 vec![pk_column("id"), string_column("name"), int_column("age")],
                 vec![],
                 vec![],
@@ -383,7 +383,7 @@ mod tests {
         .to_database();
 
         let people_table_id = database
-            .get_table_id(&PhysicalTableName::new("people", None))
+            .get_table_id(&SchemaObjectName::new("people", None))
             .unwrap();
 
         let name_col_id = database.get_column_id(people_table_id, "name").unwrap();
@@ -411,7 +411,7 @@ mod tests {
     fn string_predicates() {
         let database = DatabaseSpec::new(
             vec![TableSpec::new(
-                PhysicalTableName::new("videos", None),
+                SchemaObjectName::new("videos", None),
                 vec![pk_column("id"), string_column("title")],
                 vec![],
                 vec![],
@@ -423,7 +423,7 @@ mod tests {
         .to_database();
 
         let table_id = database
-            .get_table_id(&PhysicalTableName::new("videos", None))
+            .get_table_id(&SchemaObjectName::new("videos", None))
             .unwrap();
 
         let title_col_id = database.get_column_id(table_id, "title").unwrap();
@@ -482,7 +482,7 @@ mod tests {
     fn json_predicates() {
         let database = DatabaseSpec::new(
             vec![TableSpec::new(
-                PhysicalTableName::new("card", None),
+                SchemaObjectName::new("card", None),
                 vec![pk_column("id"), json_column("data")],
                 vec![],
                 vec![],
@@ -494,7 +494,7 @@ mod tests {
         .to_database();
 
         let table_id = database
-            .get_table_id(&PhysicalTableName::new("card", None))
+            .get_table_id(&SchemaObjectName::new("card", None))
             .unwrap();
 
         let json_col_id = database.get_column_id(table_id, "data").unwrap();

--- a/libs/exo-sql/src/sql/schema_object.rs
+++ b/libs/exo-sql/src/sql/schema_object.rs
@@ -1,0 +1,109 @@
+// Copyright Exograph, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file at the root of this repository.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::{cmp::Ordering, hash::Hash};
+
+use serde::{Deserialize, Serialize};
+
+/// A name of a table/enum/sequence along with its schema.
+#[derive(Serialize, Deserialize, Debug, Eq, Clone)]
+pub struct SchemaObjectName {
+    pub name: String,
+    /// Default is "public".
+    pub schema: Option<String>,
+}
+
+impl PartialOrd for SchemaObjectName {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SchemaObjectName {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (&self.name, self.schema.as_deref()).cmp(&(&other.name, other.schema.as_deref()))
+    }
+}
+
+impl PartialEq for SchemaObjectName {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+            && match (self.schema.as_deref(), other.schema.as_deref()) {
+                (Some(s1), Some(s2)) => s1 == s2,
+                (None, None) | (Some("public"), None) | (None, Some("public")) => true,
+                _ => false,
+            }
+    }
+}
+
+impl Hash for SchemaObjectName {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        match &self.schema {
+            Some(schema) if schema != "public" => schema.hash(state),
+            _ => (),
+        }
+    }
+}
+
+impl SchemaObjectName {
+    pub fn new(name: impl Into<String>, schema: Option<&str>) -> Self {
+        Self {
+            name: name.into(),
+            schema: match schema {
+                Some(schema) if schema != "public" => Some(schema.to_string()),
+                _ => None,
+            },
+        }
+    }
+
+    pub fn new_with_schema_name(name: impl Into<String>, schema_name: impl Into<String>) -> Self {
+        let schema_name = schema_name.into();
+
+        Self {
+            name: name.into(),
+            schema: match schema_name.as_str() {
+                "public" => None,
+                _ => Some(schema_name),
+            },
+        }
+    }
+
+    pub fn fully_qualified_name(&self) -> String {
+        self.fully_qualified_name_with_sep(".")
+    }
+
+    pub fn fully_qualified_name_with_sep(&self, sep: &str) -> String {
+        match &self.schema {
+            Some(schema) => format!("{}{}{}", schema, sep, self.name),
+            None => self.name.to_owned(),
+        }
+    }
+
+    pub(crate) fn synthetic_name(&self) -> String {
+        match &self.schema {
+            Some(schema) => format!("{}#{}", schema, self.name),
+            None => self.name.to_owned(),
+        }
+    }
+
+    pub fn sql_name(&self) -> String {
+        match self.schema {
+            Some(ref schema) => format!("\"{}\".\"{}\"", schema, self.name),
+            None => format!("\"{}\"", self.name),
+        }
+    }
+
+    pub fn schema_name(&self) -> String {
+        match self.schema {
+            Some(ref schema) => schema.to_string(),
+            None => "public".to_string(),
+        }
+    }
+}

--- a/libs/exo-sql/src/sql/select.rs
+++ b/libs/exo-sql/src/sql/select.rs
@@ -105,7 +105,7 @@ mod tests {
             test_helper::{int_column, pk_column, string_column},
         },
         sql::json_object::{JsonObject, JsonObjectElement},
-        PhysicalTableName,
+        SchemaObjectName,
     };
 
     use multiplatform_test::multiplatform_test;
@@ -116,7 +116,7 @@ mod tests {
     fn json_object() {
         let database = DatabaseSpec::new(
             vec![TableSpec::new(
-                PhysicalTableName {
+                SchemaObjectName {
                     name: "people".to_owned(),
                     schema: None,
                 },
@@ -131,7 +131,7 @@ mod tests {
         .to_database();
 
         let table_id = database
-            .get_table_id(&PhysicalTableName::new("people", None))
+            .get_table_id(&SchemaObjectName::new("people", None))
             .unwrap();
         let age_col_id = database.get_column_id(table_id, "age").unwrap();
         let age_col2_id = database.get_column_id(table_id, "age").unwrap();

--- a/libs/exo-sql/src/sql/sql_builder.rs
+++ b/libs/exo-sql/src/sql/sql_builder.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 
 use crate::Database;
 
-use super::{physical_table::PhysicalTableName, sql_param::SQLParamWithType, ExpressionBuilder};
+use super::{schema_object::SchemaObjectName, sql_param::SQLParamWithType, ExpressionBuilder};
 
 pub struct SQLBuilder {
     /// The SQL being built with placeholders for each parameter
@@ -25,7 +25,7 @@ pub struct SQLBuilder {
     /// For example, for a CTE, the alias would the name of the CTE ("WITH <alias> as
     /// (...table...)"). Similarly, for a sub-select, the alias would be the name of the sub-select.
     /// This is used to render alias in lieu of table names for the related expressions.
-    table_alias_map: HashMap<PhysicalTableName, String>,
+    table_alias_map: HashMap<SchemaObjectName, String>,
 }
 
 impl SQLBuilder {
@@ -68,7 +68,7 @@ impl SQLBuilder {
     }
 
     /// Push a table name. If the table name has an alias, push the alias instead.
-    pub fn push_table(&mut self, table_name: &PhysicalTableName) {
+    pub fn push_table(&mut self, table_name: &SchemaObjectName) {
         match &self.table_alias_map.get(table_name).cloned() {
             Some(alias) => {
                 self.push_identifier(alias);
@@ -85,7 +85,7 @@ impl SQLBuilder {
 
     /// Push a table prefix (for a column). Push `<table_name>.` if in fully_qualify_column_names
     /// mode, otherwise an empty string.
-    pub fn push_table_prefix(&mut self, table_name: &PhysicalTableName) {
+    pub fn push_table_prefix(&mut self, table_name: &SchemaObjectName) {
         if self.fully_qualify_column_names {
             self.push_table(table_name);
             self.push('.');
@@ -170,7 +170,7 @@ impl SQLBuilder {
 
     pub fn with_table_alias_map<F, R>(
         &mut self,
-        table_alias_map: HashMap<PhysicalTableName, String>,
+        table_alias_map: HashMap<SchemaObjectName, String>,
         func: F,
     ) -> R
     where

--- a/libs/exo-sql/src/sql/table.rs
+++ b/libs/exo-sql/src/sql/table.rs
@@ -10,8 +10,7 @@
 use crate::{Database, TableId};
 
 use super::{
-    join::LeftJoin, physical_table::PhysicalTableName, select::Select, ExpressionBuilder,
-    SQLBuilder,
+    join::LeftJoin, schema_object::SchemaObjectName, select::Select, ExpressionBuilder, SQLBuilder,
 };
 
 /// A table-like concept that can be used in in place of `SELECT FROM <table-query> ...`.
@@ -28,7 +27,7 @@ pub enum Table {
     SubSelect {
         select: Box<Select>,
         /// The alias of the sub-select (optional, since we need to alias the sub-select when used in a FROM clause)
-        alias: Option<(String, PhysicalTableName)>,
+        alias: Option<(String, SchemaObjectName)>,
     },
 }
 

--- a/libs/exo-sql/src/transform/pg/select/selection_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/select/selection_strategy.rs
@@ -9,8 +9,7 @@
 
 use crate::{
     sql::{
-        physical_table::PhysicalTableName, predicate::ConcretePredicate, select::Select,
-        table::Table,
+        predicate::ConcretePredicate, schema_object::SchemaObjectName, select::Select, table::Table,
     },
     transform::{
         join_util,
@@ -79,7 +78,7 @@ pub(super) fn nest_subselect(
     inner_select: Select,
     selection: Selection,
     selection_level: &SelectionLevel,
-    alias: (String, PhysicalTableName),
+    alias: (String, SchemaObjectName),
     transformer: &Postgres,
     database: &Database,
 ) -> Select {

--- a/libs/exo-sql/src/transform/test_util.rs
+++ b/libs/exo-sql/src/transform/test_util.rs
@@ -11,7 +11,7 @@
 
 use crate::schema::test_helper::{pk_column, pk_reference_column, string_column};
 use crate::schema::{database_spec::DatabaseSpec, table_spec::TableSpec};
-use crate::{ColumnId, Database, PhysicalTableName, TableId};
+use crate::{ColumnId, Database, SchemaObjectName, TableId};
 
 pub struct TestSetup {
     pub database: Database,
@@ -52,7 +52,7 @@ impl TestSetup {
         let database = DatabaseSpec::new(
             vec![
                 TableSpec::new(
-                    PhysicalTableName::new("concerts", None),
+                    SchemaObjectName::new("concerts", None),
                     vec![
                         pk_column("id"),
                         pk_reference_column("venue_id", "venues", None),
@@ -63,7 +63,7 @@ impl TestSetup {
                     true,
                 ),
                 TableSpec::new(
-                    PhysicalTableName::new("venues", None),
+                    SchemaObjectName::new("venues", None),
                     vec![
                         pk_column("id"),
                         string_column("name"),
@@ -74,7 +74,7 @@ impl TestSetup {
                     true,
                 ),
                 TableSpec::new(
-                    PhysicalTableName::new("concert_artists", None),
+                    SchemaObjectName::new("concert_artists", None),
                     vec![
                         pk_column("id"),
                         pk_reference_column("concert_id", "concerts", None),
@@ -85,7 +85,7 @@ impl TestSetup {
                     true,
                 ),
                 TableSpec::new(
-                    PhysicalTableName::new("artists", None),
+                    SchemaObjectName::new("artists", None),
                     vec![
                         pk_column("id"),
                         string_column("name"),
@@ -96,7 +96,7 @@ impl TestSetup {
                     true,
                 ),
                 TableSpec::new(
-                    PhysicalTableName::new("addresses", None),
+                    SchemaObjectName::new("addresses", None),
                     vec![pk_column("id"), string_column("city")],
                     vec![],
                     vec![],
@@ -109,7 +109,7 @@ impl TestSetup {
         .to_database();
 
         let concert_table_id = database
-            .get_table_id(&PhysicalTableName::new("concerts", None))
+            .get_table_id(&SchemaObjectName::new("concerts", None))
             .unwrap();
 
         let concerts_id_column = database.get_column_id(concert_table_id, "id").unwrap();
@@ -119,7 +119,7 @@ impl TestSetup {
             .unwrap();
 
         let venues_table_id = database
-            .get_table_id(&PhysicalTableName::new("venues", None))
+            .get_table_id(&SchemaObjectName::new("venues", None))
             .unwrap();
         let venues_id_column = database.get_column_id(venues_table_id, "id").unwrap();
         let venues_name_column = database.get_column_id(venues_table_id, "name").unwrap();
@@ -128,7 +128,7 @@ impl TestSetup {
             .unwrap();
 
         let concert_artists_table_id = database
-            .get_table_id(&PhysicalTableName::new("concert_artists", None))
+            .get_table_id(&SchemaObjectName::new("concert_artists", None))
             .unwrap();
         let _concert_artists_id_column = database
             .get_column_id(concert_artists_table_id, "id")
@@ -141,7 +141,7 @@ impl TestSetup {
             .unwrap();
 
         let artists_table_id = database
-            .get_table_id(&PhysicalTableName::new("artists", None))
+            .get_table_id(&SchemaObjectName::new("artists", None))
             .unwrap();
         let artists_id_column = database.get_column_id(artists_table_id, "id").unwrap();
         let artists_name_column = database.get_column_id(artists_table_id, "name").unwrap();
@@ -150,7 +150,7 @@ impl TestSetup {
             .unwrap();
 
         let addresses_table_id = database
-            .get_table_id(&PhysicalTableName::new("addresses", None))
+            .get_table_id(&SchemaObjectName::new("addresses", None))
             .unwrap();
         let addresses_id_column = database.get_column_id(addresses_table_id, "id").unwrap();
         let addresses_city_column = database.get_column_id(addresses_table_id, "city").unwrap();


### PR DESCRIPTION
The earlier change to support custom sequences, used `PhysicalTableName` for sequences, too (since they required schema name + seq name).

This refactors `PhysicalTableName` to a more general `SchemaObjectName`.