### PR TITLE
fix: Use full name including the schema to cast enums

### DIFF
--- a/crates/postgres-subsystem/postgres-core-resolver/src/cast.rs
+++ b/crates/postgres-subsystem/postgres-core-resolver/src/cast.rs
@@ -84,7 +84,7 @@ pub fn cast_value(
         Val::Enum(v) => match destination_type {
             PhysicalColumnType::Enum { enum_name } => Ok(Some(SQLParamContainer::enum_(
                 v.to_string(),
-                enum_name.name.to_string(),
+                enum_name.clone(),
             ))),
             _ => Err(CastError::Generic(format!(
                 "Expected enum type, got {}",

--- a/integration-tests/todo-non-public-schema/schema-tests
+++ b/integration-tests/todo-non-public-schema/schema-tests
@@ -1,0 +1,1 @@
+../todo/schema-tests

--- a/integration-tests/todo-non-public-schema/src/index.exo
+++ b/integration-tests/todo-non-public-schema/src/index.exo
@@ -1,0 +1,34 @@
+
+context AuthContext {
+  @jwt("sub") id: Int
+  @jwt("role") role: String = "user"
+}
+
+@postgres(schema="t_schema")
+module TodoDatabase {
+  @access(self.user.id == AuthContext.id || AuthContext.role == "admin")
+  type Todo {
+    @pk id: Int = autoIncrement()
+    title: String
+    completed: Boolean
+    priority: Priority = MEDIUM
+    user: User = AuthContext.id
+  }
+
+  enum Priority {
+    LOW
+    MEDIUM
+    HIGH
+  }
+
+  @access(AuthContext.role == "admin")
+  type User {
+    @pk id: Int = autoIncrement()
+    @unique email: String
+    firstName: String
+    lastName: String
+    profileImageUrl: String
+    role: String = "user"
+    todos: Set<Todo>?
+  }
+}

--- a/integration-tests/todo-non-public-schema/tests
+++ b/integration-tests/todo-non-public-schema/tests
@@ -1,0 +1,1 @@
+../todo/tests

--- a/libs/exo-sql/src/schema/column_spec.rs
+++ b/libs/exo-sql/src/schema/column_spec.rs
@@ -145,11 +145,9 @@ impl ColumnDefault {
             ColumnDefault::Enum(value) => Some(format!("'{value}'")),
             ColumnDefault::Autoincrement(autoincrement) => match autoincrement {
                 ColumnAutoincrement::Serial => None, // The type `SERIAL` takes care of the default value
-                ColumnAutoincrement::Sequence { name } => Some(format!(
-                    "nextval('{}.{}'::regclass)",
-                    name.schema.as_deref().unwrap_or("public"),
-                    name.name
-                )),
+                ColumnAutoincrement::Sequence { name } => {
+                    Some(format!("nextval('{}'::regclass)", name.sql_name()))
+                }
                 ColumnAutoincrement::Identity { .. } => None,
             },
         }

--- a/libs/exo-sql/src/sql/sql_builder.rs
+++ b/libs/exo-sql/src/sql/sql_builder.rs
@@ -103,7 +103,7 @@ impl SQLBuilder {
         let enum_cast = param
             .enum_type
             .as_ref()
-            .map(|enum_type| format!("::{}", enum_type));
+            .map(|enum_type| format!("::{}", enum_type.sql_name()));
 
         self.params.push(param);
         self.push('$');

--- a/libs/exo-sql/src/sql/sql_param.rs
+++ b/libs/exo-sql/src/sql/sql_param.rs
@@ -9,6 +9,7 @@
 
 use std::{any::Any, sync::Arc};
 
+use crate::SchemaObjectName;
 use tokio_postgres::types::{ToSql, Type};
 
 #[derive(Debug, Clone)]
@@ -16,7 +17,7 @@ pub struct SQLParamWithType {
     pub param: Arc<dyn SQLParam>,
     pub param_type: Type,
     pub is_array: bool,
-    pub enum_type: Option<String>,
+    pub enum_type: Option<SchemaObjectName>,
 }
 
 /// A trait to simplify our use of SQL parameters, specifically to have the [Send] and [Sync] bounds.

--- a/libs/exo-sql/src/sql/sql_param_container.rs
+++ b/libs/exo-sql/src/sql/sql_param_container.rs
@@ -16,7 +16,7 @@ use std::{
 };
 use tokio_postgres::types::{to_sql_checked, ToSql, Type};
 
-use crate::{SQLBytes, SQLParam};
+use crate::{SQLBytes, SQLParam, SchemaObjectName};
 
 use super::{physical_column::to_pg_array_type, sql_param::SQLParamWithType, SQLValue};
 
@@ -136,7 +136,7 @@ impl SQLParamContainer {
         Self::new(value, Type::TEXT_ARRAY)
     }
 
-    pub fn enum_(value: String, enum_type: String) -> Self {
+    pub fn enum_(value: String, enum_type: SchemaObjectName) -> Self {
         Self(SQLParamWithType {
             param: Arc::new(value),
             param_type: Type::TEXT,


### PR DESCRIPTION
This fixes mutation errors with a non-public enum type field