### PR TITLE
Make PrimitiveTypeProvider specify supported predicate operators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6915,7 +6915,6 @@ dependencies = [
  "core-plugin-shared",
  "exo-sql",
  "heck 0.5.0",
- "lazy_static",
  "postgres-core-builder",
  "postgres-core-model",
  "postgres-graphql-model",

--- a/crates/postgres-subsystem/postgres-graphql-builder/Cargo.toml
+++ b/crates/postgres-subsystem/postgres-graphql-builder/Cargo.toml
@@ -6,7 +6,6 @@ publish = false
 
 [dependencies]
 heck.workspace = true
-lazy_static.workspace = true
 
 core-model = { path = "../../core-subsystem/core-model" }
 core-model-builder = { path = "../../core-subsystem/core-model-builder" }


### PR DESCRIPTION
Move the responsibility to define operator supported (eq, neq, startsWith, etc.) to PrimitiveTypeProvider.