### PR TITLE
fix(mcp): Emit details for validation errors

### DIFF
--- a/crates/mcp-router/src/mcp_router.rs
+++ b/crates/mcp-router/src/mcp_router.rs
@@ -346,7 +346,8 @@ impl McpRouter {
                     SubsystemRpcError::ParseError
                     | SubsystemRpcError::InvalidParams(_, _)
                     | SubsystemRpcError::InvalidRequest
-                    | SubsystemRpcError::UserDisplayError(_) => StatusCode::BAD_REQUEST,
+                    | SubsystemRpcError::UserDisplayError(_)
+                    | SubsystemRpcError::SystemResolutionError(_) => StatusCode::BAD_REQUEST,
                     SubsystemRpcError::MethodNotFound(_) => StatusCode::NOT_FOUND,
                     SubsystemRpcError::InternalError => StatusCode::INTERNAL_SERVER_ERROR,
                 };
@@ -365,7 +366,7 @@ impl McpRouter {
                 (
                     json!({
                         "content": [json!({
-                            "text": e.user_error_message().unwrap_or_default(),
+                            "text": format!("Error: {}", e.user_error_message().unwrap_or_default()),
                             "type": "text",
                         })],
                         "isError": true,


### PR DESCRIPTION
We were emiting a generic "Internal Error" even for validation errors. Now we return a full error message such as `Error: Argument(s) '[\"id\"]' invalid for 'concerts', \"locations\": [2:3]` so that LLMs can fix the query and retry.