### PR TITLE
Refactor `PrimitiveType` to separate injected types

### DIFF
--- a/crates/builder/src/typechecker/mod.rs
+++ b/crates/builder/src/typechecker/mod.rs
@@ -11,7 +11,10 @@ use std::{collections::HashMap, vec};
 
 use codemap::Span;
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
-use core_model::{mapped_arena::MappedArena, primitive_type::PrimitiveType};
+use core_model::{
+    mapped_arena::MappedArena,
+    primitive_type::{InjectedType, PrimitiveType},
+};
 use core_model_builder::{
     ast::ast_types::{AstEnum, AstModel, AstModelKind, AstModule, AstSystem, Untyped},
     typechecker::{
@@ -82,12 +85,12 @@ fn populate_type_env(env: &mut MappedArena<Type>) {
     env.add("Uuid", Type::Primitive(PrimitiveType::Uuid));
     env.add("Vector", Type::Primitive(PrimitiveType::Vector));
 
-    env.add("Exograph", Type::Primitive(PrimitiveType::Exograph));
-    env.add("ExographPriv", Type::Primitive(PrimitiveType::ExographPriv));
+    env.add("Exograph", Type::Injected(InjectedType::Exograph));
+    env.add("ExographPriv", Type::Injected(InjectedType::ExographPriv));
 
     env.add(
         "Operation",
-        Type::Primitive(PrimitiveType::Interception("Operation".to_string())),
+        Type::Injected(InjectedType::Operation("Operation".to_string())),
     );
 }
 

--- a/crates/builder/src/typechecker/snapshots/simple.snap
+++ b/crates/builder/src/typechecker/snapshots/simple.snap
@@ -31,12 +31,12 @@ types:
     - - ~
       - Primitive: Vector
     - - ~
-      - Primitive: Exograph
+      - Injected: Exograph
     - - ~
-      - Primitive: ExographPriv
+      - Injected: ExographPriv
     - - ~
-      - Primitive:
-          Interception: Operation
+      - Injected:
+          Operation: Operation
     - - ~
       - Composite:
           name: User

--- a/crates/builder/src/typechecker/snapshots/with_array_in_operator.snap
+++ b/crates/builder/src/typechecker/snapshots/with_array_in_operator.snap
@@ -31,12 +31,12 @@ types:
     - - ~
       - Primitive: Vector
     - - ~
-      - Primitive: Exograph
+      - Injected: Exograph
     - - ~
-      - Primitive: ExographPriv
+      - Injected: ExographPriv
     - - ~
-      - Primitive:
-          Interception: Operation
+      - Injected:
+          Operation: Operation
     - - ~
       - Composite:
           name: AuthContext

--- a/crates/builder/src/typechecker/snapshots/with_auth_context_use_in_field_annotation.snap
+++ b/crates/builder/src/typechecker/snapshots/with_auth_context_use_in_field_annotation.snap
@@ -31,12 +31,12 @@ types:
     - - ~
       - Primitive: Vector
     - - ~
-      - Primitive: Exograph
+      - Injected: Exograph
     - - ~
-      - Primitive: ExographPriv
+      - Injected: ExographPriv
     - - ~
-      - Primitive:
-          Interception: Operation
+      - Injected:
+          Operation: Operation
     - - ~
       - Composite:
           name: AuthContext

--- a/crates/builder/src/typechecker/snapshots/with_auth_context_use_in_type_annotation.snap
+++ b/crates/builder/src/typechecker/snapshots/with_auth_context_use_in_type_annotation.snap
@@ -31,12 +31,12 @@ types:
     - - ~
       - Primitive: Vector
     - - ~
-      - Primitive: Exograph
+      - Injected: Exograph
     - - ~
-      - Primitive: ExographPriv
+      - Injected: ExographPriv
     - - ~
-      - Primitive:
-          Interception: Operation
+      - Injected:
+          Operation: Operation
     - - ~
       - Composite:
           name: AuthContext

--- a/crates/builder/src/typechecker/snapshots/with_function_calls.snap
+++ b/crates/builder/src/typechecker/snapshots/with_function_calls.snap
@@ -31,12 +31,12 @@ types:
     - - ~
       - Primitive: Vector
     - - ~
-      - Primitive: Exograph
+      - Injected: Exograph
     - - ~
-      - Primitive: ExographPriv
+      - Injected: ExographPriv
     - - ~
-      - Primitive:
-          Interception: Operation
+      - Injected:
+          Operation: Operation
     - - ~
       - Composite:
           name: AuthContext

--- a/crates/core-subsystem/core-model-builder/src/typechecker/typ.rs
+++ b/crates/core-subsystem/core-model-builder/src/typechecker/typ.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use core_model::mapped_arena::{MappedArena, SerializableSlabIndex};
-use core_model::primitive_type::PrimitiveType;
+use core_model::primitive_type::{InjectedType, PrimitiveType};
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, ops::Deref};
 
@@ -24,6 +24,7 @@ pub enum Type {
     Set(Box<Type>),
     Array(Box<Type>),
     Reference(SerializableSlabIndex<Type>),
+    Injected(InjectedType),
     Null,
     Defer,
     Error,
@@ -100,6 +101,7 @@ impl Type {
             Type::Optional(underlying) | Type::Set(underlying) | Type::Array(underlying) => {
                 underlying.get_underlying_typename(types)
             }
+            Type::Injected(it) => Some(it.name()),
             _ => None,
         }
     }

--- a/crates/core-subsystem/core-model/src/primitive_type.rs
+++ b/crates/core-subsystem/core-model/src/primitive_type.rs
@@ -31,16 +31,6 @@ pub enum PrimitiveType {
     // TODO: This should not be a primitive type, but a type with modifier or some variation of it
     /// An array version of a primitive type.
     Array(Box<PrimitiveType>),
-
-    // TODO: These should not be a primitive types... perhaps another enum `InjectedType`?
-    /// Available as an injected dependency to Deno queries and mutations so that the implementation
-    /// can execute queries and mutations.
-    Exograph,
-    /// Similar to Exograph, but also allows queries and mutations with a privilege of another
-    /// context.
-    ExographPriv,
-    /// Available to interceptors so that they can get the operation that is being intercepted.
-    Interception(String),
 }
 
 impl PrimitiveType {
@@ -59,9 +49,6 @@ impl PrimitiveType {
             PrimitiveType::Blob => "Blob".to_owned(),
             PrimitiveType::Uuid => "Uuid".to_owned(),
             PrimitiveType::Vector => "Vector".to_owned(),
-            PrimitiveType::Exograph => "Exograph".to_owned(),
-            PrimitiveType::ExographPriv => "ExographPriv".to_owned(),
-            PrimitiveType::Interception(name) => name.to_owned(),
             PrimitiveType::Array(pt) => format!("[{}]", pt.name()),
         }
     }
@@ -118,4 +105,27 @@ pub enum PrimitiveValue {
 pub enum NumberLiteral {
     Int(i64),
     Float(f64),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+
+pub enum InjectedType {
+    /// Available as an injected dependency to Deno queries and mutations so that the implementation
+    /// can execute queries and mutations.
+    Exograph,
+    /// Similar to Exograph, but also allows queries and mutations with a privilege of another
+    /// context.
+    ExographPriv,
+    /// Available to interceptors so that they can get the operation that is being intercepted.
+    Operation(String),
+}
+
+impl InjectedType {
+    pub fn name(&self) -> String {
+        match &self {
+            InjectedType::Exograph => "Exograph".to_owned(),
+            InjectedType::ExographPriv => "ExographPriv".to_owned(),
+            InjectedType::Operation(name) => name.to_owned(),
+        }
+    }
 }

--- a/crates/deno-subsystem/deno-graphql-resolver/src/deno_operation.rs
+++ b/crates/deno-subsystem/deno-graphql-resolver/src/deno_operation.rs
@@ -62,7 +62,7 @@ impl DenoOperation<'_> {
                 let return_type = return_type.typ(&subsystem.module_types);
 
                 let type_level_access = match &return_type.kind {
-                    ModuleTypeKind::Primitive => true,
+                    ModuleTypeKind::Primitive | ModuleTypeKind::Injected => true,
                     ModuleTypeKind::Composite(ModuleCompositeType { access, .. }) => subsystem
                         .solve(self.request_context, None, &access.value)
                         .await?

--- a/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
@@ -631,10 +631,7 @@ fn determine_column_type<'a>(
             PrimitiveType::Vector => PhysicalColumnType::Vector {
                 size: DEFAULT_VECTOR_SIZE,
             },
-            PrimitiveType::Array(_)
-            | PrimitiveType::Exograph
-            | PrimitiveType::ExographPriv
-            | PrimitiveType::Interception(_) => {
+            PrimitiveType::Array(_) => {
                 panic!()
             }
         }

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/column_names_for_non_standard_relational_field_names.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/column_names_for_non_standard_relational_field_names.snap
@@ -30,13 +30,6 @@ values:
   - - ~
     - Primitive: Vector
   - - ~
-    - Primitive: Exograph
-  - - ~
-    - Primitive: ExographPriv
-  - - ~
-    - Primitive:
-        Interception: Operation
-  - - ~
     - Composite:
         name: Concert
         plural_name: Concerts
@@ -282,19 +275,6 @@ values:
           delete: ~
         doc_comments: ~
   - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
 map:
   Blob:
     index: 10
@@ -303,16 +283,10 @@ map:
     index: 0
     generation: ~
   Concert:
-    index: 16
+    index: 13
     generation: ~
   Decimal:
     index: 3
-    generation: ~
-  Exograph:
-    index: 13
-    generation: ~
-  ExographPriv:
-    index: 14
     generation: ~
   Float:
     index: 2
@@ -335,9 +309,6 @@ map:
   LocalTime:
     index: 5
     generation: ~
-  Operation:
-    index: 15
-    generation: ~
   String:
     index: 4
     generation: ~
@@ -348,5 +319,5 @@ map:
     index: 12
     generation: ~
   Venue:
-    index: 17
+    index: 14
     generation: ~

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/field_name_variations.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/field_name_variations.snap
@@ -30,13 +30,6 @@ values:
   - - ~
     - Primitive: Vector
   - - ~
-    - Primitive: Exograph
-  - - ~
-    - Primitive: ExographPriv
-  - - ~
-    - Primitive:
-        Interception: Operation
-  - - ~
     - Composite:
         name: Entity
         plural_name: Entities
@@ -212,19 +205,6 @@ values:
         doc_comments: ~
   - ~
   - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
 map:
   Blob:
     index: 10
@@ -236,13 +216,7 @@ map:
     index: 3
     generation: ~
   Entity:
-    index: 16
-    generation: ~
-  Exograph:
     index: 13
-    generation: ~
-  ExographPriv:
-    index: 14
     generation: ~
   Float:
     index: 2
@@ -264,9 +238,6 @@ map:
     generation: ~
   LocalTime:
     index: 5
-    generation: ~
-  Operation:
-    index: 15
     generation: ~
   String:
     index: 4

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/non_public_schema.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/non_public_schema.snap
@@ -30,13 +30,6 @@ values:
   - - ~
     - Primitive: Vector
   - - ~
-    - Primitive: Exograph
-  - - ~
-    - Primitive: ExographPriv
-  - - ~
-    - Primitive:
-        Interception: Operation
-  - - ~
     - Composite:
         name: AuthSchemaTable
         plural_name: AuthSchemaTables
@@ -177,25 +170,12 @@ values:
           delete: ~
         doc_comments: ~
   - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
 map:
   AuthSchemaTable:
-    index: 16
+    index: 13
     generation: ~
   AuthSchemaTableWithCustomName:
-    index: 17
+    index: 14
     generation: ~
   Blob:
     index: 10
@@ -205,12 +185,6 @@ map:
     generation: ~
   Decimal:
     index: 3
-    generation: ~
-  Exograph:
-    index: 13
-    generation: ~
-  ExographPriv:
-    index: 14
     generation: ~
   Float:
     index: 2
@@ -232,9 +206,6 @@ map:
     generation: ~
   LocalTime:
     index: 5
-    generation: ~
-  Operation:
-    index: 15
     generation: ~
   String:
     index: 4

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_access.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_access.snap
@@ -30,13 +30,6 @@ values:
   - - ~
     - Primitive: Vector
   - - ~
-    - Primitive: Exograph
-  - - ~
-    - Primitive: ExographPriv
-  - - ~
-    - Primitive:
-        Interception: Operation
-  - - ~
     - Composite:
         name: Concert
         plural_name: Concerts
@@ -318,22 +311,9 @@ values:
           update: ~
           delete: ~
         doc_comments: ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
 map:
   Artist:
-    index: 18
+    index: 15
     generation: ~
   Blob:
     index: 10
@@ -342,16 +322,10 @@ map:
     index: 0
     generation: ~
   Concert:
-    index: 16
+    index: 13
     generation: ~
   Decimal:
     index: 3
-    generation: ~
-  Exograph:
-    index: 13
-    generation: ~
-  ExographPriv:
-    index: 14
     generation: ~
   Float:
     index: 2
@@ -374,9 +348,6 @@ map:
   LocalTime:
     index: 5
     generation: ~
-  Operation:
-    index: 15
-    generation: ~
   String:
     index: 4
     generation: ~
@@ -387,5 +358,5 @@ map:
     index: 12
     generation: ~
   Venue:
-    index: 17
+    index: 14
     generation: ~

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_access_default_values.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_access_default_values.snap
@@ -30,13 +30,6 @@ values:
   - - ~
     - Primitive: Vector
   - - ~
-    - Primitive: Exograph
-  - - ~
-    - Primitive: ExographPriv
-  - - ~
-    - Primitive:
-        Interception: Operation
-  - - ~
     - Composite:
         name: Concert
         plural_name: Concerts
@@ -176,19 +169,6 @@ values:
         doc_comments: ~
   - ~
   - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
 map:
   Blob:
     index: 10
@@ -197,16 +177,10 @@ map:
     index: 0
     generation: ~
   Concert:
-    index: 16
+    index: 13
     generation: ~
   Decimal:
     index: 3
-    generation: ~
-  Exograph:
-    index: 13
-    generation: ~
-  ExographPriv:
-    index: 14
     generation: ~
   Float:
     index: 2
@@ -228,9 +202,6 @@ map:
     generation: ~
   LocalTime:
     index: 5
-    generation: ~
-  Operation:
-    index: 15
     generation: ~
   String:
     index: 4

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_annotations.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_annotations.snap
@@ -30,13 +30,6 @@ values:
   - - ~
     - Primitive: Vector
   - - ~
-    - Primitive: Exograph
-  - - ~
-    - Primitive: ExographPriv
-  - - ~
-    - Primitive:
-        Interception: Operation
-  - - ~
     - Composite:
         name: Concert
         plural_name: Concerts
@@ -380,19 +373,6 @@ values:
           delete: ~
         doc_comments: ~
   - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
 map:
   Blob:
     index: 10
@@ -401,16 +381,10 @@ map:
     index: 0
     generation: ~
   Concert:
-    index: 16
+    index: 13
     generation: ~
   Decimal:
     index: 3
-    generation: ~
-  Exograph:
-    index: 13
-    generation: ~
-  ExographPriv:
-    index: 14
     generation: ~
   Float:
     index: 2
@@ -433,9 +407,6 @@ map:
   LocalTime:
     index: 5
     generation: ~
-  Operation:
-    index: 15
-    generation: ~
   String:
     index: 4
     generation: ~
@@ -446,5 +417,5 @@ map:
     index: 12
     generation: ~
   Venue:
-    index: 17
+    index: 14
     generation: ~

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_camel_case_model_and_fields.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_camel_case_model_and_fields.snap
@@ -30,13 +30,6 @@ values:
   - - ~
     - Primitive: Vector
   - - ~
-    - Primitive: Exograph
-  - - ~
-    - Primitive: ExographPriv
-  - - ~
-    - Primitive:
-        Interception: Operation
-  - - ~
     - Composite:
         name: ConcertInfo
         plural_name: ConcertInfos
@@ -108,19 +101,6 @@ values:
         doc_comments: ~
   - ~
   - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
 map:
   Blob:
     index: 10
@@ -129,16 +109,10 @@ map:
     index: 0
     generation: ~
   ConcertInfo:
-    index: 16
+    index: 13
     generation: ~
   Decimal:
     index: 3
-    generation: ~
-  Exograph:
-    index: 13
-    generation: ~
-  ExographPriv:
-    index: 14
     generation: ~
   Float:
     index: 2
@@ -160,9 +134,6 @@ map:
     generation: ~
   LocalTime:
     index: 5
-    generation: ~
-  Operation:
-    index: 15
     generation: ~
   String:
     index: 4

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_defaults.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_defaults.snap
@@ -30,13 +30,6 @@ values:
   - - ~
     - Primitive: Vector
   - - ~
-    - Primitive: Exograph
-  - - ~
-    - Primitive: ExographPriv
-  - - ~
-    - Primitive:
-        Interception: Operation
-  - - ~
     - Composite:
         name: Concert
         plural_name: Concerts
@@ -290,19 +283,6 @@ values:
           delete: ~
         doc_comments: ~
   - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
 map:
   Blob:
     index: 10
@@ -311,16 +291,10 @@ map:
     index: 0
     generation: ~
   Concert:
-    index: 16
+    index: 13
     generation: ~
   Decimal:
     index: 3
-    generation: ~
-  Exograph:
-    index: 13
-    generation: ~
-  ExographPriv:
-    index: 14
     generation: ~
   Float:
     index: 2
@@ -343,9 +317,6 @@ map:
   LocalTime:
     index: 5
     generation: ~
-  Operation:
-    index: 15
-    generation: ~
   String:
     index: 4
     generation: ~
@@ -356,5 +327,5 @@ map:
     index: 12
     generation: ~
   Venue:
-    index: 17
+    index: 14
     generation: ~

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_multiple_matching_field_with_column_annotation.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_multiple_matching_field_with_column_annotation.snap
@@ -30,13 +30,6 @@ values:
   - - ~
     - Primitive: Vector
   - - ~
-    - Primitive: Exograph
-  - - ~
-    - Primitive: ExographPriv
-  - - ~
-    - Primitive:
-        Interception: Operation
-  - - ~
     - Composite:
         name: Concert
         plural_name: Concerts
@@ -283,19 +276,6 @@ values:
           delete: ~
         doc_comments: ~
   - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
 map:
   Blob:
     index: 10
@@ -304,16 +284,10 @@ map:
     index: 0
     generation: ~
   Concert:
-    index: 16
+    index: 13
     generation: ~
   Decimal:
     index: 3
-    generation: ~
-  Exograph:
-    index: 13
-    generation: ~
-  ExographPriv:
-    index: 14
     generation: ~
   Float:
     index: 2
@@ -336,9 +310,6 @@ map:
   LocalTime:
     index: 5
     generation: ~
-  Operation:
-    index: 15
-    generation: ~
   String:
     index: 4
     generation: ~
@@ -349,5 +320,5 @@ map:
     index: 12
     generation: ~
   Venue:
-    index: 17
+    index: 14
     generation: ~

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_optional_fields.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_optional_fields.snap
@@ -30,13 +30,6 @@ values:
   - - ~
     - Primitive: Vector
   - - ~
-    - Primitive: Exograph
-  - - ~
-    - Primitive: ExographPriv
-  - - ~
-    - Primitive:
-        Interception: Operation
-  - - ~
     - Composite:
         name: Concert
         plural_name: Concerts
@@ -286,19 +279,6 @@ values:
           delete: ~
         doc_comments: ~
   - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
-  - ~
 map:
   Blob:
     index: 10
@@ -307,16 +287,10 @@ map:
     index: 0
     generation: ~
   Concert:
-    index: 16
+    index: 13
     generation: ~
   Decimal:
     index: 3
-    generation: ~
-  Exograph:
-    index: 13
-    generation: ~
-  ExographPriv:
-    index: 14
     generation: ~
   Float:
     index: 2
@@ -339,9 +313,6 @@ map:
   LocalTime:
     index: 5
     generation: ~
-  Operation:
-    index: 15
-    generation: ~
   String:
     index: 4
     generation: ~
@@ -352,5 +323,5 @@ map:
     index: 12
     generation: ~
   Venue:
-    index: 17
+    index: 14
     generation: ~

--- a/crates/subsystem-util/subsystem-model-builder-util/src/builder/resolved_builder.rs
+++ b/crates/subsystem-util/subsystem-model-builder-util/src/builder/resolved_builder.rs
@@ -12,6 +12,7 @@ use std::collections::HashSet;
 use codemap::Span;
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
 
+use core_model::primitive_type::InjectedType;
 use core_model::types::{FieldType, Named};
 use core_model::{mapped_arena::MappedArena, primitive_type::PrimitiveType};
 use core_model_builder::ast::ast_types::AstFieldType;
@@ -37,6 +38,7 @@ use super::access_builder::ResolvedAccess;
 #[allow(clippy::large_enum_variant)]
 pub enum ResolvedType {
     Primitive(PrimitiveType),
+    Injected(InjectedType),
     Composite(ResolvedCompositeType),
 }
 
@@ -44,6 +46,7 @@ impl ResolvedType {
     pub fn name(&self) -> String {
         match self {
             ResolvedType::Primitive(pt) => pt.name(),
+            ResolvedType::Injected(it) => it.name(),
             ResolvedType::Composite(ResolvedCompositeType { name, .. }) => name.to_owned(),
         }
     }
@@ -491,6 +494,10 @@ fn resolve_module_types(
         if let Type::Primitive(pt) = typ {
             // Adopt the primitive types as a ModuleType
             resolved_module_types.add(&pt.name(), ResolvedType::Primitive(pt.clone()));
+        }
+        if let Type::Injected(it) = typ {
+            // Adopt the injected types as a ModuleType
+            resolved_module_types.add(&it.name(), ResolvedType::Injected(it.clone()));
         }
     }
 

--- a/crates/subsystem-util/subsystem-model-util/src/types.rs
+++ b/crates/subsystem-util/subsystem-model-util/src/types.rs
@@ -36,6 +36,7 @@ pub struct ModuleType {
 #[allow(clippy::large_enum_variant)]
 pub enum ModuleTypeKind {
     Primitive,
+    Injected,
     Composite(ModuleCompositeType),
 }
 
@@ -70,7 +71,7 @@ impl Named for ModuleFieldType {
 impl TypeDefinitionProvider<SerializableSlab<ModuleType>> for ModuleType {
     fn type_definition(&self, module_types: &SerializableSlab<ModuleType>) -> TypeDefinition {
         match &self.kind {
-            ModuleTypeKind::Primitive => TypeDefinition {
+            ModuleTypeKind::Primitive | ModuleTypeKind::Injected => TypeDefinition {
                 extend: false,
                 description: None,
                 name: default_positioned_name(&self.name),


### PR DESCRIPTION
1PrimitiveType1 included variants for `Exograph`, `Operation`, etc., which didn't really fit the primitive type concept. Now we have a separate `InjectedType` to represent those types.

This is part of cleaning up primitive types to support more types in an extensible way.