### PR TITLE
Refactor column type determination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6858,6 +6858,7 @@ dependencies = [
  "postgres-builder",
  "postgres-core-model",
  "serde",
+ "serde_json",
  "wasm-bindgen-test",
  "wasm-bindgen-test-macro",
 ]

--- a/crates/postgres-subsystem/postgres-core-builder/Cargo.toml
+++ b/crates/postgres-subsystem/postgres-core-builder/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 heck.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 codemap-diagnostic.workspace = true
 codemap.workspace = true
 lazy_static.workspace = true

--- a/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
@@ -10,9 +10,10 @@
 use std::collections::HashSet;
 
 use crate::naming::ToPlural;
+use crate::resolved_builder::PHYSICAL_COLUMN_TYPE_PROVIDER_REGISTRY;
 use crate::resolved_type::{
-    ResolvedCompositeType, ResolvedEnumType, ResolvedField, ResolvedFieldDefault,
-    ResolvedFieldType, ResolvedType, ResolvedTypeEnv, ResolvedTypeHint,
+    ExplicitTypeHint, ResolvedCompositeType, ResolvedEnumType, ResolvedField, ResolvedFieldDefault,
+    ResolvedFieldType, ResolvedType, ResolvedTypeEnv, VectorTypeHint,
 };
 
 use codemap_diagnostic::{Diagnostic, Level, SpanLabel, SpanStyle};
@@ -25,8 +26,7 @@ use core_model_builder::{ast::ast_types::AstExpr, error::ModelBuildingError};
 
 use exo_sql::schema::column_spec::{ColumnAutoincrement, ColumnDefault};
 use exo_sql::{
-    ColumnId, DEFAULT_VECTOR_SIZE, FloatBits, IntBits, ManyToOne, PhysicalColumn,
-    PhysicalColumnType, PhysicalIndex, PhysicalTable, TableId, VectorDistanceFunction,
+    ColumnId, ManyToOne, PhysicalColumn, PhysicalColumnType, PhysicalIndex, PhysicalTable, TableId,
     schema::index_spec::IndexKind,
 };
 use exo_sql::{Database, PhysicalEnum, RelationColumnPair};
@@ -143,13 +143,15 @@ fn expand_database_info(
                         index_kind: if field.typ.innermost().type_name
                             == primitive_type::VectorType::NAME
                         {
-                            let distance_function = match field.type_hint {
-                                Some(ResolvedTypeHint::Vector {
-                                    distance_function, ..
-                                }) => distance_function,
-                                _ => None,
-                            }
-                            .unwrap_or(VectorDistanceFunction::default());
+                            let distance_function = field
+                                .type_hint
+                                .as_ref()
+                                .and_then(|hint| {
+                                    (hint.0.as_ref() as &dyn std::any::Any)
+                                        .downcast_ref::<VectorTypeHint>()
+                                        .and_then(|v| v.distance_function)
+                                })
+                                .unwrap_or_default();
 
                             IndexKind::HNWS {
                                 distance_function,
@@ -485,173 +487,23 @@ fn determine_column_type<'a>(
     pt: &'a PrimitiveType,
     field: &'a ResolvedField,
 ) -> PhysicalColumnType {
+    // Check for explicit type hints first
+    if let Some(hint) = &field.type_hint {
+        let hint_ref = hint.0.as_ref() as &dyn std::any::Any;
+        if let Some(explicit) = hint_ref.downcast_ref::<ExplicitTypeHint>() {
+            return PhysicalColumnType::from_string(&explicit.dbtype).unwrap();
+        }
+    }
+
     match pt {
         PrimitiveType::Array(underlying_pt) => PhysicalColumnType::Array {
             typ: Box::new(determine_column_type(underlying_pt, field)),
         },
         PrimitiveType::Plain(base_pt_type) => {
-            if let Some(hint) = &field.type_hint {
-                match hint {
-                    ResolvedTypeHint::Explicit { dbtype } => {
-                        PhysicalColumnType::from_string(dbtype).unwrap()
-                    }
-
-                    ResolvedTypeHint::Int { bits, range } => {
-                        assert!(base_pt_type.name() == primitive_type::IntType::NAME);
-
-                        // determine the proper sized type to use
-                        if let Some(bits) = bits {
-                            PhysicalColumnType::Int {
-                                bits: match bits {
-                                    16 => IntBits::_16,
-                                    32 => IntBits::_32,
-                                    64 => IntBits::_64,
-                                    _ => panic!("Invalid bits"),
-                                },
-                            }
-                        } else if let Some(range) = range {
-                            let is_superset = |bound_min: i64, bound_max: i64| {
-                                let range_min = range.0;
-                                let range_max = range.1;
-                                assert!(range_min <= range_max);
-                                assert!(bound_min <= bound_max);
-
-                                // is this bound a superset of the provided range?
-                                (bound_min <= range_min && bound_min <= range_max)
-                                    && (bound_max >= range_max && bound_max >= range_min)
-                            };
-
-                            // determine which SQL type is appropriate for this range
-                            {
-                                if is_superset(i16::MIN.into(), i16::MAX.into()) {
-                                    PhysicalColumnType::Int { bits: IntBits::_16 }
-                                } else if is_superset(i32::MIN.into(), i32::MAX.into()) {
-                                    PhysicalColumnType::Int { bits: IntBits::_32 }
-                                } else if is_superset(i64::MIN, i64::MAX) {
-                                    PhysicalColumnType::Int { bits: IntBits::_64 }
-                                } else {
-                                    // TODO: numeric type
-                                    panic!("Requested range is too big")
-                                }
-                            }
-                        } else {
-                            // no hints provided, go with default
-                            PhysicalColumnType::Int { bits: IntBits::_32 }
-                        }
-                    }
-
-                    ResolvedTypeHint::Float { bits, .. } => {
-                        assert!(base_pt_type.name() == primitive_type::FloatType::NAME);
-
-                        if let Some(bits) = *bits {
-                            if (1..=24).contains(&bits) {
-                                PhysicalColumnType::Float {
-                                    bits: FloatBits::_24,
-                                }
-                            } else if bits > 24 && bits <= 53 {
-                                PhysicalColumnType::Float {
-                                    bits: FloatBits::_53,
-                                }
-                            } else {
-                                panic!("Invalid bits")
-                            }
-                        } else {
-                            PhysicalColumnType::Float {
-                                bits: FloatBits::_53,
-                            }
-                        }
-                    }
-
-                    ResolvedTypeHint::Decimal { precision, scale } => {
-                        assert!(base_pt_type.name() == primitive_type::DecimalType::NAME);
-
-                        // cannot have scale and no precision specified
-                        if precision.is_none() {
-                            assert!(scale.is_none())
-                        }
-
-                        PhysicalColumnType::Numeric {
-                            precision: *precision,
-                            scale: *scale,
-                        }
-                    }
-
-                    ResolvedTypeHint::String { max_length } => {
-                        assert!(base_pt_type.name() == primitive_type::StringType::NAME);
-
-                        // length hint provided, use it
-                        PhysicalColumnType::String {
-                            max_length: Some(*max_length),
-                        }
-                    }
-
-                    ResolvedTypeHint::DateTime { precision } => {
-                        if base_pt_type.name() == primitive_type::LocalTimeType::NAME {
-                            PhysicalColumnType::Time {
-                                precision: Some(*precision),
-                            }
-                        } else if base_pt_type.name() == primitive_type::LocalDateTimeType::NAME {
-                            PhysicalColumnType::Timestamp {
-                                precision: Some(*precision),
-                                timezone: false,
-                            }
-                        } else if base_pt_type.name() == primitive_type::InstantType::NAME {
-                            PhysicalColumnType::Timestamp {
-                                precision: Some(*precision),
-                                timezone: true,
-                            }
-                        } else {
-                            panic!("Invalid type for DateTime hint: {:?}", base_pt_type);
-                        }
-                    }
-
-                    ResolvedTypeHint::Vector { size, .. } => {
-                        assert!(base_pt_type.name() == primitive_type::VectorType::NAME);
-
-                        PhysicalColumnType::Vector {
-                            size: (*size).unwrap_or(DEFAULT_VECTOR_SIZE),
-                        }
-                    }
-                }
-            } else if base_pt_type.name() == primitive_type::IntType::NAME {
-                PhysicalColumnType::Int { bits: IntBits::_32 }
-            } else if base_pt_type.name() == primitive_type::FloatType::NAME {
-                PhysicalColumnType::Float {
-                    bits: FloatBits::_24,
-                }
-            } else if base_pt_type.name() == primitive_type::DecimalType::NAME {
-                PhysicalColumnType::Numeric {
-                    precision: None,
-                    scale: None,
-                }
-            } else if base_pt_type.name() == primitive_type::StringType::NAME {
-                PhysicalColumnType::String { max_length: None }
-            } else if base_pt_type.name() == primitive_type::BooleanType::NAME {
-                PhysicalColumnType::Boolean
-            } else if base_pt_type.name() == primitive_type::LocalTimeType::NAME {
-                PhysicalColumnType::Time { precision: None }
-            } else if base_pt_type.name() == primitive_type::LocalDateTimeType::NAME {
-                PhysicalColumnType::Timestamp {
-                    precision: None,
-                    timezone: false,
-                }
-            } else if base_pt_type.name() == primitive_type::InstantType::NAME {
-                PhysicalColumnType::Timestamp {
-                    precision: None,
-                    timezone: true,
-                }
-            } else if base_pt_type.name() == primitive_type::LocalDateType::NAME {
-                PhysicalColumnType::Date
-            } else if base_pt_type.name() == primitive_type::JsonType::NAME {
-                PhysicalColumnType::Json
-            } else if base_pt_type.name() == primitive_type::BlobType::NAME {
-                PhysicalColumnType::Blob
-            } else if base_pt_type.name() == primitive_type::UuidType::NAME {
-                PhysicalColumnType::Uuid
-            } else if base_pt_type.name() == primitive_type::VectorType::NAME {
-                PhysicalColumnType::Vector {
-                    size: DEFAULT_VECTOR_SIZE,
-                }
+            // Use the registry to find the appropriate provider
+            if let Some(provider) = PHYSICAL_COLUMN_TYPE_PROVIDER_REGISTRY.get(base_pt_type.name())
+            {
+                provider.determine_column_type(field)
             } else {
                 panic!("Unknown primitive type: {:?}", base_pt_type);
             }

--- a/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
@@ -10,7 +10,7 @@
 use std::collections::HashSet;
 
 use crate::naming::ToPlural;
-use crate::resolved_builder::PHYSICAL_COLUMN_TYPE_PROVIDER_REGISTRY;
+use crate::resolved_builder::PRIMITIVE_TYPE_PROVIDER_REGISTRY;
 use crate::resolved_type::{
     ExplicitTypeHint, ResolvedCompositeType, ResolvedEnumType, ResolvedField, ResolvedFieldDefault,
     ResolvedFieldType, ResolvedType, ResolvedTypeEnv, VectorTypeHint,
@@ -500,9 +500,7 @@ fn determine_column_type<'a>(
             typ: Box::new(determine_column_type(underlying_pt, field)),
         },
         PrimitiveType::Plain(base_pt_type) => {
-            // Use the registry to find the appropriate provider
-            if let Some(provider) = PHYSICAL_COLUMN_TYPE_PROVIDER_REGISTRY.get(base_pt_type.name())
-            {
+            if let Some(provider) = PRIMITIVE_TYPE_PROVIDER_REGISTRY.get(base_pt_type.name()) {
                 provider.determine_column_type(field)
             } else {
                 panic!("Unknown primitive type: {:?}", base_pt_type);

--- a/crates/postgres-subsystem/postgres-core-builder/src/resolved_type.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/resolved_type.rs
@@ -19,7 +19,7 @@ use core_model_builder::{
 
 use crate::{access_builder::ResolvedAccess, naming::ToPlural, resolved_builder::Cardinality};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ResolvedTypeEnv<'a> {
     pub contexts: &'a MappedArena<ContextType>,
     pub resolved_types: MappedArena<ResolvedType>,
@@ -32,7 +32,7 @@ impl ResolvedTypeEnv<'_> {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum ResolvedType {
     Primitive(PrimitiveType),
@@ -52,7 +52,7 @@ pub struct ResolvedEnumType {
     pub span: Span,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ResolvedCompositeType {
     pub name: String,
     pub plural_name: String,
@@ -78,7 +78,7 @@ impl ToPlural for ResolvedCompositeType {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ResolvedField {
     pub name: String,
     pub typ: FieldType<ResolvedFieldType>,
@@ -86,7 +86,7 @@ pub struct ResolvedField {
     pub self_column: bool, // is the column name in the same table or does it point to a column in a different table?
     pub is_pk: bool,
     pub access: ResolvedAccess,
-    pub type_hint: Option<ResolvedTypeHint>,
+    pub type_hint: Option<SerializableTypeHint>,
     pub unique_constraints: Vec<String>,
     pub indices: Vec<String>,
     pub cardinality: Option<Cardinality>,
@@ -119,56 +119,198 @@ impl ResolvedField {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub enum ResolvedTypeHint {
-    Explicit {
-        dbtype: String,
-    },
-    Int {
-        bits: Option<usize>,
-        range: Option<(i64, i64)>,
-    },
-    Float {
-        bits: Option<usize>,
-        range: Option<(f64, f64)>,
-    },
-    Decimal {
-        precision: Option<usize>,
-        scale: Option<usize>,
-    },
-    String {
-        max_length: usize,
-    },
-    DateTime {
-        precision: usize,
-    },
-    Vector {
-        size: Option<usize>,
-        distance_function: Option<VectorDistanceFunction>,
-    },
+/// Trait for resolved type hints
+pub trait ResolvedTypeHint: Send + Sync + std::fmt::Debug + std::any::Any {
+    /// Get the hint type name for identification
+    fn hint_type_name(&self) -> &'static str;
+
+    /// Serialize the type hint to a serde value
+    fn serialize_data(&self) -> serde_json::Value;
 }
 
-impl TypeValidationProvider for ResolvedTypeHint {
+/// Wrapper for serializable type hints
+#[derive(Debug)]
+pub struct SerializableTypeHint(pub Box<dyn ResolvedTypeHint>);
+
+impl Serialize for SerializableTypeHint {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("TypeHint", 2)?;
+        state.serialize_field("type", self.0.hint_type_name())?;
+        state.serialize_field("data", &self.0.serialize_data())?;
+        state.end()
+    }
+}
+
+// For now, implement a simple deserialize that creates empty hints
+impl<'de> Deserialize<'de> for SerializableTypeHint {
+    fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // For now, create a default hint - this will be improved later
+        Ok(SerializableTypeHint(Box::new(ExplicitTypeHint {
+            dbtype: "TEXT".to_string(),
+        })))
+    }
+}
+
+/// Explicit type hint implementation
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ExplicitTypeHint {
+    pub dbtype: String,
+}
+
+impl ResolvedTypeHint for ExplicitTypeHint {
+    fn hint_type_name(&self) -> &'static str {
+        "Explicit"
+    }
+
+    fn serialize_data(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap()
+    }
+}
+
+/// Int type hint implementation
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct IntTypeHint {
+    pub bits: Option<usize>,
+    pub range: Option<(i64, i64)>,
+}
+
+impl ResolvedTypeHint for IntTypeHint {
+    fn hint_type_name(&self) -> &'static str {
+        "Int"
+    }
+
+    fn serialize_data(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap()
+    }
+}
+
+impl TypeValidationProvider for IntTypeHint {
     fn get_type_validation(&self) -> Option<TypeValidation> {
-        match self {
-            ResolvedTypeHint::Int { bits: _, range } => {
-                if let Some(r) = range {
-                    return Some(TypeValidation::Int {
-                        range: r.to_owned(),
-                    });
-                }
-                None
+        self.range.as_ref().map(|r| TypeValidation::Int {
+            range: r.to_owned(),
+        })
+    }
+}
+
+/// Float type hint implementation
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FloatTypeHint {
+    pub bits: Option<usize>,
+    pub range: Option<(f64, f64)>,
+}
+
+impl ResolvedTypeHint for FloatTypeHint {
+    fn hint_type_name(&self) -> &'static str {
+        "Float"
+    }
+
+    fn serialize_data(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap()
+    }
+}
+
+impl TypeValidationProvider for FloatTypeHint {
+    fn get_type_validation(&self) -> Option<TypeValidation> {
+        self.range.as_ref().map(|r| TypeValidation::Float {
+            range: r.to_owned(),
+        })
+    }
+}
+
+/// Decimal type hint implementation
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DecimalTypeHint {
+    pub precision: Option<usize>,
+    pub scale: Option<usize>,
+}
+
+impl ResolvedTypeHint for DecimalTypeHint {
+    fn hint_type_name(&self) -> &'static str {
+        "Decimal"
+    }
+
+    fn serialize_data(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap()
+    }
+}
+
+/// String type hint implementation
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StringTypeHint {
+    pub max_length: usize,
+}
+
+impl ResolvedTypeHint for StringTypeHint {
+    fn hint_type_name(&self) -> &'static str {
+        "String"
+    }
+
+    fn serialize_data(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap()
+    }
+}
+
+/// DateTime type hint implementation
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DateTimeTypeHint {
+    pub precision: usize,
+}
+
+impl ResolvedTypeHint for DateTimeTypeHint {
+    fn hint_type_name(&self) -> &'static str {
+        "DateTime"
+    }
+
+    fn serialize_data(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap()
+    }
+}
+
+/// Vector type hint implementation
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VectorTypeHint {
+    pub size: Option<usize>,
+    pub distance_function: Option<VectorDistanceFunction>,
+}
+
+impl ResolvedTypeHint for VectorTypeHint {
+    fn hint_type_name(&self) -> &'static str {
+        "Vector"
+    }
+
+    fn serialize_data(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap()
+    }
+}
+
+impl TypeValidationProvider for SerializableTypeHint {
+    fn get_type_validation(&self) -> Option<TypeValidation> {
+        let hint_ref = self.0.as_ref() as &dyn std::any::Any;
+
+        // Check if this is an IntTypeHint
+        if let Some(int_hint) = hint_ref.downcast_ref::<IntTypeHint>() {
+            if let Some(r) = &int_hint.range {
+                return Some(TypeValidation::Int {
+                    range: r.to_owned(),
+                });
             }
-            ResolvedTypeHint::Float { bits: _, range } => {
-                if let Some(r) = range {
-                    return Some(TypeValidation::Float {
-                        range: r.to_owned(),
-                    });
-                }
-                None
-            }
-            _ => None,
         }
+        // Check if this is a FloatTypeHint
+        else if let Some(float_hint) = hint_ref.downcast_ref::<FloatTypeHint>() {
+            if let Some(r) = &float_hint.range {
+                return Some(TypeValidation::Float {
+                    range: r.to_owned(),
+                });
+            }
+        }
+        None
     }
 }
 

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_annotations.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_annotations.snap
@@ -67,7 +67,8 @@ values:
               update: ~
               delete: ~
             type_hint:
-              Explicit:
+              type: Explicit
+              data:
                 dbtype: BIGINT
             unique_constraints: []
             indices: []
@@ -96,7 +97,8 @@ values:
               update: ~
               delete: ~
             type_hint:
-              String:
+              type: String
+              data:
                 max_length: 12
             unique_constraints: []
             indices: []
@@ -150,7 +152,8 @@ values:
               update: ~
               delete: ~
             type_hint:
-              Int:
+              type: Int
+              data:
                 bits: ~
                 range:
                   - 0
@@ -181,7 +184,8 @@ values:
               update: ~
               delete: ~
             type_hint:
-              DateTime:
+              type: DateTime
+              data:
                 precision: 4
             unique_constraints: []
             indices: []
@@ -209,7 +213,8 @@ values:
               update: ~
               delete: ~
             type_hint:
-              Decimal:
+              type: Decimal
+              data:
                 precision: 10
                 scale: 2
             unique_constraints: []
@@ -335,7 +340,8 @@ values:
               update: ~
               delete: ~
             type_hint:
-              Int:
+              type: Int
+              data:
                 bits: 16
                 range: ~
             unique_constraints: []
@@ -364,7 +370,8 @@ values:
               update: ~
               delete: ~
             type_hint:
-              Float:
+              type: Float
+              data:
                 bits: 24
                 range: ~
             unique_constraints: []

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_defaults.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/with_defaults.snap
@@ -67,7 +67,8 @@ values:
               update: ~
               delete: ~
             type_hint:
-              Explicit:
+              type: Explicit
+              data:
                 dbtype: BIGINT
             unique_constraints: []
             indices: []
@@ -221,7 +222,8 @@ values:
               update: ~
               delete: ~
             type_hint:
-              Explicit:
+              type: Explicit
+              data:
                 dbtype: BIGINT
             unique_constraints: []
             indices: []

--- a/crates/postgres-subsystem/postgres-graphql-builder/src/predicate_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/predicate_builder.rs
@@ -27,7 +27,7 @@ use std::collections::HashMap;
 use super::system_builder::SystemContextBuilding;
 
 use postgres_core_builder::resolved_type::{
-    ResolvedCompositeType, ResolvedType, ResolvedTypeEnv, ResolvedTypeHint,
+    ResolvedCompositeType, ResolvedType, ResolvedTypeEnv, VectorTypeHint,
 };
 use postgres_core_builder::shallow::Shallow;
 
@@ -278,12 +278,9 @@ fn expand_entity_type(
                 column_path_link,
                 access: Some(field.access.clone()),
                 vector_distance_function: resolved_field.type_hint.as_ref().and_then(|hint| {
-                    match hint {
-                        ResolvedTypeHint::Vector {
-                            distance_function, ..
-                        } => *distance_function,
-                        _ => None,
-                    }
+                    (hint.0.as_ref() as &dyn std::any::Any)
+                        .downcast_ref::<VectorTypeHint>()
+                        .and_then(|v| v.distance_function)
                 }),
             }
         })


### PR DESCRIPTION
This is a continuation of earlier changes to make primitive types extensible.

Key changes:
- Replace `ResolvedTypeHint` enum with `ResolvedTypeHint` trait and add implementations for hint types
- Add `PhysicalColumnTypeProvider` trait for column type determination and implementations for each primitive type
- Create registries for both type hint and physical column type providers and use those for dispatching