### PR TITLE
Remove APIs queries with `false` access control

### DIFF
--- a/crates/core-subsystem/core-resolver/src/validation/document_validator.rs
+++ b/crates/core-subsystem/core-resolver/src/validation/document_validator.rs
@@ -802,12 +802,14 @@ mod tests {
         let test_exo = r#"
             @postgres
             module LogModule {
+                @access(true)
                 type Concert {
                     @pk id: Int = autoIncrement()
                     title: String
                     venue: Venue
                 }
 
+                @access(true)
                 type Venue {
                     @pk id: Int = autoIncrement()
                     name: String

--- a/crates/postgres-subsystem/postgres-builder/src/test_utils.rs
+++ b/crates/postgres-subsystem/postgres-builder/src/test_utils.rs
@@ -49,8 +49,9 @@ fn deserialize_postgres_subsystem(
 
     match postgres_subsystem {
         Some(subsystem) => {
-            let mut postgres_subsystem =
-                PostgresGraphQLSubsystem::deserialize(subsystem.graphql.unwrap().0)?;
+            let mut postgres_subsystem = PostgresGraphQLSubsystem::deserialize(
+                subsystem.graphql.map(|g| g.0).unwrap_or_default(),
+            )?;
             let postgres_core_subsystem = PostgresCoreSubsystem::deserialize(subsystem.core.0)?;
             postgres_subsystem.core_subsystem = Arc::new(postgres_core_subsystem);
             Ok(postgres_subsystem)

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/create_mutation_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/create_mutation_builder.rs
@@ -63,13 +63,6 @@ impl Builder for CreateMutationBuilder {
                     .lock()
                     .unwrap()[entity_type.access.creation.precheck],
                 AccessPredicateExpression::BooleanLiteral(false)
-            ) || matches!(
-                building
-                    .core_subsystem
-                    .precheck_access_expressions
-                    .lock()
-                    .unwrap()[entity_type.access.creation.precheck],
-                AccessPredicateExpression::BooleanLiteral(false)
             )
         };
 

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/type_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/type_builder.rs
@@ -40,20 +40,28 @@ fn expand_query_mutation_map(
         building.pk_queries_map.insert(existing_type_id, pk_query);
     }
 
-    let collection_query = building
+    if let Some(collection_query) = building
         .collection_queries
         .get_id(&resolved_type.collection_query())
-        .unwrap();
+    {
+        building
+            .collection_queries_map
+            .insert(existing_type_id, collection_query);
+    }
 
-    let aggregate_query = building
+    if let Some(aggregate_query) = building
         .aggregate_queries
         .get_id(&resolved_type.aggregate_query())
-        .unwrap();
+    {
+        building
+            .aggregate_queries_map
+            .insert(existing_type_id, aggregate_query);
+    }
 
-    building
-        .collection_queries_map
-        .insert(existing_type_id, collection_query);
-    building
-        .aggregate_queries_map
-        .insert(existing_type_id, aggregate_query);
+    // building
+    //     .collection_queries_map
+    //     .insert(existing_type_id, collection_query);
+    // building
+    //     .aggregate_queries_map
+    //     .insert(existing_type_id, aggregate_query);
 }

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/access/database_solver.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/access/database_solver.rs
@@ -73,6 +73,7 @@ mod tests {
 
                 @postgres
                 module ArticleModule {
+                    @access(true)
                     type Article {
                         @pk id: Int = autoIncrement()
                         published: Boolean

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/access/precheck_solver/test_system.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/access/precheck_solver/test_system.rs
@@ -27,18 +27,21 @@ impl TestSystem {
     
                 @postgres
                 module ArticleModule {
+                    @access(true)
                     type Article {
                         @pk id: Int = autoIncrement()
                         title: String
                         publications: Set<Publication>?
                     }
 
+                    @access(true)
                     type Publication {
                         @pk author: User
                         @pk article: Article
                         royalty: Int
                     }
     
+                    @access(true)
                     type User {
                         @pk id: Int = autoIncrement()
                         name: String
@@ -48,6 +51,7 @@ impl TestSystem {
                         todos: Set<Todo>?
                     }
 
+                    @access(true)
                     type Todo {
                         @pk id: Int = autoIncrement()
                         title: String

--- a/crates/subsystem-util/subsystem-model-builder-util/src/builder/type_builder.rs
+++ b/crates/subsystem-util/subsystem-model-builder-util/src/builder/type_builder.rs
@@ -128,9 +128,12 @@ fn expand_method_access(
     resolved_env: &ResolvedTypeEnv,
     building: &mut SystemContextBuilding,
 ) -> Result<(), ModelBuildingError> {
-    let existing_method_id = building.methods.get_id(&resolved_method.name).unwrap();
-    let expr = compute_access_method(&resolved_method.access, resolved_env)?;
-    building.methods.get_by_id_mut(existing_method_id).access = expr;
+    let existing_method_id = building.methods.get_id(&resolved_method.name);
+
+    if let Some(existing_method_id) = existing_method_id {
+        let expr = compute_access_method(&resolved_method.access, resolved_env)?;
+        building.methods.get_by_id_mut(existing_method_id).access = expr;
+    }
 
     Ok(())
 }

--- a/crates/testing/src/execution/introspection_tests.rs
+++ b/crates/testing/src/execution/introspection_tests.rs
@@ -50,14 +50,20 @@ pub(super) async fn run_introspection_test(model_path: &Path) -> Result<TestResu
         create_system_router_from_file(&exo_ir_file, static_loaders, Arc::new(env)).await?
     };
 
-    let result = check_introspection(&router, model_path).await?;
+    let result = check_introspection(&router, model_path).await;
 
     match result {
-        Ok(()) => Ok(TestResult {
-            log_prefix: log_prefix.to_string(),
-            result: TestResultKind::Success,
-        }),
+        Ok(result) => match result {
+            Ok(()) => Ok(TestResult {
+                log_prefix: log_prefix.to_string(),
+                result: TestResultKind::Success,
+            }),
 
+            Err(e) => Ok(TestResult {
+                log_prefix: log_prefix.to_string(),
+                result: TestResultKind::Fail(e),
+            }),
+        },
         Err(e) => Ok(TestResult {
             log_prefix: log_prefix.to_string(),
             result: TestResultKind::Fail(e),

--- a/docs/docs/postgres/access-control.md
+++ b/docs/docs/postgres/access-control.md
@@ -188,7 +188,7 @@ While the following expression will deny access to all users:
 The default access control expression is `false`. This secure-by-default approach forces you to think about access control for each type explicitly.
 :::
 
-When you use `access(false)` for a mutation, it has the effect of removing that API. For more details, please see the [Effect on Mutation APIs](#effect-on-mutation-apis) section.
+When you use `access(false)` for a query or mutation, it has the effect of removing that API. For more details, please see the [Effect on APIs](#effect-on-apis) section.
 
 ### Using context objects
 
@@ -404,9 +404,9 @@ Since an access control expression may specify any of the `query`, `mutation`, `
 
 Another way to look at access control precedence is to know that most specific rule takes precedence over the more general rule. For example, if you specify an access control expression for a particular mutation, Exograph will use that expression. If a higher precedence expression is not defined, the expression for the next lower precedence will take effect.
 
-## Effect on Mutation APIs
+## Effect on APIs
 
-Access expression of the form `@access(false)`, whether explicitly specified or the default, removes the mutation from APIs. For example, with the following access expression, none of the mutations will be available in the API.
+Access expression of the form `@access(false)`, whether explicitly specified or the default, removes the query or mutation from APIs. For example, with the following access expression, none of the queries or mutations will be available in the API.
 
 ```exo
 @postgres
@@ -420,7 +420,7 @@ module ProductDatabase {
 }
 ```
 
-If you want to remove only a particular mutation, you can specify the access expression for that mutation. For example, the following access expression will remove the `updateProduct` mutation from the API (see [Separating queries and mutations access control](#separating-queries-and-mutations-access-control) for more details):
+If you want to remove only a particular query or mutation, you can specify the access expression for that query or mutation. For example, the following access expression will remove the `updateProduct` mutation from the API (see [Separating queries and mutations access control](#separating-queries-and-mutations-access-control) for more details):
 
 ```exo
 @postgres
@@ -440,7 +440,7 @@ module ProductDatabase {
 }
 ```
 
-Such an arrangement is helpful to avoid unnecessary mutations in the API.
+Such an arrangement is helpful to avoid unnecessary queries or mutations in the API.
 
 ## Access Control as Invariants
 

--- a/integration-tests/default-access/schema-tests/introspection.expected.graphql
+++ b/integration-tests/default-access/schema-tests/introspection.expected.graphql
@@ -1,32 +1,3 @@
-type Concert {
-  id: Int!
-  title: String!
-}
-
-"""An aggregate for the `Concert` type."""
-type ConcertAgg {
-  id: IntAgg
-  title: StringAgg
-}
-
-"""
-Predicate for the `Concert` type parameter. 
-If a field is omitted, no filter is applied for that field.
-To check a field against null, use a `<field name>: null` filter
-"""
-input ConcertFilter {
-  id: IntFilter
-  title: StringFilter
-  and: [ConcertFilter!]
-  or: [ConcertFilter!]
-  not: ConcertFilter
-}
-
-input ConcertOrdering {
-  id: Ordering
-  title: Ordering
-}
-
 type DivisionResultFullAccess {
   quotient: Int!
   remainder: Int!
@@ -37,67 +8,12 @@ type DivisionResultNoAccess {
   remainder: Int!
 }
 
-type IntAgg {
-  min: Int
-  max: Int
-  sum: Int
-  avg: Float
-  count: Int
-}
-
-input IntFilter {
-  eq: Int
-  neq: Int
-  lt: Int
-  lte: Int
-  gt: Int
-  gte: Int
-}
-
-enum Ordering {
-  ASC
-  DESC
-}
-
-type StringAgg {
-  min: String
-  max: String
-  count: Int
-}
-
-input StringFilter {
-  eq: String
-  neq: String
-  lt: String
-  lte: String
-  gt: String
-  gte: String
-  like: String
-  ilike: String
-  startsWith: String
-  endsWith: String
-}
-
 type Query {
-  """Get a single `Concert` given primary key fields"""
-  concert(id: Int!): Concert
-
-  """
-  Get multiple `Concert`s given the provided `where` filter, order by, limit, and offset
-  """
-  concerts(where: ConcertFilter, orderBy: [ConcertOrdering!], limit: Int, offset: Int): [Concert!]!
-
-  """
-  Get the aggregate value of the selected fields over all `Concert`s given the provided `where` filter
-  """
-  concertsAgg(where: ConcertFilter): ConcertAgg!
   divide(a: Int!, b: Int!): DivisionResultFullAccess!
   divideFullAccess(a: Int!, b: Int!): DivisionResultNoAccess!
-  divideNoAccess(a: Int!, b: Int!): DivisionResultFullAccess!
 }
 
 type Mutation {
   divideFullAccessMutation(a: Int!, b: Int!): DivisionResultNoAccess!
   divideMutation(a: Int!, b: Int!): DivisionResultFullAccess!
-  divideNoAccessMutation(a: Int!, b: Int!): DivisionResultFullAccess!
 }

--- a/integration-tests/default-access/tests/default-access-mutations.exotest
+++ b/integration-tests/default-access/tests/default-access-mutations.exotest
@@ -88,7 +88,13 @@ stages:
       {
         "errors": [
           {
-            "message": "Not authorized"
+            "message": "Field 'divideNoAccessMutation' is not valid for type 'Mutation'",
+            "locations": [
+              {
+                "line": 2,
+                "column": 3
+              }
+            ]
           }
         ]
       }

--- a/integration-tests/default-access/tests/default-access-queries.exotest
+++ b/integration-tests/default-access/tests/default-access-queries.exotest
@@ -9,7 +9,13 @@ stages:
       {
         "errors": [
           {
-            "message": "Not authorized"
+            "message": "Field 'concerts' is not valid for type 'Query'",
+            "locations": [
+              {
+                "line": 2,
+                "column": 3
+              }
+            ]
           }
         ]
       }
@@ -24,7 +30,13 @@ stages:
       {
         "errors": [
           {
-            "message": "Not authorized"
+            "message": "Field 'concert' is not valid for type 'Query'",
+            "locations": [
+              {
+                "line": 2,
+                "column": 3
+              }
+            ]
           }
         ]
       }
@@ -56,7 +68,13 @@ stages:
       {
         "errors": [
           {
-            "message": "Not authorized"
+            "message": "Field 'divideNoAccess' is not valid for type 'Query'",
+            "locations": [
+              {
+                "line": 2,
+                "column": 3
+              }
+            ]
           }
         ]
       }

--- a/integration-tests/interceptor/operation-params/src/index.exo
+++ b/integration-tests/interceptor/operation-params/src/index.exo
@@ -12,10 +12,12 @@ module Interception {
   @around("query *")
   interceptor captureParams(operation: Operation)
 
+  @access(true)
   type OperationParams {
     name: String
     query: String
   }
 
+  @access(true)
   query serve(intArg: Int, stringArg: String): OperationParams?
 }

--- a/integration-tests/interceptor/proceed-return/src/index.exo
+++ b/integration-tests/interceptor/proceed-return/src/index.exo
@@ -9,11 +9,13 @@ module TodoModule {
 
 @deno("test-module.ts")
 module TestModule {
+  @access(true)
   type Info {
     id: Int
     title: String
   }
 
+  @access(true)
   query getInfo(): Info
 }
 

--- a/integration-tests/interceptor/same-name/src/index.exo
+++ b/integration-tests/interceptor/same-name/src/index.exo
@@ -1,5 +1,6 @@
 @deno("core.ts")
 module Core {
+  @access(true)
   query getInt(): Int  
 }
 

--- a/integration-tests/introspection/src/index.exo
+++ b/integration-tests/introspection/src/index.exo
@@ -9,11 +9,15 @@ module PersonModule {
 
 @deno("logger.js")
 module Logger {
+  @access(true)
   type LogMessage {
     level: String
     message: String
   }
 
+  @access(true)
   export query logger(@inject exograph: Exograph, input: LogMessage): Boolean
+
+  @access(true)
   mutation debug(@inject exograph: Exograph, input: LogMessage): Boolean
 }

--- a/integration-tests/services/deno-stripe/src/index.exo
+++ b/integration-tests/services/deno-stripe/src/index.exo
@@ -1,6 +1,9 @@
 @deno("test_ops.ts")
 module TodoDatabase {
+  // Needed to get around GraphQL requirements that there must be at least one query
+  @access(true)
   query fake(): String
+
   @access(true)
   mutation create_customer(email: String): String
 }

--- a/integration-tests/services/with-auth/json
+++ b/integration-tests/services/with-auth/json
@@ -1,0 +1,13 @@
+input LogEntry {
+  level: String!
+  message: String!
+}
+
+type Query {
+  getRole: String!
+}
+
+type Mutation {
+  logNormal(entry: LogEntry!): Boolean!
+  logPrivileged(entry: LogEntry!): Boolean!
+}

--- a/integration-tests/services/with-auth/src/index.exo
+++ b/integration-tests/services/with-auth/src/index.exo
@@ -5,13 +5,16 @@ context AuthContext {
 
 @deno("logger.js")
 module PrivilegedLogger {
+    @access(true)
     type LogEntry {
         level: String
         message: String
     }
 
+    @access(true)
     query getRole(@inject auth_context: AuthContext): String
 
+    @access(true)
     mutation logNormal(entry: LogEntry): Boolean
 
     @access(AuthContext.role == "ROLE_PRIVILEGED")

--- a/integration-tests/wasm/src/index.exo
+++ b/integration-tests/wasm/src/index.exo
@@ -1,4 +1,5 @@
 @wasm("./wasm-source/target/wasm32-unknown-unknown/debug/wasi_add.wasm")
 module ArithmeticModule {
+    @access(true)
     query add(a: Int, b: Int): Int
 }


### PR DESCRIPTION
Earlier, we removed mutations with a literal `false` access control (`@access(false)`). This commit expands the same idea to queries. This is a step towards letting developers specify a "scope" to limit the API surface.