### PR TITLE
Remove unneeded code in predicate_builder

### DIFF
--- a/crates/postgres-subsystem/postgres-graphql-builder/src/predicate_builder.rs
+++ b/crates/postgres-subsystem/postgres-graphql-builder/src/predicate_builder.rs
@@ -449,10 +449,6 @@ lazy_static! {
 
         supported_operators.insert("Vector", Some(vec!["similar", "eq", "neq"]));
 
-        supported_operators.insert("Exograph", None);
-        supported_operators.insert("ExographPriv", None);
-        supported_operators.insert("Operation", None); // TODO: Re-examine if this is the best way (for both injected and interception)
-
         supported_operators
     };
 }


### PR DESCRIPTION
Since we separated primitive types from injected types in #1656, we long longer need to associated operators for injected types.