### PR TITLE
refactor: Make core primitive type extensible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,6 +1510,7 @@ version = "0.17.0"
 dependencies = [
  "async-graphql-parser",
  "async-graphql-value",
+ "indexmap 2.9.0",
  "serde",
  "typed-generational-arena",
 ]

--- a/crates/builder/src/typechecker/logical_op.rs
+++ b/crates/builder/src/typechecker/logical_op.rs
@@ -10,7 +10,7 @@
 use std::collections::HashMap;
 
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
-use core_model::{mapped_arena::MappedArena, primitive_type::PrimitiveBaseType};
+use core_model::{mapped_arena::MappedArena, primitive_type};
 use core_model_builder::typechecker::{Typed, annotation::AnnotationSpec};
 
 use crate::ast::ast_types::{AstExpr, LogicalOp, Untyped};
@@ -50,9 +50,11 @@ impl TypecheckFrom<LogicalOp<Untyped>> for LogicalOp<Typed> {
                 let in_updated = v.pass(type_env, annotation_env, scope, errors);
                 let out_updated = if o_typ.is_incomplete() {
                     match v.typ().deref(type_env) {
-                        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Boolean)) => {
+                        Type::Primitive(PrimitiveType::Plain(primitive_type))
+                            if primitive_type.name() == primitive_type::BooleanType::NAME =>
+                        {
                             *o_typ =
-                                Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Boolean));
+                                Type::Primitive(PrimitiveType::Plain(primitive_type::BOOLEAN_TYPE));
                             true
                         }
 
@@ -86,11 +88,13 @@ impl TypecheckFrom<LogicalOp<Untyped>> for LogicalOp<Typed> {
                     let left_typ = left.typ().deref(type_env);
                     let right_typ = right.typ().deref(type_env);
 
-                    if left_typ == Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Boolean))
+                    if left_typ
+                        == Type::Primitive(PrimitiveType::Plain(primitive_type::BOOLEAN_TYPE))
                         && right_typ
-                            == Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Boolean))
+                            == Type::Primitive(PrimitiveType::Plain(primitive_type::BOOLEAN_TYPE))
                     {
-                        *o_typ = Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Boolean));
+                        *o_typ =
+                            Type::Primitive(PrimitiveType::Plain(primitive_type::BOOLEAN_TYPE));
                         true
                     } else {
                         *o_typ = Type::Error;
@@ -98,7 +102,9 @@ impl TypecheckFrom<LogicalOp<Untyped>> for LogicalOp<Typed> {
                         if left_typ.is_complete() || right_typ.is_complete() {
                             let mut spans = vec![];
                             if left_typ
-                                != Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Boolean))
+                                != Type::Primitive(PrimitiveType::Plain(
+                                    primitive_type::BOOLEAN_TYPE,
+                                ))
                                 && left_typ.is_complete()
                             {
                                 spans.push(SpanLabel {
@@ -109,7 +115,9 @@ impl TypecheckFrom<LogicalOp<Untyped>> for LogicalOp<Typed> {
                             }
 
                             if right_typ
-                                != Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Boolean))
+                                != Type::Primitive(PrimitiveType::Plain(
+                                    primitive_type::BOOLEAN_TYPE,
+                                ))
                                 && right_typ.is_complete()
                             {
                                 spans.push(SpanLabel {

--- a/crates/builder/src/typechecker/mod.rs
+++ b/crates/builder/src/typechecker/mod.rs
@@ -13,7 +13,7 @@ use codemap::Span;
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
 use core_model::{
     mapped_arena::MappedArena,
-    primitive_type::{InjectedType, PrimitiveBaseType, PrimitiveType},
+    primitive_type::{self, InjectedType, PrimitiveType},
 };
 use core_model_builder::{
     ast::ast_types::{AstEnum, AstModel, AstModelKind, AstModule, AstSystem, Untyped},
@@ -67,59 +67,9 @@ where
 }
 
 fn populate_type_env(env: &mut MappedArena<Type>) {
-    // TODO: maybe we don't need to do this manually
-    env.add(
-        "Boolean",
-        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Boolean)),
-    );
-    env.add(
-        "Int",
-        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Int)),
-    );
-    env.add(
-        "Float",
-        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Float)),
-    );
-    env.add(
-        "Decimal",
-        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Decimal)),
-    );
-    env.add(
-        "String",
-        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::String)),
-    );
-    env.add(
-        "LocalTime",
-        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::LocalTime)),
-    );
-    env.add(
-        "LocalDateTime",
-        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::LocalDateTime)),
-    );
-    env.add(
-        "LocalDate",
-        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::LocalDate)),
-    );
-    env.add(
-        "Instant",
-        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Instant)),
-    );
-    env.add(
-        "Json",
-        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Json)),
-    );
-    env.add(
-        "Blob",
-        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Blob)),
-    );
-    env.add(
-        "Uuid",
-        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Uuid)),
-    );
-    env.add(
-        "Vector",
-        Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Vector)),
-    );
+    for (name, primitive_type) in primitive_type::PRIMITIVE_REGISTRY.iter() {
+        env.add(name, Type::Primitive(PrimitiveType::Plain(*primitive_type)));
+    }
 
     env.add("Exograph", Type::Injected(InjectedType::Exograph));
     env.add("ExographPriv", Type::Injected(InjectedType::ExographPriv));

--- a/crates/builder/src/typechecker/relational_op.rs
+++ b/crates/builder/src/typechecker/relational_op.rs
@@ -10,7 +10,7 @@
 use std::collections::HashMap;
 
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
-use core_model::{mapped_arena::MappedArena, primitive_type::PrimitiveBaseType};
+use core_model::{mapped_arena::MappedArena, primitive_type};
 use core_model_builder::typechecker::{Typed, annotation::AnnotationSpec};
 
 use crate::ast::ast_types::{AstExpr, RelationalOp, Untyped};
@@ -59,7 +59,7 @@ impl TypecheckFrom<RelationalOp<Untyped>> for RelationalOp<Typed> {
                     && right_typ.is_complete()
                     && type_match(&left_typ, &right_typ)
                 {
-                    *o_typ = Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Boolean));
+                    *o_typ = Type::Primitive(PrimitiveType::Plain(primitive_type::BOOLEAN_TYPE));
                     true
                 } else {
                     *o_typ = Type::Error;
@@ -138,13 +138,15 @@ pub fn identical_match(left: &Type, right: &Type) -> bool {
             (Type::Primitive(left_typ), Type::Primitive(right_typ)) => {
                 match (left_typ, right_typ) {
                     (
-                        PrimitiveType::Plain(PrimitiveBaseType::Float),
-                        PrimitiveType::Plain(PrimitiveBaseType::Int),
-                    )
-                    | (
-                        PrimitiveType::Plain(PrimitiveBaseType::Int),
-                        PrimitiveType::Plain(PrimitiveBaseType::Float),
-                    ) => true,
+                        PrimitiveType::Plain(left_primitive),
+                        PrimitiveType::Plain(right_primitive),
+                    ) if (left_primitive.name() == primitive_type::FloatType::NAME
+                        && right_primitive.name() == primitive_type::IntType::NAME)
+                        || (left_primitive.name() == primitive_type::IntType::NAME
+                            && right_primitive.name() == primitive_type::FloatType::NAME) =>
+                    {
+                        true
+                    }
                     _ => left_typ == right_typ,
                 }
             }

--- a/crates/builder/src/typechecker/selection.rs
+++ b/crates/builder/src/typechecker/selection.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
 use core_model::{
     mapped_arena::MappedArena,
-    primitive_type::{PrimitiveBaseType, PrimitiveType},
+    primitive_type::{self, PrimitiveType},
 };
 use core_model_builder::{
     ast::ast_types::{AstExpr, AstModel, FieldSelectionElement},
@@ -217,7 +217,7 @@ impl TypecheckFunctionCallFrom<FieldSelectionElement<Untyped>> for FieldSelectio
                         if let Some(elem_type) = elem_type {
                             if identical_match(elem_type, &param_type) {
                                 *typ = Type::Primitive(PrimitiveType::Plain(
-                                    PrimitiveBaseType::Boolean,
+                                    primitive_type::BOOLEAN_TYPE,
                                 ));
                             } else {
                                 *typ = Type::Error;

--- a/crates/core-subsystem/core-model-builder/src/builder/system_builder.rs
+++ b/crates/core-subsystem/core-model-builder/src/builder/system_builder.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use core_model::function_defn::FunctionDefinition;
-use core_model::primitive_type::{PrimitiveBaseType, PrimitiveType};
+use core_model::primitive_type::PrimitiveType;
 use core_model::types::FieldType;
 use core_model::{context_type::ContextType, mapped_arena::MappedArena};
 
@@ -48,7 +48,9 @@ pub fn build(
 
     vec![FunctionDefinition {
         name: "contains".to_string(),
-        return_type: FieldType::Plain(PrimitiveType::Plain(PrimitiveBaseType::Boolean)),
+        return_type: FieldType::Plain(PrimitiveType::Plain(
+            core_model::primitive_type::BOOLEAN_TYPE,
+        )),
     }]
     .into_iter()
     .for_each(|defn| {

--- a/crates/core-subsystem/core-model-builder/src/typechecker/expression.rs
+++ b/crates/core-subsystem/core-model-builder/src/typechecker/expression.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use core_model::primitive_type::{PrimitiveBaseType, PrimitiveType};
+use core_model::primitive_type::{self, PrimitiveType};
 
 use crate::ast::ast_types::AstExpr;
 
@@ -20,20 +20,20 @@ impl AstExpr<Typed> {
             AstExpr::LogicalOp(logic) => logic.typ().clone(),
             AstExpr::RelationalOp(relation) => relation.typ().clone(),
             AstExpr::StringLiteral(_, _) => {
-                Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::String))
+                Type::Primitive(PrimitiveType::Plain(primitive_type::STRING_TYPE))
             }
             AstExpr::BooleanLiteral(_, _) => {
-                Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Boolean))
+                Type::Primitive(PrimitiveType::Plain(primitive_type::BOOLEAN_TYPE))
             }
             AstExpr::NumberLiteral(value, _) => {
                 if value.parse::<i64>().is_ok() {
-                    Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Int))
+                    Type::Primitive(PrimitiveType::Plain(primitive_type::INT_TYPE))
                 } else {
-                    Type::Primitive(PrimitiveType::Plain(PrimitiveBaseType::Float))
+                    Type::Primitive(PrimitiveType::Plain(primitive_type::FLOAT_TYPE))
                 }
             }
             AstExpr::StringList(_, _) => Type::Array(Box::new(Type::Primitive(
-                PrimitiveType::Plain(PrimitiveBaseType::String),
+                PrimitiveType::Plain(primitive_type::STRING_TYPE),
             ))),
             AstExpr::NullLiteral(_) => Type::Null,
         }

--- a/crates/core-subsystem/core-model/Cargo.toml
+++ b/crates/core-subsystem/core-model/Cargo.toml
@@ -9,6 +9,7 @@ serde.workspace = true
 typed-generational-arena.workspace = true
 async-graphql-parser.workspace = true
 async-graphql-value.workspace = true
+indexmap.workspace = true
 
 [dev-dependencies]
 

--- a/crates/core-subsystem/core-model/src/primitive_type.rs
+++ b/crates/core-subsystem/core-model/src/primitive_type.rs
@@ -8,79 +8,161 @@
 // by the Apache License, Version 2.0.
 
 use std::fmt::{Display, Formatter};
+use std::sync::LazyLock;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::type_normalization::{BaseType, Type};
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// Trait that all primitive base types must implement
+pub trait PrimitiveBaseType: Send + Sync + std::fmt::Debug {
+    /// Returns the name of the primitive type
+    fn name(&self) -> &'static str;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum PrimitiveType {
-    Plain(PrimitiveBaseType),
+    Plain(
+        #[serde(
+            serialize_with = "serialize_primitive",
+            deserialize_with = "deserialize_primitive"
+        )]
+        &'static dyn PrimitiveBaseType,
+    ),
     Array(Box<PrimitiveType>),
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub enum PrimitiveBaseType {
-    Int,
-    Float,
-    Decimal,
-    String,
-    Boolean,
-    LocalDate,
-    LocalTime,
-    LocalDateTime,
-    Instant,
-    Json,
-    Blob,
-    Uuid,
-    Vector,
+impl PartialEq for PrimitiveType {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (PrimitiveType::Plain(a), PrimitiveType::Plain(b)) => a.name() == b.name(),
+            (PrimitiveType::Array(a), PrimitiveType::Array(b)) => a == b,
+            _ => false,
+        }
+    }
 }
+
+fn serialize_primitive<S>(
+    primitive: &&'static dyn PrimitiveBaseType,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(primitive.name())
+}
+
+fn deserialize_primitive<'de, D>(
+    deserializer: D,
+) -> Result<&'static dyn PrimitiveBaseType, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let name = String::deserialize(deserializer)?;
+    PRIMITIVE_REGISTRY
+        .get(name.as_str())
+        .copied()
+        .ok_or_else(|| serde::de::Error::custom(format!("Unknown primitive type: {}", name)))
+}
+
+// Macro to define primitive types with minimal boilerplate
+macro_rules! define_primitive_type {
+    ($type_name:ident, $type_str:literal) => {
+        #[derive(Debug)]
+        pub struct $type_name;
+
+        impl $type_name {
+            pub const NAME: &'static str = $type_str;
+        }
+
+        impl PrimitiveBaseType for $type_name {
+            fn name(&self) -> &'static str {
+                Self::NAME
+            }
+        }
+    };
+}
+
+// Define all primitive types using the macro
+define_primitive_type!(IntType, "Int");
+define_primitive_type!(FloatType, "Float");
+define_primitive_type!(DecimalType, "Decimal");
+define_primitive_type!(StringType, "String");
+define_primitive_type!(BooleanType, "Boolean");
+define_primitive_type!(LocalDateType, "LocalDate");
+define_primitive_type!(LocalTimeType, "LocalTime");
+define_primitive_type!(LocalDateTimeType, "LocalDateTime");
+define_primitive_type!(InstantType, "Instant");
+define_primitive_type!(JsonType, "Json");
+define_primitive_type!(BlobType, "Blob");
+define_primitive_type!(UuidType, "Uuid");
+define_primitive_type!(VectorType, "Vector");
+
+// Macro to register primitive types in the registry
+macro_rules! register_primitive_types {
+    ($registry:ident, $($type_name:ident),* $(,)?) => {
+        $(
+            $registry.insert(
+                $type_name::NAME,
+                &$type_name as &'static dyn PrimitiveBaseType,
+            );
+        )*
+    };
+}
+
+// Global registry for primitive types (uses IndexMap so that the indices in snapshot tests don't change)
+pub static PRIMITIVE_REGISTRY: LazyLock<
+    indexmap::IndexMap<&'static str, &'static dyn PrimitiveBaseType>,
+> = LazyLock::new(|| {
+    let mut registry: indexmap::IndexMap<&'static str, &'static dyn PrimitiveBaseType> =
+        indexmap::IndexMap::new();
+
+    // Register built-in primitive types
+    register_primitive_types!(
+        registry,
+        BooleanType,
+        IntType,
+        FloatType,
+        DecimalType,
+        StringType,
+        LocalTimeType,
+        LocalDateTimeType,
+        LocalDateType,
+        InstantType,
+        JsonType,
+        BlobType,
+        UuidType,
+        VectorType,
+    );
+
+    registry
+});
+
+// Convenience constants for commonly used types (TODO: Once the full refactor is done, we can remove these)
+pub static INT_TYPE: &'static dyn PrimitiveBaseType = &IntType;
+pub static FLOAT_TYPE: &'static dyn PrimitiveBaseType = &FloatType;
+pub static DECIMAL_TYPE: &'static dyn PrimitiveBaseType = &DecimalType;
+pub static STRING_TYPE: &'static dyn PrimitiveBaseType = &StringType;
+pub static BOOLEAN_TYPE: &'static dyn PrimitiveBaseType = &BooleanType;
+pub static LOCAL_DATE_TYPE: &'static dyn PrimitiveBaseType = &LocalDateType;
+pub static LOCAL_TIME_TYPE: &'static dyn PrimitiveBaseType = &LocalTimeType;
+pub static LOCAL_DATE_TIME_TYPE: &'static dyn PrimitiveBaseType = &LocalDateTimeType;
+pub static INSTANT_TYPE: &'static dyn PrimitiveBaseType = &InstantType;
+pub static JSON_TYPE: &'static dyn PrimitiveBaseType = &JsonType;
+pub static BLOB_TYPE: &'static dyn PrimitiveBaseType = &BlobType;
+pub static UUID_TYPE: &'static dyn PrimitiveBaseType = &UuidType;
+pub static VECTOR_TYPE: &'static dyn PrimitiveBaseType = &VectorType;
 
 impl PrimitiveType {
     pub fn name(&self) -> String {
         match &self {
-            PrimitiveType::Plain(pt) => pt.name(),
+            PrimitiveType::Plain(pt) => pt.name().to_string(),
             PrimitiveType::Array(pt) => format!("[{}]", pt.name()),
-        }
-    }
-}
-
-impl PrimitiveBaseType {
-    pub fn name(&self) -> String {
-        match &self {
-            PrimitiveBaseType::Int => "Int".to_owned(),
-            PrimitiveBaseType::Float => "Float".to_owned(),
-            PrimitiveBaseType::Decimal => "Decimal".to_owned(),
-            PrimitiveBaseType::String => "String".to_owned(),
-            PrimitiveBaseType::Boolean => "Boolean".to_owned(),
-            PrimitiveBaseType::LocalDate => "LocalDate".to_owned(),
-            PrimitiveBaseType::LocalTime => "LocalTime".to_owned(),
-            PrimitiveBaseType::LocalDateTime => "LocalDateTime".to_owned(),
-            PrimitiveBaseType::Instant => "Instant".to_owned(),
-            PrimitiveBaseType::Json => "Json".to_owned(),
-            PrimitiveBaseType::Blob => "Blob".to_owned(),
-            PrimitiveBaseType::Uuid => "Uuid".to_owned(),
-            PrimitiveBaseType::Vector => "Vector".to_owned(),
         }
     }
 
     pub fn is_primitive(name: &str) -> bool {
-        matches!(
-            name,
-            "Int"
-                | "Float"
-                | "Decimal"
-                | "String"
-                | "Boolean"
-                | "LocalDate"
-                | "LocalTime"
-                | "LocalDateTime"
-                | "Instant"
-                | "Json"
-                | "Blob"
-                | "Uuid"
-                | "Vector"
-        )
+        PRIMITIVE_REGISTRY.contains_key(name)
     }
 }
 

--- a/crates/core-subsystem/core-resolver/src/introspection/definition/schema.rs
+++ b/crates/core-subsystem/core-resolver/src/introspection/definition/schema.rs
@@ -17,8 +17,11 @@ use async_graphql_parser::{
 };
 
 use async_graphql_value::Name;
-use core_model::type_normalization::{
-    TypeDefinitionIntrospection, default_positioned, default_positioned_name,
+use core_model::{
+    primitive_type,
+    type_normalization::{
+        TypeDefinitionIntrospection, default_positioned, default_positioned_name,
+    },
 };
 
 use crate::{plugin::SubsystemGraphQLResolver, validation::underlying_type};
@@ -69,7 +72,7 @@ impl Schema {
                                 profile.query_matches(
                                     field_return_type,
                                     &field_defn.name.node,
-                                    core_model::primitive_type::PrimitiveBaseType::is_primitive,
+                                    primitive_type::PrimitiveType::is_primitive,
                                 )
                             })
                             .collect::<Vec<FieldDefinition>>(),
@@ -95,7 +98,7 @@ impl Schema {
                                 profile.mutation_matches(
                                     field_return_type,
                                     &field_defn.name.node,
-                                    core_model::primitive_type::PrimitiveBaseType::is_primitive,
+                                    primitive_type::PrimitiveType::is_primitive,
                                 )
                             })
                             .collect::<Vec<FieldDefinition>>(),

--- a/crates/core-subsystem/core-resolver/src/validation/arguments_validator.rs
+++ b/crates/core-subsystem/core-resolver/src/validation/arguments_validator.rs
@@ -15,6 +15,7 @@ use async_graphql_parser::{
 };
 use async_graphql_value::{ConstValue, Name, Number, Value, indexmap::IndexMap};
 use bytes::Bytes;
+use core_model::primitive_type;
 
 use crate::{
     introspection::definition::schema::Schema, validation::validation_error::ValidationError,
@@ -213,7 +214,10 @@ impl<'a> ArgumentValidator<'a> {
         // TODO: Use the types from PrimitiveType (but that is currently in the builder crate, which we don't want to depend on)
         self.validate_scalar_argument(
             "Number",
-            &["Int", "Float"],
+            &[
+                primitive_type::IntType::NAME,
+                primitive_type::FloatType::NAME,
+            ],
             || {
                 Ok(Val::Number(number.clone().try_into().map_err(|_| {
                     ValidationError::InvalidArgumentType {

--- a/crates/postgres-subsystem/postgres-core-builder/src/access/database_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/access/database_builder.rs
@@ -17,7 +17,7 @@ use core_model::{
     },
     context_type::{ContextFieldType, ContextSelection},
     mapped_arena::MappedArena,
-    primitive_type::{PrimitiveBaseType, PrimitiveType},
+    primitive_type::{self, PrimitiveType},
     types::FieldType,
 };
 use core_model_builder::{
@@ -78,7 +78,7 @@ pub fn compute_predicate_expression(
                         subsystem_entity_types.values_ref(),
                     )
                     .name()
-                        == "Boolean"
+                        == primitive_type::BooleanType::NAME
                     {
                         // Treat boolean columns in the same way as an "eq" relational expression
                         // For example, treat `self.published` the same as `self.published == true`
@@ -113,7 +113,8 @@ pub fn compute_predicate_expression(
                     }
                 }
                 DatabasePathSelection::Context(context_selection, field_type) => {
-                    if field_type.innermost() == &PrimitiveType::Plain(PrimitiveBaseType::Boolean) {
+                    if field_type.innermost() == &PrimitiveType::Plain(primitive_type::BOOLEAN_TYPE)
+                    {
                         // Treat boolean context expressions in the same way as an "eq" relational expression
                         // For example, treat `AuthContext.superUser` the same way as `AuthContext.superUser == true`
                         Ok(AccessPredicateExpression::RelationalOp(

--- a/crates/postgres-subsystem/postgres-core-builder/src/access/precheck_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/access/precheck_builder.rs
@@ -17,7 +17,7 @@ use core_model::{
     },
     context_type::{ContextFieldType, ContextSelection},
     mapped_arena::MappedArena,
-    primitive_type::{PrimitiveBaseType, PrimitiveType},
+    primitive_type::{self, PrimitiveType},
     types::FieldType,
 };
 use core_model_builder::{
@@ -81,7 +81,7 @@ pub fn compute_precheck_predicate_expression(
                         subsystem_entity_types.values_ref(),
                     );
 
-                    if field_entity_type.name() == "Boolean" {
+                    if field_entity_type.name() == primitive_type::BooleanType::NAME {
                         // Treat boolean context expressions in the same way as an "eq" relational expression
                         // For example, treat `AuthContext.superUser` the same way as `AuthContext.superUser == true`
                         Ok(AccessPredicateExpression::RelationalOp(
@@ -102,7 +102,8 @@ pub fn compute_precheck_predicate_expression(
                     }
                 }
                 PrecheckPathSelection::Context(context_selection, field_type) => {
-                    if field_type.innermost() == &PrimitiveType::Plain(PrimitiveBaseType::Boolean) {
+                    if field_type.innermost() == &PrimitiveType::Plain(primitive_type::BOOLEAN_TYPE)
+                    {
                         // Treat boolean context expressions in the same way as an "eq" relational expression
                         // For example, treat `AuthContext.superUser` the same way as `AuthContext.superUser == true`
                         Ok(AccessPredicateExpression::RelationalOp(

--- a/crates/postgres-subsystem/postgres-core-builder/src/aggregate_type_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/aggregate_type_builder.rs
@@ -9,6 +9,7 @@
 
 use std::collections::HashMap;
 
+use core_model::primitive_type;
 use core_model::types::Named;
 use core_model_builder::error::ModelBuildingError;
 use lazy_static::lazy_static;
@@ -75,7 +76,7 @@ fn create_shallow_type(resolved_type: &ResolvedType, building: &mut SystemContex
                 // For enums, we support only the count aggregate
                 name: ScalarAggregateFieldKind::Count.name().to_string(),
                 typ: AggregateFieldType::Scalar {
-                    type_name: "Int".to_string(),
+                    type_name: primitive_type::IntType::NAME.to_string(),
                     kind: ScalarAggregateFieldKind::Count,
                 },
                 relation: None,
@@ -110,7 +111,7 @@ fn create_shallow_type(resolved_type: &ResolvedType, building: &mut SystemContex
                     // Always add the count aggregate
                     name: ScalarAggregateFieldKind::Count.name().to_string(),
                     typ: AggregateFieldType::Scalar {
-                        type_name: "Int".to_string(),
+                        type_name: primitive_type::IntType::NAME.to_string(),
                         kind: ScalarAggregateFieldKind::Count,
                     },
                     relation: None,
@@ -201,19 +202,19 @@ lazy_static! {
     // We don't specify the "count" aggregate here because it is always supported (see above)
     // The second element in the tuple is the return type of the avg, if it differs from the input type
     static ref AGG_MAP: HashMap<&'static str, Vec<(ScalarAggregateFieldKind, Option<&'static str>)>> = HashMap::from([
-        ("Int",
+        (primitive_type::IntType::NAME,
             vec![(ScalarAggregateFieldKind::Min, None), (ScalarAggregateFieldKind::Max, None),
-                 (ScalarAggregateFieldKind::Sum, None), (ScalarAggregateFieldKind::Avg, Some("Float"))]),
-        ("Float",
+                 (ScalarAggregateFieldKind::Sum, None), (ScalarAggregateFieldKind::Avg, Some(primitive_type::FloatType::NAME))]),
+        (primitive_type::FloatType::NAME,
             vec![(ScalarAggregateFieldKind::Min, None), (ScalarAggregateFieldKind::Max, None),
-                 (ScalarAggregateFieldKind::Sum, Some("Float")), (ScalarAggregateFieldKind::Avg, Some("Float"))]),
-        ("Decimal",
+                 (ScalarAggregateFieldKind::Sum, Some(primitive_type::FloatType::NAME)), (ScalarAggregateFieldKind::Avg, Some(primitive_type::FloatType::NAME))]),
+        (primitive_type::DecimalType::NAME,
             vec![(ScalarAggregateFieldKind::Min, None), (ScalarAggregateFieldKind::Max, None),
                  (ScalarAggregateFieldKind::Sum, None), (ScalarAggregateFieldKind::Avg, None)]),
 
-        ("String",
+        (primitive_type::StringType::NAME,
                 vec![(ScalarAggregateFieldKind::Min, None), (ScalarAggregateFieldKind::Max, None)]),
 
-        ("Vector", vec![(ScalarAggregateFieldKind::Avg, None)])
+        (primitive_type::VectorType::NAME, vec![(ScalarAggregateFieldKind::Avg, None)])
     ]);
 }

--- a/crates/postgres-subsystem/postgres-core-builder/src/type_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/type_builder.rs
@@ -18,7 +18,7 @@ use crate::resolved_type::{
 use common::value::Val;
 use common::value::val::ValNumber;
 use core_model::access::AccessPredicateExpression;
-use core_model::primitive_type::PrimitiveBaseType;
+use core_model::primitive_type;
 use core_model::types::{Named, TypeValidationProvider};
 use postgres_core_model::access::{CreationAccessExpression, PrecheckAccessPrimitiveExpression};
 use postgres_core_model::types::{
@@ -103,7 +103,8 @@ fn create_shallow_type(
                     kind: PostgresPrimitiveTypeKind::Builtin,
                 },
             );
-            if matches!(pt, PrimitiveType::Plain(PrimitiveBaseType::Vector)) {
+            if matches!(pt, PrimitiveType::Plain(pbt) if pbt.name() == primitive_type::VectorType::NAME)
+            {
                 let vector_distance_type = VectorDistanceType::new("VectorDistance".to_string());
                 building
                     .vector_distance_types
@@ -587,7 +588,7 @@ fn create_persistent_field(
                     Ok(PostgresFieldDefaultValue::Static(Val::Bool(*boolean)))
                 }
                 AstExpr::NumberLiteral(number, _) => {
-                    let parsed_number = if field.typ.name() == "Float" {
+                    let parsed_number = if field.typ.name() == primitive_type::FloatType::NAME {
                         let float_number = number.parse::<f64>().map_err(|_| {
                             ModelBuildingError::Generic(format!(
                                 "Invalid float default value: {}",
@@ -595,7 +596,7 @@ fn create_persistent_field(
                             ))
                         })?;
                         Ok(ValNumber::F64(float_number))
-                    } else if field.typ.name() == "Int" {
+                    } else if field.typ.name() == primitive_type::IntType::NAME {
                         let int_number = number.parse::<i64>().map_err(|_| {
                             ModelBuildingError::Generic(format!(
                                 "Invalid int default value: {}",

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/query_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/query_builder.rs
@@ -10,6 +10,7 @@
 use core_model::{
     access::AccessPredicateExpression,
     mapped_arena::{MappedArena, SerializableSlabIndex},
+    primitive_type,
     types::{BaseOperationReturnType, FieldType, Named, OperationReturnType},
 };
 
@@ -388,25 +389,25 @@ pub fn expand_unique_queries(
 }
 
 pub fn limit_param(primitive_types: &MappedArena<PostgresPrimitiveType>) -> LimitParameter {
-    let param_type_name = "Int".to_string();
+    let param_type_name = primitive_type::IntType::NAME;
 
     LimitParameter {
         name: "limit".to_string(),
         typ: FieldType::Optional(Box::new(FieldType::Plain(LimitParameterType {
-            type_name: param_type_name.clone(),
-            type_id: primitive_types.get_id(&param_type_name).unwrap(),
+            type_name: param_type_name.to_string(),
+            type_id: primitive_types.get_id(param_type_name).unwrap(),
         }))),
     }
 }
 
 pub fn offset_param(primitive_types: &MappedArena<PostgresPrimitiveType>) -> OffsetParameter {
-    let param_type_name = "Int".to_string();
+    let param_type_name = primitive_type::IntType::NAME;
 
     OffsetParameter {
         name: "offset".to_string(),
         typ: FieldType::Optional(Box::new(FieldType::Plain(OffsetParameterType {
-            type_name: param_type_name.clone(),
-            type_id: primitive_types.get_id(&param_type_name).unwrap(),
+            type_name: param_type_name.to_string(),
+            type_id: primitive_types.get_id(param_type_name).unwrap(),
         }))),
     }
 }

--- a/crates/subsystem-util/subsystem-model-builder-util/src/builder/access_utils.rs
+++ b/crates/subsystem-util/subsystem-model-builder-util/src/builder/access_utils.rs
@@ -13,7 +13,7 @@ use core_model::{
         CommonAccessPrimitiveExpression,
     },
     context_type::{ContextFieldType, ContextSelection},
-    primitive_type::{PrimitiveBaseType, PrimitiveType},
+    primitive_type::{self, PrimitiveType},
 };
 use core_model_builder::{
     ast::ast_types::{AstExpr, FieldSelection, LogicalOp, RelationalOp},
@@ -35,7 +35,7 @@ pub fn compute_predicate_expression(
     match expr {
         AstExpr::FieldSelection(selection) => match compute_selection(selection, resolved_env)? {
             PathSelection::Context(context_selection, field_type) => {
-                if field_type.innermost() == &PrimitiveType::Plain(PrimitiveBaseType::Boolean) {
+                if field_type.innermost() == &PrimitiveType::Plain(primitive_type::BOOLEAN_TYPE) {
                     // Treat boolean context expressions in the same way as an "eq" relational expression
                     // For example, treat `AuthContext.superUser` the same way as `AuthContext.superUser == true`
                     Ok(AccessPredicateExpression::RelationalOp(


### PR DESCRIPTION
This is the first step making primitive types user-extensible. The main change is the use of trait with an implementation for each primitive type instead of an enum with a variant for each type.