### PR TITLE
fix(import): annotate with @column when digits are involved

### DIFF
--- a/crates/cli/src/commands/schema/import/test-data/columns-with-numbers/index.expected.exo
+++ b/crates/cli/src/commands/schema/import/test-data/columns-with-numbers/index.expected.exo
@@ -1,0 +1,10 @@
+@postgres
+module Database {
+  @access(query=true, mutation=false)
+  type Metric {
+    @pk id: Int = autoIncrement()
+    name: String
+    @singlePrecision @column("min_30d_price") min30dPrice: Float
+    @singlePrecision max30dPrice: Float
+  }
+}

--- a/crates/cli/src/commands/schema/import/test-data/columns-with-numbers/schema.sql
+++ b/crates/cli/src/commands/schema/import/test-data/columns-with-numbers/schema.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "metrics" (
+        "id" SERIAL PRIMARY KEY,
+        "name" TEXT NOT NULL,
+        "min_30d_price" REAL NOT NULL,
+        "max30d_price" REAL NOT NULL
+);


### PR DESCRIPTION
When a column name has a digit (for example `min_30d_price`, but not `min30d_price`),  snake_case(lowerCamelCase(column-name)) != column-name. In such cases, we add an explicit `@column` when importing.