### PR TITLE
Allow developers to specify the docker image when running tests

### DIFF
--- a/docs/docs/cli-reference/development/test.md
+++ b/docs/docs/cli-reference/development/test.md
@@ -13,4 +13,12 @@ Like the [yolo] mode, it will use the locally installed Postgres server or start
 exo test <directory> [pattern]
 ```
 
+You can control the database server that is used for testing by setting the `EXO_SQL_EPHEMERAL_DATABASE_LAUNCH_PREFERENCE` environment variable to one of the following values:
+- `prefer-local`: Use the locally installed Postgres server if available, otherwise use a Docker container.
+- `prefer-docker`: Use a Docker container if available, otherwise use the locally installed Postgres server.
+- `local-only`: Only use the locally installed Postgres server.
+- `docker-only`: Only use a Docker container.
+
+When using a Docker container, you can override the default Docker image (currently `pgvector/pgvector:pg14`) that is used by setting the `EXO_SQL_EPHEMERAL_DATABASE_DOCKER_IMAGE` environment variable.
+
 Please see the [testing](/production/testing.md) section for more information about writing tests.

--- a/libs/exo-sql/src/testing/docker.rs
+++ b/libs/exo-sql/src/testing/docker.rs
@@ -19,6 +19,8 @@ use super::{
     error::EphemeralDatabaseSetupError,
 };
 
+pub const EXO_SQL_EPHEMERAL_DATABASE_DOCKER_IMAGE: &str = "EXO_SQL_EPHEMERAL_DATABASE_DOCKER_IMAGE";
+
 pub struct DockerPostgresDatabaseServer {
     container_name: String,
     port: u16,
@@ -53,6 +55,9 @@ impl DockerPostgresDatabaseServer {
         // generate container name
         let container_name = format!("exograph-db-{}", generate_random_string());
 
+        let docker_image = std::env::var(EXO_SQL_EPHEMERAL_DATABASE_DOCKER_IMAGE)
+            .unwrap_or_else(|_| "pgvector/pgvector:pg14".to_string());
+
         // start postgres docker in background
         let mut db_background = std::process::Command::new("docker");
         let db_background = db_background
@@ -67,7 +72,7 @@ impl DockerPostgresDatabaseServer {
                 "POSTGRES_PASSWORD=exo",
                 "-p",
                 &format!("{port}:5432"),
-                "postgres",
+                &docker_image,
             ])
             .stdin(Stdio::null())
             .stdout(Stdio::piped())


### PR DESCRIPTION
Introduce a new env `EXO_SQL_EPHEMERAL_DATABASE_DOCKER_IMAGE` to override the default docker image (which is now changed to `pgvector/pgvector:pg14`.