### PR TITLE
Make PrimitiveTypeProvider specify supported aggregates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6852,7 +6852,6 @@ dependencies = [
  "exo-sql",
  "heck 0.5.0",
  "insta",
- "lazy_static",
  "multiplatform_test",
  "pluralizer",
  "postgres-builder",

--- a/crates/postgres-subsystem/postgres-core-builder/Cargo.toml
+++ b/crates/postgres-subsystem/postgres-core-builder/Cargo.toml
@@ -10,7 +10,6 @@ serde.workspace = true
 serde_json.workspace = true
 codemap-diagnostic.workspace = true
 codemap.workspace = true
-lazy_static.workspace = true
 pluralizer.workspace = true
 
 core-model = { path = "../../core-subsystem/core-model" }


### PR DESCRIPTION
Move the responsibility to define aggrgations supported (eq, sum, avg, etc.) to PrimitiveTypeProvider.