### PR TITLE
Separate plain and array variants of PrimitiveType

### DIFF
--- a/crates/builder/src/typechecker/logical_op.rs
+++ b/crates/builder/src/typechecker/logical_op.rs
@@ -10,7 +10,7 @@
 use std::collections::HashMap;
 
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
-use core_model::mapped_arena::MappedArena;
+use core_model::{mapped_arena::MappedArena, primitive_type::PrimitiveBaseType};
 use core_model_builder::typechecker::{annotation::AnnotationSpec, Typed};
 
 use crate::ast::ast_types::{AstExpr, LogicalOp, Untyped};
@@ -50,8 +50,9 @@ impl TypecheckFrom<LogicalOp<Untyped>> for LogicalOp<Typed> {
                 let in_updated = v.pass(type_env, annotation_env, scope, errors);
                 let out_updated = if o_typ.is_incomplete() {
                     match v.typ().deref(type_env) {
-                        Type::Primitive(PrimitiveType::Boolean) => {
-                            *o_typ = Type::Primitive(PrimitiveType::Boolean);
+                        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Boolean)) => {
+                            *o_typ =
+                                Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Boolean));
                             true
                         }
 
@@ -85,17 +86,19 @@ impl TypecheckFrom<LogicalOp<Untyped>> for LogicalOp<Typed> {
                     let left_typ = left.typ().deref(type_env);
                     let right_typ = right.typ().deref(type_env);
 
-                    if left_typ == Type::Primitive(PrimitiveType::Boolean)
-                        && right_typ == Type::Primitive(PrimitiveType::Boolean)
+                    if left_typ == Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Boolean))
+                        && right_typ
+                            == Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Boolean))
                     {
-                        *o_typ = Type::Primitive(PrimitiveType::Boolean);
+                        *o_typ = Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Boolean));
                         true
                     } else {
                         *o_typ = Type::Error;
 
                         if left_typ.is_complete() || right_typ.is_complete() {
                             let mut spans = vec![];
-                            if left_typ != Type::Primitive(PrimitiveType::Boolean)
+                            if left_typ
+                                != Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Boolean))
                                 && left_typ.is_complete()
                             {
                                 spans.push(SpanLabel {
@@ -105,7 +108,8 @@ impl TypecheckFrom<LogicalOp<Untyped>> for LogicalOp<Typed> {
                                 })
                             }
 
-                            if right_typ != Type::Primitive(PrimitiveType::Boolean)
+                            if right_typ
+                                != Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Boolean))
                                 && right_typ.is_complete()
                             {
                                 spans.push(SpanLabel {

--- a/crates/builder/src/typechecker/mod.rs
+++ b/crates/builder/src/typechecker/mod.rs
@@ -13,7 +13,7 @@ use codemap::Span;
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
 use core_model::{
     mapped_arena::MappedArena,
-    primitive_type::{InjectedType, PrimitiveType},
+    primitive_type::{InjectedType, PrimitiveBaseType, PrimitiveType},
 };
 use core_model_builder::{
     ast::ast_types::{AstEnum, AstModel, AstModelKind, AstModule, AstSystem, Untyped},
@@ -68,22 +68,58 @@ where
 
 fn populate_type_env(env: &mut MappedArena<Type>) {
     // TODO: maybe we don't need to do this manually
-    env.add("Boolean", Type::Primitive(PrimitiveType::Boolean));
-    env.add("Int", Type::Primitive(PrimitiveType::Int));
-    env.add("Float", Type::Primitive(PrimitiveType::Float));
-    env.add("Decimal", Type::Primitive(PrimitiveType::Decimal));
-    env.add("String", Type::Primitive(PrimitiveType::String));
-    env.add("LocalTime", Type::Primitive(PrimitiveType::LocalTime));
+    env.add(
+        "Boolean",
+        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Boolean)),
+    );
+    env.add(
+        "Int",
+        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Int)),
+    );
+    env.add(
+        "Float",
+        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Float)),
+    );
+    env.add(
+        "Decimal",
+        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Decimal)),
+    );
+    env.add(
+        "String",
+        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::String)),
+    );
+    env.add(
+        "LocalTime",
+        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::LocalTime)),
+    );
     env.add(
         "LocalDateTime",
-        Type::Primitive(PrimitiveType::LocalDateTime),
+        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::LocalDateTime)),
     );
-    env.add("LocalDate", Type::Primitive(PrimitiveType::LocalDate));
-    env.add("Instant", Type::Primitive(PrimitiveType::Instant));
-    env.add("Json", Type::Primitive(PrimitiveType::Json));
-    env.add("Blob", Type::Primitive(PrimitiveType::Blob));
-    env.add("Uuid", Type::Primitive(PrimitiveType::Uuid));
-    env.add("Vector", Type::Primitive(PrimitiveType::Vector));
+    env.add(
+        "LocalDate",
+        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::LocalDate)),
+    );
+    env.add(
+        "Instant",
+        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Instant)),
+    );
+    env.add(
+        "Json",
+        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Json)),
+    );
+    env.add(
+        "Blob",
+        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Blob)),
+    );
+    env.add(
+        "Uuid",
+        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Uuid)),
+    );
+    env.add(
+        "Vector",
+        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Vector)),
+    );
 
     env.add("Exograph", Type::Injected(InjectedType::Exograph));
     env.add("ExographPriv", Type::Injected(InjectedType::ExographPriv));

--- a/crates/builder/src/typechecker/relational_op.rs
+++ b/crates/builder/src/typechecker/relational_op.rs
@@ -10,7 +10,7 @@
 use std::collections::HashMap;
 
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
-use core_model::mapped_arena::MappedArena;
+use core_model::{mapped_arena::MappedArena, primitive_type::PrimitiveBaseType};
 use core_model_builder::typechecker::{annotation::AnnotationSpec, Typed};
 
 use crate::ast::ast_types::{AstExpr, RelationalOp, Untyped};
@@ -59,7 +59,7 @@ impl TypecheckFrom<RelationalOp<Untyped>> for RelationalOp<Typed> {
                     && right_typ.is_complete()
                     && type_match(&left_typ, &right_typ)
                 {
-                    *o_typ = Type::Primitive(PrimitiveType::Boolean);
+                    *o_typ = Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Boolean));
                     true
                 } else {
                     *o_typ = Type::Error;
@@ -137,8 +137,14 @@ pub fn identical_match(left: &Type, right: &Type) -> bool {
         match (left, right) {
             (Type::Primitive(left_typ), Type::Primitive(right_typ)) => {
                 match (left_typ, right_typ) {
-                    (PrimitiveType::Float, PrimitiveType::Int)
-                    | (PrimitiveType::Int, PrimitiveType::Float) => true,
+                    (
+                        PrimitiveType::Plain(PrimitiveBaseType::Float),
+                        PrimitiveType::Plain(PrimitiveBaseType::Int),
+                    )
+                    | (
+                        PrimitiveType::Plain(PrimitiveBaseType::Int),
+                        PrimitiveType::Plain(PrimitiveBaseType::Float),
+                    ) => true,
                     _ => left_typ == right_typ,
                 }
             }

--- a/crates/builder/src/typechecker/selection.rs
+++ b/crates/builder/src/typechecker/selection.rs
@@ -10,7 +10,10 @@
 use std::collections::HashMap;
 
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
-use core_model::{mapped_arena::MappedArena, primitive_type::PrimitiveType};
+use core_model::{
+    mapped_arena::MappedArena,
+    primitive_type::{PrimitiveBaseType, PrimitiveType},
+};
 use core_model_builder::{
     ast::ast_types::{AstExpr, AstModel, FieldSelectionElement},
     typechecker::{annotation::AnnotationSpec, Typed},
@@ -213,7 +216,9 @@ impl TypecheckFunctionCallFrom<FieldSelectionElement<Untyped>> for FieldSelectio
                         let param_type = params[0].typ();
                         if let Some(elem_type) = elem_type {
                             if identical_match(elem_type, &param_type) {
-                                *typ = Type::Primitive(PrimitiveType::Boolean);
+                                *typ = Type::Primitive(PrimitiveType::Plain(
+                                    PrimitiveBaseType::Boolean,
+                                ));
                             } else {
                                 *typ = Type::Error;
                                 errors.push(Diagnostic {

--- a/crates/builder/src/typechecker/snapshots/simple.snap
+++ b/crates/builder/src/typechecker/snapshots/simple.snap
@@ -5,31 +5,44 @@ expression: built
 types:
   values:
     - - ~
-      - Primitive: Boolean
+      - Primitive:
+          Plain: Boolean
     - - ~
-      - Primitive: Int
+      - Primitive:
+          Plain: Int
     - - ~
-      - Primitive: Float
+      - Primitive:
+          Plain: Float
     - - ~
-      - Primitive: Decimal
+      - Primitive:
+          Plain: Decimal
     - - ~
-      - Primitive: String
+      - Primitive:
+          Plain: String
     - - ~
-      - Primitive: LocalTime
+      - Primitive:
+          Plain: LocalTime
     - - ~
-      - Primitive: LocalDateTime
+      - Primitive:
+          Plain: LocalDateTime
     - - ~
-      - Primitive: LocalDate
+      - Primitive:
+          Plain: LocalDate
     - - ~
-      - Primitive: Instant
+      - Primitive:
+          Plain: Instant
     - - ~
-      - Primitive: Json
+      - Primitive:
+          Plain: Json
     - - ~
-      - Primitive: Blob
+      - Primitive:
+          Plain: Blob
     - - ~
-      - Primitive: Uuid
+      - Primitive:
+          Plain: Uuid
     - - ~
-      - Primitive: Vector
+      - Primitive:
+          Plain: Vector
     - - ~
       - Injected: Exograph
     - - ~
@@ -80,7 +93,8 @@ types:
                                                     generation: ~
                                           - StringLiteral:
                                               - role_admin
-                                          - Primitive: Boolean
+                                          - Primitive:
+                                              Plain: Boolean
                                     - RelationalOp:
                                         Eq:
                                           - FieldSelection:
@@ -102,8 +116,10 @@ types:
                                                     generation: ~
                                           - StringLiteral:
                                               - role_superuser
-                                          - Primitive: Boolean
-                                    - Primitive: Boolean
+                                          - Primitive:
+                                              Plain: Boolean
+                                    - Primitive:
+                                        Plain: Boolean
                               - FieldSelection:
                                   Select:
                                     - Select:
@@ -128,7 +144,8 @@ types:
                                     - Reference:
                                         index: 0
                                         generation: ~
-                              - Primitive: Boolean
+                              - Primitive:
+                                  Plain: Boolean
                   column:
                     name: column
                     params:
@@ -292,7 +309,8 @@ modules:
                                                       generation: ~
                                             - StringLiteral:
                                                 - role_admin
-                                            - Primitive: Boolean
+                                            - Primitive:
+                                                Plain: Boolean
                                       - RelationalOp:
                                           Eq:
                                             - FieldSelection:
@@ -314,8 +332,10 @@ modules:
                                                       generation: ~
                                             - StringLiteral:
                                                 - role_superuser
-                                            - Primitive: Boolean
-                                      - Primitive: Boolean
+                                            - Primitive:
+                                                Plain: Boolean
+                                      - Primitive:
+                                          Plain: Boolean
                                 - FieldSelection:
                                     Select:
                                       - Select:
@@ -340,7 +360,8 @@ modules:
                                       - Reference:
                                           index: 0
                                           generation: ~
-                                - Primitive: Boolean
+                                - Primitive:
+                                    Plain: Boolean
                     column:
                       name: column
                       params:

--- a/crates/builder/src/typechecker/snapshots/with_array_in_operator.snap
+++ b/crates/builder/src/typechecker/snapshots/with_array_in_operator.snap
@@ -5,31 +5,44 @@ expression: built
 types:
   values:
     - - ~
-      - Primitive: Boolean
+      - Primitive:
+          Plain: Boolean
     - - ~
-      - Primitive: Int
+      - Primitive:
+          Plain: Int
     - - ~
-      - Primitive: Float
+      - Primitive:
+          Plain: Float
     - - ~
-      - Primitive: Decimal
+      - Primitive:
+          Plain: Decimal
     - - ~
-      - Primitive: String
+      - Primitive:
+          Plain: String
     - - ~
-      - Primitive: LocalTime
+      - Primitive:
+          Plain: LocalTime
     - - ~
-      - Primitive: LocalDateTime
+      - Primitive:
+          Plain: LocalDateTime
     - - ~
-      - Primitive: LocalDate
+      - Primitive:
+          Plain: LocalDate
     - - ~
-      - Primitive: Instant
+      - Primitive:
+          Plain: Instant
     - - ~
-      - Primitive: Json
+      - Primitive:
+          Plain: Json
     - - ~
-      - Primitive: Blob
+      - Primitive:
+          Plain: Blob
     - - ~
-      - Primitive: Uuid
+      - Primitive:
+          Plain: Uuid
     - - ~
-      - Primitive: Vector
+      - Primitive:
+          Plain: Vector
     - - ~
       - Injected: Exograph
     - - ~
@@ -104,7 +117,8 @@ types:
                                         Reference:
                                           index: 4
                                           generation: ~
-                              - Primitive: Boolean
+                              - Primitive:
+                                  Plain: Boolean
               default_value: ~
               doc_comments: ~
           fragment_references: []
@@ -228,7 +242,8 @@ modules:
                                           Reference:
                                             index: 4
                                             generation: ~
-                                - Primitive: Boolean
+                                - Primitive:
+                                    Plain: Boolean
                 default_value: ~
                 doc_comments: ~
             fragment_references: []

--- a/crates/builder/src/typechecker/snapshots/with_auth_context_use_in_field_annotation.snap
+++ b/crates/builder/src/typechecker/snapshots/with_auth_context_use_in_field_annotation.snap
@@ -5,31 +5,44 @@ expression: built
 types:
   values:
     - - ~
-      - Primitive: Boolean
+      - Primitive:
+          Plain: Boolean
     - - ~
-      - Primitive: Int
+      - Primitive:
+          Plain: Int
     - - ~
-      - Primitive: Float
+      - Primitive:
+          Plain: Float
     - - ~
-      - Primitive: Decimal
+      - Primitive:
+          Plain: Decimal
     - - ~
-      - Primitive: String
+      - Primitive:
+          Plain: String
     - - ~
-      - Primitive: LocalTime
+      - Primitive:
+          Plain: LocalTime
     - - ~
-      - Primitive: LocalDateTime
+      - Primitive:
+          Plain: LocalDateTime
     - - ~
-      - Primitive: LocalDate
+      - Primitive:
+          Plain: LocalDate
     - - ~
-      - Primitive: Instant
+      - Primitive:
+          Plain: Instant
     - - ~
-      - Primitive: Json
+      - Primitive:
+          Plain: Json
     - - ~
-      - Primitive: Blob
+      - Primitive:
+          Plain: Blob
     - - ~
-      - Primitive: Uuid
+      - Primitive:
+          Plain: Uuid
     - - ~
-      - Primitive: Vector
+      - Primitive:
+          Plain: Vector
     - - ~
       - Injected: Exograph
     - - ~
@@ -112,7 +125,8 @@ types:
                                               generation: ~
                                     - StringLiteral:
                                         - ROLE_ADMIN
-                                    - Primitive: Boolean
+                                    - Primitive:
+                                        Plain: Boolean
                               - FieldSelection:
                                   Select:
                                     - Single:
@@ -130,7 +144,8 @@ types:
                                     - Reference:
                                         index: 0
                                         generation: ~
-                              - Primitive: Boolean
+                              - Primitive:
+                                  Plain: Boolean
               default_value: ~
               doc_comments: ~
           fragment_references: []
@@ -266,7 +281,8 @@ modules:
                                                 generation: ~
                                       - StringLiteral:
                                           - ROLE_ADMIN
-                                      - Primitive: Boolean
+                                      - Primitive:
+                                          Plain: Boolean
                                 - FieldSelection:
                                     Select:
                                       - Single:
@@ -284,7 +300,8 @@ modules:
                                       - Reference:
                                           index: 0
                                           generation: ~
-                                - Primitive: Boolean
+                                - Primitive:
+                                    Plain: Boolean
                 default_value: ~
                 doc_comments: ~
             fragment_references: []

--- a/crates/builder/src/typechecker/snapshots/with_auth_context_use_in_type_annotation.snap
+++ b/crates/builder/src/typechecker/snapshots/with_auth_context_use_in_type_annotation.snap
@@ -5,31 +5,44 @@ expression: built
 types:
   values:
     - - ~
-      - Primitive: Boolean
+      - Primitive:
+          Plain: Boolean
     - - ~
-      - Primitive: Int
+      - Primitive:
+          Plain: Int
     - - ~
-      - Primitive: Float
+      - Primitive:
+          Plain: Float
     - - ~
-      - Primitive: Decimal
+      - Primitive:
+          Plain: Decimal
     - - ~
-      - Primitive: String
+      - Primitive:
+          Plain: String
     - - ~
-      - Primitive: LocalTime
+      - Primitive:
+          Plain: LocalTime
     - - ~
-      - Primitive: LocalDateTime
+      - Primitive:
+          Plain: LocalDateTime
     - - ~
-      - Primitive: LocalDate
+      - Primitive:
+          Plain: LocalDate
     - - ~
-      - Primitive: Instant
+      - Primitive:
+          Plain: Instant
     - - ~
-      - Primitive: Json
+      - Primitive:
+          Plain: Json
     - - ~
-      - Primitive: Blob
+      - Primitive:
+          Plain: Blob
     - - ~
-      - Primitive: Uuid
+      - Primitive:
+          Plain: Uuid
     - - ~
-      - Primitive: Vector
+      - Primitive:
+          Plain: Vector
     - - ~
       - Injected: Exograph
     - - ~
@@ -117,7 +130,8 @@ types:
                                           generation: ~
                                 - StringLiteral:
                                     - ROLE_ADMIN
-                                - Primitive: Boolean
+                                - Primitive:
+                                    Plain: Boolean
                           - FieldSelection:
                               Select:
                                 - Single:
@@ -135,7 +149,8 @@ types:
                                 - Reference:
                                     index: 0
                                     generation: ~
-                          - Primitive: Boolean
+                          - Primitive:
+                              Plain: Boolean
           doc_comments: ~
     - ~
     - ~
@@ -271,7 +286,8 @@ modules:
                                             generation: ~
                                   - StringLiteral:
                                       - ROLE_ADMIN
-                                  - Primitive: Boolean
+                                  - Primitive:
+                                      Plain: Boolean
                             - FieldSelection:
                                 Select:
                                   - Single:
@@ -289,7 +305,8 @@ modules:
                                   - Reference:
                                       index: 0
                                       generation: ~
-                            - Primitive: Boolean
+                            - Primitive:
+                                Plain: Boolean
             doc_comments: ~
         enums: []
         methods: []

--- a/crates/builder/src/typechecker/snapshots/with_function_calls.snap
+++ b/crates/builder/src/typechecker/snapshots/with_function_calls.snap
@@ -5,31 +5,44 @@ expression: built
 types:
   values:
     - - ~
-      - Primitive: Boolean
+      - Primitive:
+          Plain: Boolean
     - - ~
-      - Primitive: Int
+      - Primitive:
+          Plain: Int
     - - ~
-      - Primitive: Float
+      - Primitive:
+          Plain: Float
     - - ~
-      - Primitive: Decimal
+      - Primitive:
+          Plain: Decimal
     - - ~
-      - Primitive: String
+      - Primitive:
+          Plain: String
     - - ~
-      - Primitive: LocalTime
+      - Primitive:
+          Plain: LocalTime
     - - ~
-      - Primitive: LocalDateTime
+      - Primitive:
+          Plain: LocalDateTime
     - - ~
-      - Primitive: LocalDate
+      - Primitive:
+          Plain: LocalDate
     - - ~
-      - Primitive: Instant
+      - Primitive:
+          Plain: Instant
     - - ~
-      - Primitive: Json
+      - Primitive:
+          Plain: Json
     - - ~
-      - Primitive: Blob
+      - Primitive:
+          Plain: Blob
     - - ~
-      - Primitive: Uuid
+      - Primitive:
+          Plain: Uuid
     - - ~
-      - Primitive: Vector
+      - Primitive:
+          Plain: Vector
     - - ~
       - Injected: Exograph
     - - ~
@@ -182,7 +195,8 @@ types:
                                                       generation: ~
                                             - StringLiteral:
                                                 - admin
-                                            - Primitive: Boolean
+                                            - Primitive:
+                                                Plain: Boolean
                                       - LogicalOp:
                                           And:
                                             - RelationalOp:
@@ -221,7 +235,8 @@ types:
                                                         - Reference:
                                                             index: 4
                                                             generation: ~
-                                                  - Primitive: Boolean
+                                                  - Primitive:
+                                                      Plain: Boolean
                                             - FieldSelection:
                                                 Select:
                                                   - Single:
@@ -239,11 +254,15 @@ types:
                                                   - Reference:
                                                       index: 0
                                                       generation: ~
-                                            - Primitive: Boolean
-                                      - Primitive: Boolean
+                                            - Primitive:
+                                                Plain: Boolean
+                                      - Primitive:
+                                          Plain: Boolean
                                 typ:
-                                  Primitive: Boolean
-                            - Primitive: Boolean
+                                  Primitive:
+                                    Plain: Boolean
+                            - Primitive:
+                                Plain: Boolean
                       query:
                         FieldSelection:
                           Select:
@@ -293,7 +312,8 @@ types:
                                                       generation: ~
                                             - StringLiteral:
                                                 - admin
-                                            - Primitive: Boolean
+                                            - Primitive:
+                                                Plain: Boolean
                                       - LogicalOp:
                                           And:
                                             - RelationalOp:
@@ -332,7 +352,8 @@ types:
                                                         - Reference:
                                                             index: 4
                                                             generation: ~
-                                                  - Primitive: Boolean
+                                                  - Primitive:
+                                                      Plain: Boolean
                                             - FieldSelection:
                                                 Select:
                                                   - Single:
@@ -350,11 +371,15 @@ types:
                                                   - Reference:
                                                       index: 0
                                                       generation: ~
-                                            - Primitive: Boolean
-                                      - Primitive: Boolean
+                                            - Primitive:
+                                                Plain: Boolean
+                                      - Primitive:
+                                          Plain: Boolean
                                 typ:
-                                  Primitive: Boolean
-                            - Primitive: Boolean
+                                  Primitive:
+                                    Plain: Boolean
+                            - Primitive:
+                                Plain: Boolean
           doc_comments: ~
     - - ~
       - Composite:
@@ -611,7 +636,8 @@ modules:
                                                         generation: ~
                                               - StringLiteral:
                                                   - admin
-                                              - Primitive: Boolean
+                                              - Primitive:
+                                                  Plain: Boolean
                                         - LogicalOp:
                                             And:
                                               - RelationalOp:
@@ -650,7 +676,8 @@ modules:
                                                           - Reference:
                                                               index: 4
                                                               generation: ~
-                                                    - Primitive: Boolean
+                                                    - Primitive:
+                                                        Plain: Boolean
                                               - FieldSelection:
                                                   Select:
                                                     - Single:
@@ -668,11 +695,15 @@ modules:
                                                     - Reference:
                                                         index: 0
                                                         generation: ~
-                                              - Primitive: Boolean
-                                        - Primitive: Boolean
+                                              - Primitive:
+                                                  Plain: Boolean
+                                        - Primitive:
+                                            Plain: Boolean
                                   typ:
-                                    Primitive: Boolean
-                              - Primitive: Boolean
+                                    Primitive:
+                                      Plain: Boolean
+                              - Primitive:
+                                  Plain: Boolean
                         query:
                           FieldSelection:
                             Select:
@@ -722,7 +753,8 @@ modules:
                                                         generation: ~
                                               - StringLiteral:
                                                   - admin
-                                              - Primitive: Boolean
+                                              - Primitive:
+                                                  Plain: Boolean
                                         - LogicalOp:
                                             And:
                                               - RelationalOp:
@@ -761,7 +793,8 @@ modules:
                                                           - Reference:
                                                               index: 4
                                                               generation: ~
-                                                    - Primitive: Boolean
+                                                    - Primitive:
+                                                        Plain: Boolean
                                               - FieldSelection:
                                                   Select:
                                                     - Single:
@@ -779,11 +812,15 @@ modules:
                                                     - Reference:
                                                         index: 0
                                                         generation: ~
-                                              - Primitive: Boolean
-                                        - Primitive: Boolean
+                                              - Primitive:
+                                                  Plain: Boolean
+                                        - Primitive:
+                                            Plain: Boolean
                                   typ:
-                                    Primitive: Boolean
-                              - Primitive: Boolean
+                                    Primitive:
+                                      Plain: Boolean
+                              - Primitive:
+                                  Plain: Boolean
             doc_comments: ~
           - name: DocumentUser
             kind: Type

--- a/crates/core-subsystem/core-model-builder/src/builder/system_builder.rs
+++ b/crates/core-subsystem/core-model-builder/src/builder/system_builder.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use core_model::function_defn::FunctionDefinition;
-use core_model::primitive_type::PrimitiveType;
+use core_model::primitive_type::{PrimitiveBaseType, PrimitiveType};
 use core_model::types::FieldType;
 use core_model::{context_type::ContextType, mapped_arena::MappedArena};
 
@@ -48,7 +48,7 @@ pub fn build(
 
     vec![FunctionDefinition {
         name: "contains".to_string(),
-        return_type: FieldType::Plain(PrimitiveType::Boolean),
+        return_type: FieldType::Plain(PrimitiveType::Plain(PrimitiveBaseType::Boolean)),
     }]
     .into_iter()
     .for_each(|defn| {

--- a/crates/core-subsystem/core-model-builder/src/typechecker/expression.rs
+++ b/crates/core-subsystem/core-model-builder/src/typechecker/expression.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use core_model::primitive_type::PrimitiveType;
+use core_model::primitive_type::{PrimitiveBaseType, PrimitiveType};
 
 use crate::ast::ast_types::AstExpr;
 
@@ -19,18 +19,22 @@ impl AstExpr<Typed> {
             AstExpr::FieldSelection(select) => select.typ().clone(),
             AstExpr::LogicalOp(logic) => logic.typ().clone(),
             AstExpr::RelationalOp(relation) => relation.typ().clone(),
-            AstExpr::StringLiteral(_, _) => Type::Primitive(PrimitiveType::String),
-            AstExpr::BooleanLiteral(_, _) => Type::Primitive(PrimitiveType::Boolean),
+            AstExpr::StringLiteral(_, _) => {
+                Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::String))
+            }
+            AstExpr::BooleanLiteral(_, _) => {
+                Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Boolean))
+            }
             AstExpr::NumberLiteral(value, _) => {
                 if value.parse::<i64>().is_ok() {
-                    Type::Primitive(PrimitiveType::Int)
+                    Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Int))
                 } else {
-                    Type::Primitive(PrimitiveType::Float)
+                    Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Float))
                 }
             }
-            AstExpr::StringList(_, _) => {
-                Type::Array(Box::new(Type::Primitive(PrimitiveType::String)))
-            }
+            AstExpr::StringList(_, _) => Type::Array(Box::new(Type::Primitive(
+                PrimitiveType::Plain(PrimitiveBaseType::String),
+            ))),
             AstExpr::NullLiteral(_) => Type::Null,
         }
     }

--- a/crates/core-subsystem/core-model/src/primitive_type.rs
+++ b/crates/core-subsystem/core-model/src/primitive_type.rs
@@ -15,6 +15,12 @@ use crate::type_normalization::{BaseType, Type};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum PrimitiveType {
+    Plain(PrimitiveBaseType),
+    Array(Box<PrimitiveType>),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum PrimitiveBaseType {
     Int,
     Float,
     Decimal,
@@ -28,28 +34,33 @@ pub enum PrimitiveType {
     Blob,
     Uuid,
     Vector,
-    // TODO: This should not be a primitive type, but a type with modifier or some variation of it
-    /// An array version of a primitive type.
-    Array(Box<PrimitiveType>),
 }
 
 impl PrimitiveType {
     pub fn name(&self) -> String {
         match &self {
-            PrimitiveType::Int => "Int".to_owned(),
-            PrimitiveType::Float => "Float".to_owned(),
-            PrimitiveType::Decimal => "Decimal".to_owned(),
-            PrimitiveType::String => "String".to_owned(),
-            PrimitiveType::Boolean => "Boolean".to_owned(),
-            PrimitiveType::LocalDate => "LocalDate".to_owned(),
-            PrimitiveType::LocalTime => "LocalTime".to_owned(),
-            PrimitiveType::LocalDateTime => "LocalDateTime".to_owned(),
-            PrimitiveType::Instant => "Instant".to_owned(),
-            PrimitiveType::Json => "Json".to_owned(),
-            PrimitiveType::Blob => "Blob".to_owned(),
-            PrimitiveType::Uuid => "Uuid".to_owned(),
-            PrimitiveType::Vector => "Vector".to_owned(),
+            PrimitiveType::Plain(pt) => pt.name(),
             PrimitiveType::Array(pt) => format!("[{}]", pt.name()),
+        }
+    }
+}
+
+impl PrimitiveBaseType {
+    pub fn name(&self) -> String {
+        match &self {
+            PrimitiveBaseType::Int => "Int".to_owned(),
+            PrimitiveBaseType::Float => "Float".to_owned(),
+            PrimitiveBaseType::Decimal => "Decimal".to_owned(),
+            PrimitiveBaseType::String => "String".to_owned(),
+            PrimitiveBaseType::Boolean => "Boolean".to_owned(),
+            PrimitiveBaseType::LocalDate => "LocalDate".to_owned(),
+            PrimitiveBaseType::LocalTime => "LocalTime".to_owned(),
+            PrimitiveBaseType::LocalDateTime => "LocalDateTime".to_owned(),
+            PrimitiveBaseType::Instant => "Instant".to_owned(),
+            PrimitiveBaseType::Json => "Json".to_owned(),
+            PrimitiveBaseType::Blob => "Blob".to_owned(),
+            PrimitiveBaseType::Uuid => "Uuid".to_owned(),
+            PrimitiveBaseType::Vector => "Vector".to_owned(),
         }
     }
 

--- a/crates/core-subsystem/core-resolver/src/introspection/definition/schema.rs
+++ b/crates/core-subsystem/core-resolver/src/introspection/definition/schema.rs
@@ -69,7 +69,7 @@ impl Schema {
                                 profile.query_matches(
                                     field_return_type,
                                     &field_defn.name.node,
-                                    core_model::primitive_type::PrimitiveType::is_primitive,
+                                    core_model::primitive_type::PrimitiveBaseType::is_primitive,
                                 )
                             })
                             .collect::<Vec<FieldDefinition>>(),
@@ -95,7 +95,7 @@ impl Schema {
                                 profile.mutation_matches(
                                     field_return_type,
                                     &field_defn.name.node,
-                                    core_model::primitive_type::PrimitiveType::is_primitive,
+                                    core_model::primitive_type::PrimitiveBaseType::is_primitive,
                                 )
                             })
                             .collect::<Vec<FieldDefinition>>(),

--- a/crates/postgres-subsystem/postgres-core-builder/src/access/database_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/access/database_builder.rs
@@ -17,7 +17,7 @@ use core_model::{
     },
     context_type::{ContextFieldType, ContextSelection},
     mapped_arena::MappedArena,
-    primitive_type::PrimitiveType,
+    primitive_type::{PrimitiveBaseType, PrimitiveType},
     types::FieldType,
 };
 use core_model_builder::{
@@ -113,7 +113,7 @@ pub fn compute_predicate_expression(
                     }
                 }
                 DatabasePathSelection::Context(context_selection, field_type) => {
-                    if field_type.innermost() == &PrimitiveType::Boolean {
+                    if field_type.innermost() == &PrimitiveType::Plain(PrimitiveBaseType::Boolean) {
                         // Treat boolean context expressions in the same way as an "eq" relational expression
                         // For example, treat `AuthContext.superUser` the same way as `AuthContext.superUser == true`
                         Ok(AccessPredicateExpression::RelationalOp(

--- a/crates/postgres-subsystem/postgres-core-builder/src/access/precheck_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/access/precheck_builder.rs
@@ -17,7 +17,7 @@ use core_model::{
     },
     context_type::{ContextFieldType, ContextSelection},
     mapped_arena::MappedArena,
-    primitive_type::PrimitiveType,
+    primitive_type::{PrimitiveBaseType, PrimitiveType},
     types::FieldType,
 };
 use core_model_builder::{
@@ -102,7 +102,7 @@ pub fn compute_precheck_predicate_expression(
                     }
                 }
                 PrecheckPathSelection::Context(context_selection, field_type) => {
-                    if field_type.innermost() == &PrimitiveType::Boolean {
+                    if field_type.innermost() == &PrimitiveType::Plain(PrimitiveBaseType::Boolean) {
                         // Treat boolean context expressions in the same way as an "eq" relational expression
                         // For example, treat `AuthContext.superUser` the same way as `AuthContext.superUser == true`
                         Ok(AccessPredicateExpression::RelationalOp(

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/column_names_for_non_standard_relational_field_names.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/column_names_for_non_standard_relational_field_names.snap
@@ -4,31 +4,44 @@ expression: resolved
 ---
 values:
   - - ~
-    - Primitive: Boolean
+    - Primitive:
+        Plain: Boolean
   - - ~
-    - Primitive: Int
+    - Primitive:
+        Plain: Int
   - - ~
-    - Primitive: Float
+    - Primitive:
+        Plain: Float
   - - ~
-    - Primitive: Decimal
+    - Primitive:
+        Plain: Decimal
   - - ~
-    - Primitive: String
+    - Primitive:
+        Plain: String
   - - ~
-    - Primitive: LocalTime
+    - Primitive:
+        Plain: LocalTime
   - - ~
-    - Primitive: LocalDateTime
+    - Primitive:
+        Plain: LocalDateTime
   - - ~
-    - Primitive: LocalDate
+    - Primitive:
+        Plain: LocalDate
   - - ~
-    - Primitive: Instant
+    - Primitive:
+        Plain: Instant
   - - ~
-    - Primitive: Json
+    - Primitive:
+        Plain: Json
   - - ~
-    - Primitive: Blob
+    - Primitive:
+        Plain: Blob
   - - ~
-    - Primitive: Uuid
+    - Primitive:
+        Plain: Uuid
   - - ~
-    - Primitive: Vector
+    - Primitive:
+        Plain: Vector
   - - ~
     - Composite:
         name: Concert

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/field_name_variations.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/field_name_variations.snap
@@ -4,31 +4,44 @@ expression: resolved
 ---
 values:
   - - ~
-    - Primitive: Boolean
+    - Primitive:
+        Plain: Boolean
   - - ~
-    - Primitive: Int
+    - Primitive:
+        Plain: Int
   - - ~
-    - Primitive: Float
+    - Primitive:
+        Plain: Float
   - - ~
-    - Primitive: Decimal
+    - Primitive:
+        Plain: Decimal
   - - ~
-    - Primitive: String
+    - Primitive:
+        Plain: String
   - - ~
-    - Primitive: LocalTime
+    - Primitive:
+        Plain: LocalTime
   - - ~
-    - Primitive: LocalDateTime
+    - Primitive:
+        Plain: LocalDateTime
   - - ~
-    - Primitive: LocalDate
+    - Primitive:
+        Plain: LocalDate
   - - ~
-    - Primitive: Instant
+    - Primitive:
+        Plain: Instant
   - - ~
-    - Primitive: Json
+    - Primitive:
+        Plain: Json
   - - ~
-    - Primitive: Blob
+    - Primitive:
+        Plain: Blob
   - - ~
-    - Primitive: Uuid
+    - Primitive:
+        Plain: Uuid
   - - ~
-    - Primitive: Vector
+    - Primitive:
+        Plain: Vector
   - - ~
     - Composite:
         name: Entity

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/non_public_schema.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/non_public_schema.snap
@@ -4,31 +4,44 @@ expression: resolved
 ---
 values:
   - - ~
-    - Primitive: Boolean
+    - Primitive:
+        Plain: Boolean
   - - ~
-    - Primitive: Int
+    - Primitive:
+        Plain: Int
   - - ~
-    - Primitive: Float
+    - Primitive:
+        Plain: Float
   - - ~
-    - Primitive: Decimal
+    - Primitive:
+        Plain: Decimal
   - - ~
-    - Primitive: String
+    - Primitive:
+        Plain: String
   - - ~
-    - Primitive: LocalTime
+    - Primitive:
+        Plain: LocalTime
   - - ~
-    - Primitive: LocalDateTime
+    - Primitive:
+        Plain: LocalDateTime
   - - ~
-    - Primitive: LocalDate
+    - Primitive:
+        Plain: LocalDate
   - - ~
-    - Primitive: Instant
+    - Primitive:
+        Plain: Instant
   - - ~
-    - Primitive: Json
+    - Primitive:
+        Plain: Json
   - - ~
-    - Primitive: Blob
+    - Primitive:
+        Plain: Blob
   - - ~
-    - Primitive: Uuid
+    - Primitive:
+        Plain: Uuid
   - - ~
-    - Primitive: Vector
+    - Primitive:
+        Plain: Vector
   - - ~
     - Composite:
         name: AuthSchemaTable

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_access.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_access.snap
@@ -4,31 +4,44 @@ expression: resolved
 ---
 values:
   - - ~
-    - Primitive: Boolean
+    - Primitive:
+        Plain: Boolean
   - - ~
-    - Primitive: Int
+    - Primitive:
+        Plain: Int
   - - ~
-    - Primitive: Float
+    - Primitive:
+        Plain: Float
   - - ~
-    - Primitive: Decimal
+    - Primitive:
+        Plain: Decimal
   - - ~
-    - Primitive: String
+    - Primitive:
+        Plain: String
   - - ~
-    - Primitive: LocalTime
+    - Primitive:
+        Plain: LocalTime
   - - ~
-    - Primitive: LocalDateTime
+    - Primitive:
+        Plain: LocalDateTime
   - - ~
-    - Primitive: LocalDate
+    - Primitive:
+        Plain: LocalDate
   - - ~
-    - Primitive: Instant
+    - Primitive:
+        Plain: Instant
   - - ~
-    - Primitive: Json
+    - Primitive:
+        Plain: Json
   - - ~
-    - Primitive: Blob
+    - Primitive:
+        Plain: Blob
   - - ~
-    - Primitive: Uuid
+    - Primitive:
+        Plain: Uuid
   - - ~
-    - Primitive: Vector
+    - Primitive:
+        Plain: Vector
   - - ~
     - Composite:
         name: Concert
@@ -142,7 +155,8 @@ values:
                                 generation: ~
                       - StringLiteral:
                           - ROLE_ADMIN
-                      - Primitive: Boolean
+                      - Primitive:
+                          Plain: Boolean
                 - FieldSelection:
                     Select:
                       - Single:
@@ -160,7 +174,8 @@ values:
                       - Reference:
                           index: 0
                           generation: ~
-                - Primitive: Boolean
+                - Primitive:
+                    Plain: Boolean
           query: ~
           mutation: ~
           creation: ~

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_access_default_values.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_access_default_values.snap
@@ -4,31 +4,44 @@ expression: resolved
 ---
 values:
   - - ~
-    - Primitive: Boolean
+    - Primitive:
+        Plain: Boolean
   - - ~
-    - Primitive: Int
+    - Primitive:
+        Plain: Int
   - - ~
-    - Primitive: Float
+    - Primitive:
+        Plain: Float
   - - ~
-    - Primitive: Decimal
+    - Primitive:
+        Plain: Decimal
   - - ~
-    - Primitive: String
+    - Primitive:
+        Plain: String
   - - ~
-    - Primitive: LocalTime
+    - Primitive:
+        Plain: LocalTime
   - - ~
-    - Primitive: LocalDateTime
+    - Primitive:
+        Plain: LocalDateTime
   - - ~
-    - Primitive: LocalDate
+    - Primitive:
+        Plain: LocalDate
   - - ~
-    - Primitive: Instant
+    - Primitive:
+        Plain: Instant
   - - ~
-    - Primitive: Json
+    - Primitive:
+        Plain: Json
   - - ~
-    - Primitive: Blob
+    - Primitive:
+        Plain: Blob
   - - ~
-    - Primitive: Uuid
+    - Primitive:
+        Plain: Uuid
   - - ~
-    - Primitive: Vector
+    - Primitive:
+        Plain: Vector
   - - ~
     - Composite:
         name: Concert
@@ -142,7 +155,8 @@ values:
                                 generation: ~
                       - StringLiteral:
                           - ROLE_ADMIN
-                      - Primitive: Boolean
+                      - Primitive:
+                          Plain: Boolean
                 - FieldSelection:
                     Select:
                       - Single:
@@ -160,7 +174,8 @@ values:
                       - Reference:
                           index: 0
                           generation: ~
-                - Primitive: Boolean
+                - Primitive:
+                    Plain: Boolean
           query: ~
           mutation: ~
           creation: ~

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_annotations.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_annotations.snap
@@ -4,31 +4,44 @@ expression: resolved
 ---
 values:
   - - ~
-    - Primitive: Boolean
+    - Primitive:
+        Plain: Boolean
   - - ~
-    - Primitive: Int
+    - Primitive:
+        Plain: Int
   - - ~
-    - Primitive: Float
+    - Primitive:
+        Plain: Float
   - - ~
-    - Primitive: Decimal
+    - Primitive:
+        Plain: Decimal
   - - ~
-    - Primitive: String
+    - Primitive:
+        Plain: String
   - - ~
-    - Primitive: LocalTime
+    - Primitive:
+        Plain: LocalTime
   - - ~
-    - Primitive: LocalDateTime
+    - Primitive:
+        Plain: LocalDateTime
   - - ~
-    - Primitive: LocalDate
+    - Primitive:
+        Plain: LocalDate
   - - ~
-    - Primitive: Instant
+    - Primitive:
+        Plain: Instant
   - - ~
-    - Primitive: Json
+    - Primitive:
+        Plain: Json
   - - ~
-    - Primitive: Blob
+    - Primitive:
+        Plain: Blob
   - - ~
-    - Primitive: Uuid
+    - Primitive:
+        Plain: Uuid
   - - ~
-    - Primitive: Vector
+    - Primitive:
+        Plain: Vector
   - - ~
     - Composite:
         name: Concert

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_camel_case_model_and_fields.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_camel_case_model_and_fields.snap
@@ -4,31 +4,44 @@ expression: resolved
 ---
 values:
   - - ~
-    - Primitive: Boolean
+    - Primitive:
+        Plain: Boolean
   - - ~
-    - Primitive: Int
+    - Primitive:
+        Plain: Int
   - - ~
-    - Primitive: Float
+    - Primitive:
+        Plain: Float
   - - ~
-    - Primitive: Decimal
+    - Primitive:
+        Plain: Decimal
   - - ~
-    - Primitive: String
+    - Primitive:
+        Plain: String
   - - ~
-    - Primitive: LocalTime
+    - Primitive:
+        Plain: LocalTime
   - - ~
-    - Primitive: LocalDateTime
+    - Primitive:
+        Plain: LocalDateTime
   - - ~
-    - Primitive: LocalDate
+    - Primitive:
+        Plain: LocalDate
   - - ~
-    - Primitive: Instant
+    - Primitive:
+        Plain: Instant
   - - ~
-    - Primitive: Json
+    - Primitive:
+        Plain: Json
   - - ~
-    - Primitive: Blob
+    - Primitive:
+        Plain: Blob
   - - ~
-    - Primitive: Uuid
+    - Primitive:
+        Plain: Uuid
   - - ~
-    - Primitive: Vector
+    - Primitive:
+        Plain: Vector
   - - ~
     - Composite:
         name: ConcertInfo

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_defaults.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_defaults.snap
@@ -4,31 +4,44 @@ expression: resolved
 ---
 values:
   - - ~
-    - Primitive: Boolean
+    - Primitive:
+        Plain: Boolean
   - - ~
-    - Primitive: Int
+    - Primitive:
+        Plain: Int
   - - ~
-    - Primitive: Float
+    - Primitive:
+        Plain: Float
   - - ~
-    - Primitive: Decimal
+    - Primitive:
+        Plain: Decimal
   - - ~
-    - Primitive: String
+    - Primitive:
+        Plain: String
   - - ~
-    - Primitive: LocalTime
+    - Primitive:
+        Plain: LocalTime
   - - ~
-    - Primitive: LocalDateTime
+    - Primitive:
+        Plain: LocalDateTime
   - - ~
-    - Primitive: LocalDate
+    - Primitive:
+        Plain: LocalDate
   - - ~
-    - Primitive: Instant
+    - Primitive:
+        Plain: Instant
   - - ~
-    - Primitive: Json
+    - Primitive:
+        Plain: Json
   - - ~
-    - Primitive: Blob
+    - Primitive:
+        Plain: Blob
   - - ~
-    - Primitive: Uuid
+    - Primitive:
+        Plain: Uuid
   - - ~
-    - Primitive: Vector
+    - Primitive:
+        Plain: Vector
   - - ~
     - Composite:
         name: Concert

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_multiple_matching_field_with_column_annotation.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_multiple_matching_field_with_column_annotation.snap
@@ -4,31 +4,44 @@ expression: resolved
 ---
 values:
   - - ~
-    - Primitive: Boolean
+    - Primitive:
+        Plain: Boolean
   - - ~
-    - Primitive: Int
+    - Primitive:
+        Plain: Int
   - - ~
-    - Primitive: Float
+    - Primitive:
+        Plain: Float
   - - ~
-    - Primitive: Decimal
+    - Primitive:
+        Plain: Decimal
   - - ~
-    - Primitive: String
+    - Primitive:
+        Plain: String
   - - ~
-    - Primitive: LocalTime
+    - Primitive:
+        Plain: LocalTime
   - - ~
-    - Primitive: LocalDateTime
+    - Primitive:
+        Plain: LocalDateTime
   - - ~
-    - Primitive: LocalDate
+    - Primitive:
+        Plain: LocalDate
   - - ~
-    - Primitive: Instant
+    - Primitive:
+        Plain: Instant
   - - ~
-    - Primitive: Json
+    - Primitive:
+        Plain: Json
   - - ~
-    - Primitive: Blob
+    - Primitive:
+        Plain: Blob
   - - ~
-    - Primitive: Uuid
+    - Primitive:
+        Plain: Uuid
   - - ~
-    - Primitive: Vector
+    - Primitive:
+        Plain: Vector
   - - ~
     - Composite:
         name: Concert

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_optional_fields.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_optional_fields.snap
@@ -4,31 +4,44 @@ expression: resolved
 ---
 values:
   - - ~
-    - Primitive: Boolean
+    - Primitive:
+        Plain: Boolean
   - - ~
-    - Primitive: Int
+    - Primitive:
+        Plain: Int
   - - ~
-    - Primitive: Float
+    - Primitive:
+        Plain: Float
   - - ~
-    - Primitive: Decimal
+    - Primitive:
+        Plain: Decimal
   - - ~
-    - Primitive: String
+    - Primitive:
+        Plain: String
   - - ~
-    - Primitive: LocalTime
+    - Primitive:
+        Plain: LocalTime
   - - ~
-    - Primitive: LocalDateTime
+    - Primitive:
+        Plain: LocalDateTime
   - - ~
-    - Primitive: LocalDate
+    - Primitive:
+        Plain: LocalDate
   - - ~
-    - Primitive: Instant
+    - Primitive:
+        Plain: Instant
   - - ~
-    - Primitive: Json
+    - Primitive:
+        Plain: Json
   - - ~
-    - Primitive: Blob
+    - Primitive:
+        Plain: Blob
   - - ~
-    - Primitive: Uuid
+    - Primitive:
+        Plain: Uuid
   - - ~
-    - Primitive: Vector
+    - Primitive:
+        Plain: Vector
   - - ~
     - Composite:
         name: Concert

--- a/crates/postgres-subsystem/postgres-core-builder/src/type_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/type_builder.rs
@@ -18,6 +18,7 @@ use crate::resolved_type::{
 use common::value::val::ValNumber;
 use common::value::Val;
 use core_model::access::AccessPredicateExpression;
+use core_model::primitive_type::PrimitiveBaseType;
 use core_model::types::{Named, TypeValidationProvider};
 use postgres_core_model::access::{CreationAccessExpression, PrecheckAccessPrimitiveExpression};
 use postgres_core_model::types::{
@@ -102,7 +103,7 @@ fn create_shallow_type(
                     kind: PostgresPrimitiveTypeKind::Builtin,
                 },
             );
-            if matches!(pt, PrimitiveType::Vector) {
+            if matches!(pt, PrimitiveType::Plain(PrimitiveBaseType::Vector)) {
                 let vector_distance_type = VectorDistanceType::new("VectorDistance".to_string());
                 building
                     .vector_distance_types

--- a/crates/subsystem-util/subsystem-model-builder-util/src/builder/access_utils.rs
+++ b/crates/subsystem-util/subsystem-model-builder-util/src/builder/access_utils.rs
@@ -13,7 +13,7 @@ use core_model::{
         CommonAccessPrimitiveExpression,
     },
     context_type::{ContextFieldType, ContextSelection},
-    primitive_type::PrimitiveType,
+    primitive_type::{PrimitiveBaseType, PrimitiveType},
 };
 use core_model_builder::{
     ast::ast_types::{AstExpr, FieldSelection, LogicalOp, RelationalOp},
@@ -35,7 +35,7 @@ pub fn compute_predicate_expression(
     match expr {
         AstExpr::FieldSelection(selection) => match compute_selection(selection, resolved_env)? {
             PathSelection::Context(context_selection, field_type) => {
-                if field_type.innermost() == &PrimitiveType::Boolean {
+                if field_type.innermost() == &PrimitiveType::Plain(PrimitiveBaseType::Boolean) {
                     // Treat boolean context expressions in the same way as an "eq" relational expression
                     // For example, treat `AuthContext.superUser` the same way as `AuthContext.superUser == true`
                     Ok(AccessPredicateExpression::RelationalOp(


### PR DESCRIPTION
Following the earlier commit, this addresses another mismatch where the "plain" types (string, int, etc.) and their array versions were represented in the same enum.

This separates them so that we can generalize over the plain variants.