### PR TITLE
Check for invalid type hint annotations

### DIFF
--- a/crates/postgres-subsystem/postgres-builder/src/plugin.rs
+++ b/crates/postgres-subsystem/postgres-builder/src/plugin.rs
@@ -16,9 +16,7 @@ use core_plugin_interface::interface::{SubsystemBuild, SubsystemBuilder};
 use core_plugin_shared::{
     serializable_system::SerializableCoreBytes, system_serializer::SystemSerializer,
 };
-use postgres_core_builder::{
-    resolved_builder::TYPE_HINT_PROVIDER_REGISTRY, resolved_type::ResolvedTypeEnv,
-};
+use postgres_core_builder::{resolved_builder, resolved_type::ResolvedTypeEnv};
 use postgres_graphql_builder::PostgresGraphQLSubsystemBuilder;
 use postgres_rest_builder::PostgresRestSubsystemBuilder;
 use postgres_rpc_builder::PostgresRpcSubsystemBuilder;
@@ -197,9 +195,7 @@ impl SubsystemBuilder for PostgresSubsystemBuilder {
             ),
         ];
 
-        for (_, provider) in TYPE_HINT_PROVIDER_REGISTRY.iter() {
-            annotations.extend(provider.applicable_hint_annotations());
-        }
+        annotations.extend(resolved_builder::collect_all_hint_annotations());
 
         annotations
     }

--- a/crates/postgres-subsystem/postgres-core-builder/src/resolved_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/resolved_builder.rs
@@ -548,63 +548,24 @@ impl_default_type_hint_provider!(
 pub static TYPE_HINT_PROVIDER_REGISTRY: LazyLock<
     HashMap<&'static str, &'static dyn ResolveTypeHintProvider>,
 > = LazyLock::new(|| {
-    let mut registry = HashMap::new();
-
-    // Register all primitive types that can compute type hints
-    registry.insert(
-        primitive_type::IntType::NAME,
+    [
         &primitive_type::IntType as &'static dyn ResolveTypeHintProvider,
-    );
-    registry.insert(
-        primitive_type::FloatType::NAME,
         &primitive_type::FloatType as &'static dyn ResolveTypeHintProvider,
-    );
-    registry.insert(
-        primitive_type::DecimalType::NAME,
         &primitive_type::DecimalType as &'static dyn ResolveTypeHintProvider,
-    );
-    registry.insert(
-        primitive_type::StringType::NAME,
         &primitive_type::StringType as &'static dyn ResolveTypeHintProvider,
-    );
-    registry.insert(
-        primitive_type::InstantType::NAME,
         &primitive_type::InstantType as &'static dyn ResolveTypeHintProvider,
-    );
-    registry.insert(
-        primitive_type::VectorType::NAME,
         &primitive_type::VectorType as &'static dyn ResolveTypeHintProvider,
-    );
-    registry.insert(
-        primitive_type::BooleanType::NAME,
         &primitive_type::BooleanType as &'static dyn ResolveTypeHintProvider,
-    );
-    registry.insert(
-        primitive_type::LocalDateType::NAME,
         &primitive_type::LocalDateType as &'static dyn ResolveTypeHintProvider,
-    );
-    registry.insert(
-        primitive_type::LocalTimeType::NAME,
         &primitive_type::LocalTimeType as &'static dyn ResolveTypeHintProvider,
-    );
-    registry.insert(
-        primitive_type::LocalDateTimeType::NAME,
         &primitive_type::LocalDateTimeType as &'static dyn ResolveTypeHintProvider,
-    );
-    registry.insert(
-        primitive_type::JsonType::NAME,
         &primitive_type::JsonType as &'static dyn ResolveTypeHintProvider,
-    );
-    registry.insert(
-        primitive_type::BlobType::NAME,
         &primitive_type::BlobType as &'static dyn ResolveTypeHintProvider,
-    );
-    registry.insert(
-        primitive_type::UuidType::NAME,
         &primitive_type::UuidType as &'static dyn ResolveTypeHintProvider,
-    );
-
-    registry
+    ]
+    .iter()
+    .map(|provider| (provider.name(), *provider))
+    .collect()
 });
 
 static ALL_HINT_ANNOTATION_NAMES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {

--- a/error-report-testing/unsupported-hint-annotations/error.txt
+++ b/error-report-testing/unsupported-hint-annotations/error.txt
@@ -1,0 +1,13 @@
+error[C000]: Annotation @bits16 is not supported for type Decimal
+ --> src/index.exo:5:9
+  |
+5 |         @bits16 price: Decimal  // This should cause an error - bits16 is not supported for Decimal
+  |         ^^^^^^^^^^^^^^^^^^^^^^
+error[C000]: Annotation @singlePrecision is not supported for type Int
+ --> src/index.exo:7:9
+  |
+7 |         @singlePrecision weight: Int  // This should also cause an error - singlePrecision is not supported for Int
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Error: Parser error: Could not process input exo files
+

--- a/error-report-testing/unsupported-hint-annotations/src/index.exo
+++ b/error-report-testing/unsupported-hint-annotations/src/index.exo
@@ -1,0 +1,9 @@
+@postgres
+module TestModule {
+    type Product {
+        @pk id: Int = autoIncrement()
+        @bits16 price: Decimal  // This should cause an error - bits16 is not supported for Decimal
+        @maxLength(20) description: String
+        @singlePrecision weight: Int  // This should also cause an error - singlePrecision is not supported for Int
+    }
+}


### PR DESCRIPTION
We were silently ignoring inapplicable annotations (for example `@singlePrecision` for an `Int`).

Now we report an error for any invalid hint annotations.