### PR TITLE
feat(mcp): support separating introspection from tool description

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5619,6 +5619,7 @@ dependencies = [
 name = "mcp-router"
 version = "0.14.2"
 dependencies = [
+ "async-graphql-parser",
  "async-stream",
  "async-trait",
  "bytes",

--- a/crates/core-subsystem/core-resolver/src/system_resolver.rs
+++ b/crates/core-subsystem/core-resolver/src/system_resolver.rs
@@ -60,7 +60,7 @@ pub struct GraphQLSystemResolver {
     query_interception_map: InterceptionMap,
     mutation_interception_map: InterceptionMap,
     trusted_documents: TrustedDocuments,
-    schema: Arc<Schema>,
+    pub schema: Arc<Schema>,
     normal_query_depth_limit: usize,
     introspection_query_depth_limit: usize,
 }

--- a/crates/mcp-router/Cargo.toml
+++ b/crates/mcp-router/Cargo.toml
@@ -12,6 +12,7 @@ async-stream.workspace = true
 bytes.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+async-graphql-parser.workspace = true
 
 common = { path = "../common" }
 exo-env = { path = "../../libs/exo-env" }

--- a/libs/exo-env/src/lib.rs
+++ b/libs/exo-env/src/lib.rs
@@ -18,6 +18,10 @@ pub trait Environment: Send + Sync {
             None => default_value,
         }
     }
+
+    fn get_or_else(&self, key: &str, default_value: &str) -> String {
+        self.get(key).unwrap_or(default_value.to_string())
+    }
 }
 
 pub struct SystemEnvironment;


### PR DESCRIPTION
When the `EXO_UNSTABLE_MCP_MODE` is set to "separate", add a dedicated introspect tool that allows LLMs to obtain the schema independently. This reduces network overhead and token consumption per call.

Additionally, include the schema description and the names of entities in the execute_query tool’s description to provide richer metacontext for LLMs.