### PR TITLE
fix(mcp): Make compatible with streaming HTTP

### DIFF
--- a/crates/mcp-router/src/mcp_router.rs
+++ b/crates/mcp-router/src/mcp_router.rs
@@ -228,6 +228,7 @@ impl<'a> Router<RequestContext<'a>> for McpRouter {
 
         let mut id = None;
         let mut headers = Headers::new();
+        headers.insert("content-type".into(), "application/json".into());
 
         let response = {
             match request {


### PR DESCRIPTION
Add `Content-Type: application/json` to MCP response to make it compatible with the "streaming HTTP" protocol. Tested with the MCP Inspector.