### PR TITLE
Remove the use of std::env::set_var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1237,6 +1237,7 @@ dependencies = [
  "core-plugin-shared",
  "ctrlc",
  "deno-builder",
+ "exo-env",
  "exo-sql",
  "futures",
  "heck 0.5.0",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -42,6 +42,7 @@ exo-sql = { path = "../../libs/exo-sql", features = [
   "pool",
   "interactive-migration",
 ] }
+exo-env = { path = "../../libs/exo-env" }
 builder = { path = "../builder" }
 testing = { path = "../testing" }
 common = { path = "../common" }

--- a/crates/cli/src/commands/command.rs
+++ b/crates/cli/src/commands/command.rs
@@ -230,7 +230,7 @@ pub(crate) fn mutation_access_value(matches: &ArgMatches) -> bool {
     get(matches, "mutation-access").unwrap_or(false)
 }
 
-pub(crate) fn setup_trusted_documents_enforcement(matches: &ArgMatches) {
+pub(crate) fn trusted_documents_enforcement_env(matches: &ArgMatches) -> Option<(String, String)> {
     let enforce_trusted_documents: bool = get::<String>(matches, "enforce-trusted-documents")
         .map(|value| value != "false")
         .unwrap_or(false);
@@ -242,6 +242,11 @@ pub(crate) fn setup_trusted_documents_enforcement(matches: &ArgMatches) {
                 .red()
                 .bold()
         );
-        std::env::set_var(_EXO_ENFORCE_TRUSTED_DOCUMENTS, "false");
+        Some((
+            _EXO_ENFORCE_TRUSTED_DOCUMENTS.to_string(),
+            "false".to_string(),
+        ))
+    } else {
+        None
     }
 }

--- a/crates/cli/src/commands/command.rs
+++ b/crates/cli/src/commands/command.rs
@@ -14,6 +14,7 @@ use async_trait::async_trait;
 use clap::{Arg, ArgMatches, Command};
 use colored::Colorize;
 use common::env_const::_EXO_ENFORCE_TRUSTED_DOCUMENTS;
+use exo_env::MapEnvironment;
 
 use super::{build::BuildError, update::report_update_needed};
 use crate::config::Config;
@@ -230,7 +231,10 @@ pub(crate) fn mutation_access_value(matches: &ArgMatches) -> bool {
     get(matches, "mutation-access").unwrap_or(false)
 }
 
-pub(crate) fn trusted_documents_enforcement_env(matches: &ArgMatches) -> Option<(String, String)> {
+pub(crate) fn setup_trusted_documents_enforcement(
+    matches: &ArgMatches,
+    env_vars: &mut MapEnvironment,
+) {
     let enforce_trusted_documents: bool = get::<String>(matches, "enforce-trusted-documents")
         .map(|value| value != "false")
         .unwrap_or(false);
@@ -242,11 +246,6 @@ pub(crate) fn trusted_documents_enforcement_env(matches: &ArgMatches) -> Option<
                 .red()
                 .bold()
         );
-        Some((
-            _EXO_ENFORCE_TRUSTED_DOCUMENTS.to_string(),
-            "false".to_string(),
-        ))
-    } else {
-        None
+        env_vars.set(_EXO_ENFORCE_TRUSTED_DOCUMENTS, "false");
     }
 }

--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -14,6 +14,7 @@ use colored::Colorize;
 use common::env_const::{
     EXO_CORS_DOMAINS, EXO_INTROSPECTION, EXO_INTROSPECTION_LIVE_UPDATE, _EXO_DEPLOYMENT_MODE,
 };
+use exo_env::{MapEnvironment, SystemEnvironment};
 use exo_sql::schema::migration::{Migration, VerificationErrors};
 use exo_sql::DatabaseClient;
 use futures::FutureExt;
@@ -26,9 +27,7 @@ use crate::commands::command::migration_scope_value;
 use crate::config::{Config, WatchStage};
 use crate::{
     commands::{
-        command::{
-            default_model_file, ensure_exo_project_dir, setup_trusted_documents_enforcement,
-        },
+        command::{default_model_file, ensure_exo_project_dir, trusted_documents_enforcement_env},
         schema::util,
         util::wait_for_enter,
     },
@@ -61,10 +60,10 @@ impl CommandDefinition for DevCommandDefinition {
         let root_path = PathBuf::from(".");
         ensure_exo_project_dir(&root_path)?;
 
-        let model: PathBuf = default_model_file();
+        let model_file: PathBuf = default_model_file();
         let port: Option<u32> = get(matches, "port");
 
-        setup_trusted_documents_enforcement(matches);
+        let trusted_document_env = trusted_documents_enforcement_env(matches);
 
         let ignore_migration_errors: bool =
             get(matches, "ignore-migration-errors").unwrap_or(false);
@@ -73,94 +72,108 @@ impl CommandDefinition for DevCommandDefinition {
             "{}",
             "Starting server in development mode...".purple().bold()
         );
-        // In the serve mode, which is meant for development, always enable introspection and use relaxed CORS
-        std::env::set_var(EXO_INTROSPECTION, "true");
-        std::env::set_var(EXO_INTROSPECTION_LIVE_UPDATE, "true");
-        std::env::set_var(_EXO_DEPLOYMENT_MODE, "dev");
 
-        std::env::set_var(EXO_CORS_DOMAINS, "*");
+        let migration_scope_str = migration_scope_value(matches);
 
-        let migration_scope = compute_migration_scope(migration_scope_value(matches));
+        // Create environment variables for the child server process
+        let mut env_vars = MapEnvironment::new();
+        env_vars.extend_from_env(&SystemEnvironment);
+        env_vars.set(EXO_INTROSPECTION, "true");
+        env_vars.set(EXO_INTROSPECTION_LIVE_UPDATE, "true");
+        env_vars.set(_EXO_DEPLOYMENT_MODE, "dev");
+        env_vars.set(EXO_CORS_DOMAINS, "*");
+
+        if let Some((ref key, ref value)) = trusted_document_env {
+            env_vars.set(key, value);
+        }
 
         const MIGRATE: &str = "Attempt migration";
         const CONTINUE: &str = "Continue with old schema";
         const PAUSE: &str = "Pause for manual repair";
         const EXIT: &str = "Exit";
 
-        watcher::start_watcher(&root_path, port, config, Some(&WatchStage::Dev), || async {
-            println!("{}", "\nVerifying new model...".blue().bold());
-            let db_client = util::open_database(None).await?;
+        watcher::start_watcher(&root_path, port, config, Some(&WatchStage::Dev), move || {
+            let model_file = model_file.clone();
+            let migration_scope_str = migration_scope_str.clone();
+            let env_vars = env_vars.clone();
+            async move {
+                let migration_scope = compute_migration_scope(migration_scope_str);
+                println!("{}", "\nVerifying new model...".blue().bold());
 
-            loop {
-                // Pass true as use_ir to use the IR model, since we just built the model in the watcher
-                let database = util::extract_postgres_database(&model, None, true).await?;
-                let mut db_client = db_client.get_client().await?;
-                let verification_result = Migration::verify(&db_client, &database, &migration_scope).await;
+                let db_client = util::open_database(None).await?;
 
-                match verification_result {
-                    Err(e @ VerificationErrors::ModelNotCompatible(_)) => {
-                        let migrations = Migration::from_db_and_model(&db_client, &database, &migration_scope).await?;
+                loop {
+                    // Pass true as use_ir to use the IR model, since we just built the model in the watcher
+                    let database = util::extract_postgres_database(&model_file, None, true).await?;
+                    let mut db_client = db_client.get_client().await?;
+                    let verification_result = Migration::verify(&db_client, &database, &migration_scope).await;
 
-                        // If migrations are safe to apply, let's go ahead with those
-                        if !migrations.has_destructive_changes() {
-                            if apply_migration(&mut db_client, &migrations, ignore_migration_errors).await? {
-                                break Ok(());
-                            } else {
-                                // Migration failed, perhaps due to adding a non-nullable column and table already had rows
-                                continue;
-                            }
-                        }
+                    match verification_result {
+                        Err(e @ VerificationErrors::ModelNotCompatible(_)) => {
+                            let migrations = Migration::from_db_and_model(&db_client, &database, &migration_scope).await?;
 
-                        println!("{}", "The schema of the current database is not compatible with the current model for the following reasons:".red().bold());
-                        println!("{}", e.to_string().red().bold());
-
-                        let options = vec![MIGRATE, CONTINUE, PAUSE, EXIT];
-                        let ans = inquire::Select::new("Choose an option:", options).prompt()?;
-
-                        match ans {
-                            MIGRATE => {
-                                println!("{}", "Attempting migration...".blue().bold());
-
-                                // We will reach here only if the migration has some destructive changes (we auto-apply safe migrations; see above)
-                                let allow_destructive_changes =
-                                    inquire::Confirm::new("This migration contains destructive changes. Do you still want to proceed?")
-                                    .with_default(false)
-                                    .prompt()?;
-
-                                if !allow_destructive_changes {
-                                    println!("{}", "Aborting migration...".red().bold());
-                                    continue;
-                                }
-
+                            // If migrations are safe to apply, let's go ahead with those
+                            if !migrations.has_destructive_changes() {
                                 if apply_migration(&mut db_client, &migrations, ignore_migration_errors).await? {
-                                    break Ok(());
+                                    break Ok(env_vars);
                                 } else {
+                                    // Migration failed, perhaps due to adding a non-nullable column and table already had rows
                                     continue;
                                 }
                             }
-                            CONTINUE => {
-                                println!("{}", "Continuing...".green().bold());
-                                break Ok(());
-                            }
-                            PAUSE => {
-                                wait_for_enter(&"Paused. Press enter to re-verify.".blue().bold())?;
-                            }
-                            EXIT => {
-                                println!("Exiting...");
-                                let _ = crate::SIGINT.0.send(());
-                                break Ok(());
 
+                            println!("{}", "The schema of the current database is not compatible with the current model for the following reasons:".red().bold());
+                            println!("{}", e.to_string().red().bold());
+
+                            let options = vec![MIGRATE, CONTINUE, PAUSE, EXIT];
+                            let ans = inquire::Select::new("Choose an option:", options).prompt()?;
+
+                            match ans {
+                                MIGRATE => {
+                                    println!("{}", "Attempting migration...".blue().bold());
+
+                                    // We will reach here only if the migration has some destructive changes (we auto-apply safe migrations; see above)
+                                    let allow_destructive_changes =
+                                        inquire::Confirm::new("This migration contains destructive changes. Do you still want to proceed?")
+                                        .with_default(false)
+                                        .prompt()?;
+
+                                    if !allow_destructive_changes {
+                                        println!("{}", "Aborting migration...".red().bold());
+                                        continue;
+                                    }
+
+                                    if apply_migration(&mut db_client, &migrations, ignore_migration_errors).await? {
+                                        break Ok(env_vars);
+                                    } else {
+                                        continue;
+                                    }
+                                }
+                                CONTINUE => {
+                                    println!("{}", "Continuing...".green().bold());
+                                    break Ok(env_vars);
+                                }
+                                PAUSE => {
+                                    wait_for_enter(&"Paused. Press enter to re-verify.".blue().bold())?;
+                                }
+                                EXIT => {
+                                    println!("Exiting...");
+                                    let _ = crate::SIGINT.0.send(());
+                                    break Ok(env_vars);
+
+                                }
+                                _ => unreachable!(),
                             }
-                            _ => unreachable!(),
                         }
-                    }
-                    _ => {
-                        break verification_result
-                            .map_err(|e| anyhow!("Verification failed: {}", e))
+                        _ => {
+                            break verification_result
+                                .map_err(|e| anyhow!("Verification failed: {}", e))
+                                .map(|_| env_vars)
+                        }
                     }
                 }
-            }
-        }.boxed()).await
+            }.boxed()
+        }).await
     }
 }
 

--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -18,7 +18,7 @@ use exo_env::{MapEnvironment, SystemEnvironment};
 use exo_sql::schema::migration::{Migration, VerificationErrors};
 use exo_sql::DatabaseClient;
 use futures::FutureExt;
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 use super::command::{
     enforce_trusted_documents_arg, get, migration_scope_arg, port_arg, CommandDefinition,
@@ -76,8 +76,7 @@ impl CommandDefinition for DevCommandDefinition {
         let migration_scope_str = migration_scope_value(matches);
 
         // Create environment variables for the child server process
-        let mut env_vars = MapEnvironment::new();
-        env_vars.extend_from_env(&SystemEnvironment);
+        let mut env_vars = MapEnvironment::new_with_fallback(Arc::new(SystemEnvironment));
         env_vars.set(EXO_INTROSPECTION, "true");
         env_vars.set(EXO_INTROSPECTION_LIVE_UPDATE, "true");
         env_vars.set(_EXO_DEPLOYMENT_MODE, "dev");

--- a/crates/cli/src/commands/playground.rs
+++ b/crates/cli/src/commands/playground.rs
@@ -11,6 +11,7 @@ use common::env_const::{
     EXO_CHECK_CONNECTION_ON_STARTUP, EXO_CORS_DOMAINS, EXO_INTROSPECTION, EXO_POSTGRES_URL,
     _EXO_DEPLOYMENT_MODE, _EXO_UPSTREAM_ENDPOINT_URL,
 };
+use exo_env::{MapEnvironment, SystemEnvironment};
 
 use crate::{commands::command::get_required, config::Config, util::watcher};
 
@@ -47,21 +48,23 @@ impl CommandDefinition for PlaygroundCommandDefinition {
 
         ensure_exo_project_dir(&PathBuf::from("."))?;
 
-        std::env::set_var(EXO_INTROSPECTION, "only");
+        // Create environment variables for the child server process
+        let mut env_vars = MapEnvironment::new();
+        env_vars.extend_from_env(&SystemEnvironment);
+        env_vars.set(EXO_INTROSPECTION, "only");
         // We don't need a database connection in playground mode, but the Postgres resolver
         // currently requires a valid URL to be set (when we fix
         // https://github.com/exograph/exograph/issues/532), we won't need to instantiate the
         // Postgres resolver at all.
-        std::env::set_var(EXO_POSTGRES_URL, "postgres://__placeholder");
-        std::env::set_var(EXO_CHECK_CONNECTION_ON_STARTUP, "false");
-
-        std::env::set_var(EXO_CORS_DOMAINS, "*");
-
-        std::env::set_var(_EXO_DEPLOYMENT_MODE, "playground");
-        std::env::set_var(_EXO_UPSTREAM_ENDPOINT_URL, &endpoint_url);
+        env_vars.set(EXO_POSTGRES_URL, "postgres://__placeholder");
+        env_vars.set(EXO_CHECK_CONNECTION_ON_STARTUP, "false");
+        env_vars.set(EXO_CORS_DOMAINS, "*");
+        env_vars.set(_EXO_DEPLOYMENT_MODE, "playground");
+        env_vars.set(_EXO_UPSTREAM_ENDPOINT_URL, &endpoint_url);
 
         let mut server = watcher::build_and_start_server(port, &Config::default(), None, &|| {
-            async { Ok(()) }.boxed()
+            let env_vars = env_vars.clone();
+            async move { Ok(env_vars) }.boxed()
         })
         .await?;
 

--- a/crates/cli/src/commands/playground.rs
+++ b/crates/cli/src/commands/playground.rs
@@ -1,6 +1,6 @@
 use colored::Colorize;
 use futures::FutureExt;
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -49,8 +49,7 @@ impl CommandDefinition for PlaygroundCommandDefinition {
         ensure_exo_project_dir(&PathBuf::from("."))?;
 
         // Create environment variables for the child server process
-        let mut env_vars = MapEnvironment::new();
-        env_vars.extend_from_env(&SystemEnvironment);
+        let mut env_vars = MapEnvironment::new_with_fallback(Arc::new(SystemEnvironment));
         env_vars.set(EXO_INTROSPECTION, "only");
         // We don't need a database connection in playground mode, but the Postgres resolver
         // currently requires a valid URL to be set (when we fix

--- a/crates/cli/src/commands/yolo.rs
+++ b/crates/cli/src/commands/yolo.rs
@@ -19,7 +19,7 @@ use exo_env::{MapEnvironment, SystemEnvironment};
 use exo_sql::schema::migration::Migration;
 use std::{
     path::{Path, PathBuf},
-    sync::atomic::Ordering,
+    sync::{atomic::Ordering, Arc},
 };
 
 use crate::{
@@ -106,8 +106,7 @@ async fn run(
     }?;
 
     // Create environment variables for the child server process
-    let mut env_vars = MapEnvironment::new();
-    env_vars.extend_from_env(&SystemEnvironment);
+    let mut env_vars = MapEnvironment::new_with_fallback(Arc::new(SystemEnvironment));
     env_vars.set(EXO_POSTGRES_URL, &db.url());
     env_vars.set(EXO_INTROSPECTION, "true");
     env_vars.set(EXO_INTROSPECTION_LIVE_UPDATE, "true");

--- a/crates/cli/src/util/watcher.rs
+++ b/crates/cli/src/util/watcher.rs
@@ -13,7 +13,7 @@ use anyhow::{anyhow, Context, Result};
 use builder::error::ParserError;
 use colored::Colorize;
 use common::env_const::EXO_SERVER_PORT;
-use exo_env::{Environment, MapEnvironment};
+use exo_env::MapEnvironment;
 use futures::{future::BoxFuture, FutureExt};
 use notify_debouncer_mini::notify::RecursiveMode;
 use tokio::process::Child;
@@ -160,9 +160,7 @@ where
 
             // Apply environment variables from MapEnvironment if provided
             if let Some(env_vars) = env_vars {
-                for (key, value) in env_vars.vars() {
-                    command.env(key, value);
-                }
+                command.envs(env_vars.vars());
             }
 
             if let Some(watch_stage) = watch_stage {

--- a/crates/server-cf-worker/src/env.rs
+++ b/crates/server-cf-worker/src/env.rs
@@ -30,4 +30,11 @@ impl Environment for WorkerEnvironment {
             .map(|binding| binding.to_string())
             .or(self.additional_envs.get(key).cloned())
     }
+
+    fn vars(&self) -> Vec<(String, String)> {
+        self.additional_envs
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    }
 }

--- a/crates/server-cf-worker/src/env.rs
+++ b/crates/server-cf-worker/src/env.rs
@@ -30,11 +30,4 @@ impl Environment for WorkerEnvironment {
             .map(|binding| binding.to_string())
             .or(self.additional_envs.get(key).cloned())
     }
-
-    fn vars(&self) -> Vec<(String, String)> {
-        self.additional_envs
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect()
-    }
 }


### PR DESCRIPTION
`std::env::set_var` is marked as unsafe in Rust 2024 edition. Our usage of `set_var` was to set up environment variables for child  processes. We can avoid this function by instead using `Command::env()`.

Fixes #1650