### PR TITLE
chore: Downgrade Rust to 1.86

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.86.0"
 components = ["clippy", "rustfmt"]
 targets = ["wasm32-wasip2", "wasm32-unknown-unknown"]
 profile = "minimal"


### PR DESCRIPTION
With Rust 1.87.0, we see CI failures only in release mode (https://github.com/exograph/exograph/actions/runs/15525713525) and only for aws-lambda, linux, and macOS 13.

Others seem to encounter the same/similar issue (https://github.com/denoland/deno/actions/runs/15228733115/job/42833974584).

This commit keeps all the clippy-enforced changes, but reverts the Rust version.