### PR TITLE
fix: Provide a proper error message for invalid orderBy param

### DIFF
--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/order_by_mapper.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/order_by_mapper.rs
@@ -77,7 +77,10 @@ impl<'a> SQLMapper<'a, AbstractOrderBy> for OrderByParameterInput<'a> {
                 flatten(mapped)
             }
 
-            _ => todo!(), // Invalid
+            _ => Err(PostgresExecutionError::Validation(
+                self.param.name.clone(),
+                format!("Invalid argument ('{argument}')"),
+            )),
         }
     }
 

--- a/integration-tests/simple-model/tests/error-invalid-orderBy.exotest
+++ b/integration-tests/simple-model/tests/error-invalid-orderBy.exotest
@@ -1,0 +1,12 @@
+operation: |
+  query {
+    result: logs(orderBy: [text_DESC])
+  }
+response: |
+  {
+    "errors": [
+      {
+        "message": "Invalid field 'orderBy': Invalid argument ('text_DESC')"
+      }
+    ]
+  }


### PR DESCRIPTION
For invalid queries such as:
```
  query {
    result: logs(orderBy: [text_DESC])
  }
```
we return an error message such as `Invalid field 'orderBy': Invalid argument ('text_DESC')`