### PR TITLE
Support global documentation comments

### DIFF
--- a/crates/builder/grammar/grammar.js
+++ b/crates/builder/grammar/grammar.js
@@ -36,6 +36,7 @@ module.exports = grammar({
   rules: {
     source_file: $ => repeat($.declaration),
     declaration: $ => choice(
+      $.declaration_doc_comment,
       $.context,
       $.module,
       $.import
@@ -290,6 +291,14 @@ module.exports = grammar({
         /\*\//
       ),
       repeat1(seq('///', field("doc_line", $.doc_line_content)))
+    ),
+    declaration_doc_comment: $ => choice(
+      seq(
+        /\/\*\![ \t]*\n/,
+        repeat1(seq('*', field("doc_line", $.doc_line_content))),
+        /\*\//
+      ),
+      prec(1, repeat1(seq('//!', field("doc_line", $.doc_line_content))))
     ),
 
     doc_line_content: $ => /.*/,

--- a/crates/builder/grammar/grammar.js
+++ b/crates/builder/grammar/grammar.js
@@ -286,7 +286,7 @@ module.exports = grammar({
     ),
     doc_comment: $ => choice(
       seq(
-        /\/\*\*[ \t]*\n/,
+        /\/\*\*[ \t]*(?:\r?\n)/,
         repeat1(seq('*', field("doc_line", $.doc_line_content))),
         /\*\//
       ),
@@ -294,7 +294,7 @@ module.exports = grammar({
     ),
     declaration_doc_comment: $ => choice(
       seq(
-        /\/\*\![ \t]*\n/,
+        /\/\*\![ \t]*(?:\r?\n)/,
         repeat1(seq('*', field("doc_line", $.doc_line_content))),
         /\*\//
       ),

--- a/crates/builder/src/builder/system_builder.rs
+++ b/crates/builder/src/builder/system_builder.rs
@@ -118,5 +118,6 @@ pub async fn build(
         query_interception_map,
         mutation_interception_map,
         trusted_documents,
+        declaration_doc_comments: typechecked_system.declaration_doc_comments,
     })
 }

--- a/crates/builder/src/parser/snapshots/access_control_function_with_paren.snap
+++ b/crates/builder/src/parser/snapshots/access_control_function_with_paren.snap
@@ -107,3 +107,4 @@ modules:
     base_exofile: input.exo
     doc_comments: ~
 imports: []
+declaration_doc_comments: ~

--- a/crates/builder/src/parser/snapshots/access_control_function_without_paren.snap
+++ b/crates/builder/src/parser/snapshots/access_control_function_without_paren.snap
@@ -107,3 +107,4 @@ modules:
     base_exofile: input.exo
     doc_comments: ~
 imports: []
+declaration_doc_comments: ~

--- a/crates/builder/src/parser/snapshots/bb_schema.snap
+++ b/crates/builder/src/parser/snapshots/bb_schema.snap
@@ -123,3 +123,4 @@ modules:
     base_exofile: input.exo
     doc_comments: ~
 imports: []
+declaration_doc_comments: ~

--- a/crates/builder/src/parser/snapshots/context_schema.snap
+++ b/crates/builder/src/parser/snapshots/context_schema.snap
@@ -42,3 +42,4 @@ types:
     doc_comments: ~
 modules: []
 imports: []
+declaration_doc_comments: ~

--- a/crates/builder/src/parser/snapshots/doc_comments_block_comment.snap
+++ b/crates/builder/src/parser/snapshots/doc_comments_block_comment.snap
@@ -73,3 +73,4 @@ modules:
     base_exofile: input.exo
     doc_comments: ~
 imports: []
+declaration_doc_comments: ~

--- a/crates/builder/src/parser/snapshots/doc_comments_triple_slash.snap
+++ b/crates/builder/src/parser/snapshots/doc_comments_triple_slash.snap
@@ -73,3 +73,4 @@ modules:
     base_exofile: input.exo
     doc_comments: ~
 imports: []
+declaration_doc_comments: ~

--- a/crates/builder/src/parser/snapshots/expression_precedence.snap
+++ b/crates/builder/src/parser/snapshots/expression_precedence.snap
@@ -77,3 +77,4 @@ modules:
     base_exofile: input.exo
     doc_comments: ~
 imports: []
+declaration_doc_comments: ~

--- a/crates/builder/src/parser/snapshots/logical_not_precedence_logical.snap
+++ b/crates/builder/src/parser/snapshots/logical_not_precedence_logical.snap
@@ -42,3 +42,4 @@ modules:
     base_exofile: input.exo
     doc_comments: ~
 imports: []
+declaration_doc_comments: ~

--- a/crates/builder/src/parser/snapshots/logical_not_precedence_relational.snap
+++ b/crates/builder/src/parser/snapshots/logical_not_precedence_relational.snap
@@ -42,3 +42,4 @@ modules:
     base_exofile: input.exo
     doc_comments: ~
 imports: []
+declaration_doc_comments: ~

--- a/crates/builder/src/parser/snapshots/logical_op_precedence.snap
+++ b/crates/builder/src/parser/snapshots/logical_op_precedence.snap
@@ -48,3 +48,4 @@ modules:
     base_exofile: input.exo
     doc_comments: ~
 imports: []
+declaration_doc_comments: ~

--- a/crates/builder/src/typechecker/mod.rs
+++ b/crates/builder/src/typechecker/mod.rs
@@ -358,6 +358,7 @@ pub fn build(
                 return Ok(TypecheckedSystem {
                     types: types_arena,
                     modules: modules_arena,
+                    declaration_doc_comments: ast_system.declaration_doc_comments,
                 });
             }
         }

--- a/crates/builder/src/typechecker/snapshots/simple.snap
+++ b/crates/builder/src/typechecker/snapshots/simple.snap
@@ -394,3 +394,4 @@ modules:
     UserModule:
       index: 0
       generation: ~
+declaration_doc_comments: ~

--- a/crates/builder/src/typechecker/snapshots/with_array_in_operator.snap
+++ b/crates/builder/src/typechecker/snapshots/with_array_in_operator.snap
@@ -247,3 +247,4 @@ modules:
     DocumentModule:
       index: 0
       generation: ~
+declaration_doc_comments: ~

--- a/crates/builder/src/typechecker/snapshots/with_auth_context_use_in_field_annotation.snap
+++ b/crates/builder/src/typechecker/snapshots/with_auth_context_use_in_field_annotation.snap
@@ -303,3 +303,4 @@ modules:
     DocumentModule:
       index: 0
       generation: ~
+declaration_doc_comments: ~

--- a/crates/builder/src/typechecker/snapshots/with_auth_context_use_in_type_annotation.snap
+++ b/crates/builder/src/typechecker/snapshots/with_auth_context_use_in_type_annotation.snap
@@ -303,3 +303,4 @@ modules:
     DocumentModule:
       index: 0
       generation: ~
+declaration_doc_comments: ~

--- a/crates/builder/src/typechecker/snapshots/with_function_calls.snap
+++ b/crates/builder/src/typechecker/snapshots/with_function_calls.snap
@@ -866,3 +866,4 @@ modules:
     DocsDatabase:
       index: 0
       generation: ~
+declaration_doc_comments: ~

--- a/crates/cli/src/commands/graphql/schema.rs
+++ b/crates/cli/src/commands/graphql/schema.rs
@@ -32,7 +32,7 @@ impl CommandDefinition for SchemaCommandDefinition {
         Command::new("schema")
             .about("Obtain GraphQL schema")
             .arg(output_arg().long_help(
-                "Output file for the introspection result. Default: generated/schema.json",
+                "Output file for the introspection result. Default: generated/schema.graphql or generated/schema.json (depending on format)",
             ))
             .arg(
                 Arg::new("format")

--- a/crates/core-subsystem/core-model-builder/src/ast/ast_types.rs
+++ b/crates/core-subsystem/core-model-builder/src/ast/ast_types.rs
@@ -62,6 +62,7 @@ pub struct AstSystem<T: NodeTypedness> {
     pub types: Vec<AstModel<T>>,
     pub modules: Vec<AstModule<T>>,
     pub imports: Vec<PathBuf>,
+    pub declaration_doc_comments: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/crates/core-subsystem/core-model-builder/src/typechecker/typ.rs
+++ b/crates/core-subsystem/core-model-builder/src/typechecker/typ.rs
@@ -121,4 +121,5 @@ impl Type {
 pub struct TypecheckedSystem {
     pub types: MappedArena<Type>,
     pub modules: MappedArena<Module>,
+    pub declaration_doc_comments: Option<String>,
 }

--- a/crates/core-subsystem/core-plugin-shared/src/serializable_system.rs
+++ b/crates/core-subsystem/core-plugin-shared/src/serializable_system.rs
@@ -25,6 +25,7 @@ pub struct SerializableSystem {
     pub query_interception_map: InterceptionMap,
     pub mutation_interception_map: InterceptionMap,
     pub trusted_documents: TrustedDocuments,
+    pub declaration_doc_comments: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -207,6 +208,7 @@ mod test {
                 rpc: Some(super::SerializableRpcBytes(vec![])),
                 core: super::SerializableCoreBytes(vec![]),
             }],
+            declaration_doc_comments: None,
         }
     }
 

--- a/crates/core-subsystem/core-resolver/src/introspection/definition/schema.rs
+++ b/crates/core-subsystem/core-resolver/src/introspection/definition/schema.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::Arc};
 
 use async_graphql_parser::{
     types::{
@@ -28,6 +28,7 @@ pub struct Schema {
     pub type_definitions: Vec<TypeDefinition>,
     pub(crate) schema_field_definition: FieldDefinition,
     pub(crate) type_field_definition: FieldDefinition,
+    pub declaration_doc_comments: Arc<Option<String>>,
 }
 
 pub const QUERY_ROOT_TYPENAME: &str = "Query";
@@ -38,6 +39,7 @@ impl Schema {
     pub fn new_from_resolvers(
         subsystem_resolvers: &[Box<dyn SubsystemGraphQLResolver + Send + Sync>],
         allow_mutations: bool,
+        declaration_doc_comments: Arc<Option<String>>,
     ) -> Schema {
         let type_definitions: Vec<TypeDefinition> = {
             let mut typedefs = subsystem_resolvers
@@ -80,13 +82,19 @@ impl Schema {
             vec![]
         };
 
-        Self::new(type_definitions, queries, mutations)
+        Self::new(
+            type_definitions,
+            queries,
+            mutations,
+            declaration_doc_comments,
+        )
     }
 
     pub(crate) fn new(
         type_definitions: Vec<TypeDefinition>,
         queries: Vec<FieldDefinition>,
         mutations: Vec<FieldDefinition>,
+        declaration_doc_comments: Arc<Option<String>>,
     ) -> Schema {
         let mut type_definitions = type_definitions;
 
@@ -185,6 +193,7 @@ impl Schema {
                 })],
             )
             .node,
+            declaration_doc_comments,
         }
     }
 

--- a/crates/core-subsystem/core-resolver/src/validation/document_validator.rs
+++ b/crates/core-subsystem/core-resolver/src/validation/document_validator.rs
@@ -108,6 +108,8 @@ impl<'a> DocumentValidator<'a> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
 
     use async_graphql_parser::parse_query;
@@ -829,6 +831,7 @@ mod tests {
                 .as_ref()
                 .unwrap()
                 .schema_mutations(),
+            Arc::new(None),
         )
     }
 

--- a/crates/deno-subsystem/deno-graphql-builder/src/module_skeleton_generator.rs
+++ b/crates/deno-subsystem/deno-graphql-builder/src/module_skeleton_generator.rs
@@ -642,6 +642,7 @@ mod tests {
             &TypecheckedSystem {
                 types: Default::default(),
                 modules: Default::default(),
+                declaration_doc_comments: None,
             },
             &mut temp_file,
         )
@@ -667,6 +668,7 @@ mod tests {
             &TypecheckedSystem {
                 types: Default::default(),
                 modules: Default::default(),
+                declaration_doc_comments: None,
             },
             &mut temp_file,
         )
@@ -699,6 +701,7 @@ mod tests {
             &TypecheckedSystem {
                 types: Default::default(),
                 modules: Default::default(),
+                declaration_doc_comments: None,
             },
         )
         .unwrap();

--- a/crates/introspection-subsystem/introspection-resolver/src/schema_resolver.rs
+++ b/crates/introspection-subsystem/introspection-resolver/src/schema_resolver.rs
@@ -51,7 +51,12 @@ impl FieldResolver<Value, SubsystemResolutionError> for Schema {
                     .await
             }
             "directives" => Ok(Value::Array(vec![])), // TODO
-            "description" => Ok(Value::String("Top-level schema".to_string())),
+            "description" => Ok(self
+                .declaration_doc_comments
+                .as_ref()
+                .as_ref()
+                .map(|s| Value::String(s.clone()))
+                .unwrap_or(Value::Null)),
             "__typename" => Ok(Value::String("__Schema".to_string())),
             field_name => Err(SubsystemResolutionError::InvalidField(
                 field_name.to_owned(),

--- a/crates/introspection-util/src/execution/introspection.js
+++ b/crates/introspection-util/src/execution/introspection.js
@@ -13,7 +13,7 @@ import { printSchema } from "embedded://graphql/utilities/printSchema.mjs"
 import { assertValidSchema } from "embedded://graphql/type/validate.mjs"
 
 export async function introspectionQuery() {
-    return getIntrospectionQuery();
+    return getIntrospectionQuery({ schemaDescription: true });
 }
 
 export async function assertSchema(response) {

--- a/crates/testing/src/execution/introspection_tests.rs
+++ b/crates/testing/src/execution/introspection_tests.rs
@@ -176,6 +176,7 @@ async fn check_introspection(
 
                         if sdl_line_count != expected_sdl_line_count {
                             std::fs::write(&actual_sdl_path, &sdl)?;
+                            print_diff(&expected_sdl_path, &actual_sdl_path)?;
                             return Err(anyhow!(
                                 "SDL does not match the expected schema in {}. Expected {} lines, got {} lines",
                                 model_path.display(),
@@ -192,6 +193,7 @@ async fn check_introspection(
                         {
                             if sdl_line.trim() != expected_sdl_line.trim() {
                                 std::fs::write(&actual_sdl_path, &sdl)?;
+                                print_diff(&expected_sdl_path, &actual_sdl_path)?;
                                 return Err(anyhow!(
                                     "SDL does not match the expected schema in {}. Difference at line {}",
                                     model_path.display(),
@@ -215,5 +217,25 @@ async fn check_introspection(
             DenoError::Explicit(e) => Err(anyhow!(e)),
             e => Err(e.into()),
         },
+    }
+}
+
+fn print_diff(expected_file: &Path, actual_file: &Path) -> Result<()> {
+    let diff_output = std::process::Command::new("diff")
+        .arg("-u")
+        .arg(expected_file)
+        .arg(actual_file)
+        .output()?;
+
+    if diff_output.status.success() {
+        Ok(())
+    } else {
+        // If the files are different, print the diff
+        eprintln!("{}", String::from_utf8(diff_output.stdout)?);
+        Err(anyhow!(
+            "Files {} and {} differ",
+            expected_file.display(),
+            actual_file.display()
+        ))
     }
 }

--- a/crates/testing/src/execution/introspection_tests.rs
+++ b/crates/testing/src/execution/introspection_tests.rs
@@ -223,6 +223,7 @@ async fn check_introspection(
 fn print_diff(expected_file: &Path, actual_file: &Path) -> Result<()> {
     let diff_output = std::process::Command::new("diff")
         .arg("-u")
+        .arg("-b")
         .arg(expected_file)
         .arg(actual_file)
         .output()?;

--- a/integration-tests/todo-non-public-schema/src/index.exo
+++ b/integration-tests/todo-non-public-schema/src/index.exo
@@ -1,3 +1,9 @@
+//! Multi-user todo application model. Users can only query/mutate their own todos. Admins can query/mutate all todos.
+
+/*!
+ * The default user role is "user".
+ * The default priority is "medium".
+*/
 
 context AuthContext {
   @jwt("sub") id: Int

--- a/integration-tests/todo/schema-tests/introspection.expected.graphql
+++ b/integration-tests/todo/schema-tests/introspection.expected.graphql
@@ -1,3 +1,13 @@
+"""
+Multi-user todo application model. Users can only query/mutate their own todos. Admins can query/mutate all todos.
+The default user role is "user".
+The default priority is "medium".
+"""
+schema {
+  query: Query
+  mutation: Mutation
+}
+
 type BooleanAgg {
   count: Int
 }

--- a/integration-tests/todo/src/index.exo
+++ b/integration-tests/todo/src/index.exo
@@ -1,3 +1,9 @@
+//! Multi-user todo application model. Users can only query/mutate their own todos. Admins can query/mutate all todos.
+
+/*!
+ * The default user role is "user".
+ * The default priority is "medium".
+*/
 
 context AuthContext {
   @jwt("sub") id: Int


### PR DESCRIPTION
Through a Rust-like syntax (`//!` or `/*!`) allow developers to declare global comments (not associcated with any particular elements such as type or module). Like other doc comments, introspection output includes such comments.

Example:
```exo
//! Multi-user todo application model. Users can only query/mutate their own todos. Admins can query/mutate all todos.

/*!
 * The default user role is "user".
 * The default priority is "medium".
*/

context AuthContext {
  ...

```