### PR TITLE
Remove `ColumnTypeSpec` to use `PhysicalColumnType`

### DIFF
--- a/crates/cli/src/commands/schema/import/column_processor.rs
+++ b/crates/cli/src/commands/schema/import/column_processor.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
 
-use exo_sql::schema::column_spec::{ColumnSpec, ColumnTypeSpec};
+use exo_sql::schema::column_spec::ColumnSpec;
 
 use exo_sql::schema::table_spec::TableSpec;
 use exo_sql::{
-    FloatBits, FloatColumnType, IntBits, IntColumnType, NumericColumnType, PhysicalColumnTypeExt,
-    StringColumnType, TimeColumnType, TimestampColumnType, VectorColumnType,
+    FloatBits, FloatColumnType, IntBits, IntColumnType, NumericColumnType, StringColumnType,
+    TimeColumnType, TimestampColumnType, VectorColumnType,
 };
 
 use super::{ImportContext, ModelProcessor};
@@ -22,11 +22,11 @@ impl ModelProcessor<TableSpec> for ColumnSpec {
     ) -> Result<()> {
         // [@pk] [type-annotations] [name]: [data-type] = [default-value]
 
-        let column_type_name = context.type_name(&self.typ);
+        let column_type_name = context.column_type_name(self);
         let is_column_type_name_reference =
             matches!(column_type_name, ColumnTypeName::ReferenceType(_));
 
-        if let ColumnTypeSpec::Reference(reference) = &self.typ {
+        if let Some(reference) = &self.reference_spec {
             // The column was referring to a table, but that table is not in the context
             if !is_column_type_name_reference {
                 writeln!(
@@ -43,7 +43,7 @@ impl ModelProcessor<TableSpec> for ColumnSpec {
             write!(writer, "@pk ")?;
         }
 
-        if let ColumnTypeSpec::Reference(reference) = &self.typ {
+        if let Some(reference) = &self.reference_spec {
             if parent.name == reference.foreign_table_name {
                 let cardinality_annotation =
                     if self.unique_constraints.is_empty() || self.is_nullable {
@@ -59,10 +59,13 @@ impl ModelProcessor<TableSpec> for ColumnSpec {
             write!(writer, "@unique ")?;
         }
 
-        let annots = type_annotation(&self.typ);
+        // Only add type annotations for non-reference columns
+        if self.reference_spec.is_none() {
+            let annots = type_annotation(self.typ.as_ref());
 
-        if !annots.is_empty() {
-            write!(writer, "{} ", annots)?;
+            if !annots.is_empty() {
+                write!(writer, "{} ", annots)?;
+            }
         }
 
         let (standard_field_name, needs_column_annotation) = context.standard_field_naming(self);
@@ -99,57 +102,46 @@ pub enum ColumnTypeName {
     ReferenceType(String),
 }
 
-fn type_annotation(column_type: &ColumnTypeSpec) -> String {
-    match column_type {
-        ColumnTypeSpec::Direct(physical_type) => {
-            let inner_type = physical_type.inner();
-            if let Some(int_type) = inner_type.as_any().downcast_ref::<IntColumnType>() {
-                match int_type.bits {
-                    IntBits::_16 => "@bits16".to_string(),
-                    IntBits::_32 => "".to_string(),
-                    IntBits::_64 => "@bits64".to_string(),
-                }
-            } else if let Some(float_type) = inner_type.as_any().downcast_ref::<FloatColumnType>() {
-                match float_type.bits {
-                    FloatBits::_24 => "@singlePrecision".to_string(),
-                    FloatBits::_53 => "@doublePrecision".to_string(),
-                }
-            } else if let Some(numeric_type) =
-                inner_type.as_any().downcast_ref::<NumericColumnType>()
-            {
-                let precision_part = numeric_type.precision.map(|p| format!("@precision({p})"));
-                let scale_part = numeric_type.scale.map(|s| format!("@scale({s})"));
-                match (precision_part, scale_part) {
-                    (Some(precision), Some(scale)) => format!("{precision} {scale}"),
-                    (Some(precision), None) => precision,
-                    (None, Some(scale)) => scale,
-                    (None, None) => "".to_string(),
-                }
-            } else if let Some(string_type) = inner_type.as_any().downcast_ref::<StringColumnType>()
-            {
-                match string_type.max_length {
-                    Some(max_length) => format!("@maxLength({max_length})"),
-                    None => "".to_string(),
-                }
-            } else if let Some(timestamp_type) =
-                inner_type.as_any().downcast_ref::<TimestampColumnType>()
-            {
-                match timestamp_type.precision {
-                    Some(precision) => format!("@precision({precision})"),
-                    None => "".to_string(),
-                }
-            } else if let Some(time_type) = inner_type.as_any().downcast_ref::<TimeColumnType>() {
-                match time_type.precision {
-                    Some(precision) => format!("@precision({precision})"),
-                    None => "".to_string(),
-                }
-            } else if let Some(vector_type) = inner_type.as_any().downcast_ref::<VectorColumnType>()
-            {
-                format!("@size({})", vector_type.size)
-            } else {
-                "".to_string()
-            }
+fn type_annotation(physical_type: &dyn exo_sql::PhysicalColumnType) -> String {
+    let inner_type = physical_type;
+    if let Some(int_type) = inner_type.as_any().downcast_ref::<IntColumnType>() {
+        match int_type.bits {
+            IntBits::_16 => "@bits16".to_string(),
+            IntBits::_32 => "".to_string(),
+            IntBits::_64 => "@bits64".to_string(),
         }
-        _ => "".to_string(),
+    } else if let Some(float_type) = inner_type.as_any().downcast_ref::<FloatColumnType>() {
+        match float_type.bits {
+            FloatBits::_24 => "@singlePrecision".to_string(),
+            FloatBits::_53 => "@doublePrecision".to_string(),
+        }
+    } else if let Some(numeric_type) = inner_type.as_any().downcast_ref::<NumericColumnType>() {
+        let precision_part = numeric_type.precision.map(|p| format!("@precision({p})"));
+        let scale_part = numeric_type.scale.map(|s| format!("@scale({s})"));
+        match (precision_part, scale_part) {
+            (Some(precision), Some(scale)) => format!("{precision} {scale}"),
+            (Some(precision), None) => precision,
+            (None, Some(scale)) => scale,
+            (None, None) => "".to_string(),
+        }
+    } else if let Some(string_type) = inner_type.as_any().downcast_ref::<StringColumnType>() {
+        match string_type.max_length {
+            Some(max_length) => format!("@maxLength({max_length})"),
+            None => "".to_string(),
+        }
+    } else if let Some(timestamp_type) = inner_type.as_any().downcast_ref::<TimestampColumnType>() {
+        match timestamp_type.precision {
+            Some(precision) => format!("@precision({precision})"),
+            None => "".to_string(),
+        }
+    } else if let Some(time_type) = inner_type.as_any().downcast_ref::<TimeColumnType>() {
+        match time_type.precision {
+            Some(precision) => format!("@precision({precision})"),
+            None => "".to_string(),
+        }
+    } else if let Some(vector_type) = inner_type.as_any().downcast_ref::<VectorColumnType>() {
+        format!("@size({})", vector_type.size)
+    } else {
+        "".to_string()
     }
 }

--- a/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
@@ -495,12 +495,11 @@ fn determine_column_type<'a>(
     if let Some(hint) = &field.type_hint {
         let hint_ref = hint.0.as_ref() as &dyn std::any::Any;
         if let Some(explicit) = hint_ref.downcast_ref::<ExplicitTypeHint>() {
-            return exo_sql::schema::column_spec::ColumnTypeSpec::from_string(
+            return exo_sql::schema::column_spec::physical_column_type_from_string(
                 &explicit.dbtype,
                 &vec![],
             )
-            .unwrap()
-            .to_database_type();
+            .unwrap();
         }
     }
 

--- a/libs/exo-sql/src/schema/test_helper.rs
+++ b/libs/exo-sql/src/schema/test_helper.rs
@@ -3,14 +3,13 @@
 use crate::SchemaObjectName;
 use crate::sql::physical_column_type::{IntBits, IntColumnType, JsonColumnType, StringColumnType};
 
-use super::column_spec::{
-    ColumnAutoincrement, ColumnDefault, ColumnReferenceSpec, ColumnSpec, ColumnTypeSpec,
-};
+use super::column_spec::{ColumnAutoincrement, ColumnDefault, ColumnReferenceSpec, ColumnSpec};
 
 pub fn pk_column(name: impl Into<String>) -> ColumnSpec {
     ColumnSpec {
         name: name.into(),
-        typ: ColumnTypeSpec::Direct(Box::new(IntColumnType { bits: IntBits::_16 })),
+        typ: Box::new(IntColumnType { bits: IntBits::_16 }),
+        reference_spec: None,
         is_pk: true,
         is_nullable: false,
         unique_constraints: vec![],
@@ -26,7 +25,8 @@ pub fn pk_reference_column(
 ) -> ColumnSpec {
     ColumnSpec {
         name: name.into(),
-        typ: ColumnTypeSpec::Reference(ColumnReferenceSpec {
+        typ: Box::new(IntColumnType { bits: IntBits::_16 }),
+        reference_spec: Some(ColumnReferenceSpec {
             foreign_table_name: SchemaObjectName::new(
                 foreign_table_name,
                 foreign_table_schema_name,
@@ -45,7 +45,8 @@ pub fn pk_reference_column(
 pub fn int_column(name: impl Into<String>) -> ColumnSpec {
     ColumnSpec {
         name: name.into(),
-        typ: ColumnTypeSpec::Direct(Box::new(IntColumnType { bits: IntBits::_16 })),
+        typ: Box::new(IntColumnType { bits: IntBits::_16 }),
+        reference_spec: None,
         is_pk: false,
         is_nullable: false,
         unique_constraints: vec![],
@@ -57,7 +58,8 @@ pub fn int_column(name: impl Into<String>) -> ColumnSpec {
 pub fn string_column(name: impl Into<String>) -> ColumnSpec {
     ColumnSpec {
         name: name.into(),
-        typ: ColumnTypeSpec::Direct(Box::new(StringColumnType { max_length: None })),
+        typ: Box::new(StringColumnType { max_length: None }),
+        reference_spec: None,
         is_pk: false,
         is_nullable: false,
         unique_constraints: vec![],
@@ -69,7 +71,8 @@ pub fn string_column(name: impl Into<String>) -> ColumnSpec {
 pub fn json_column(name: impl Into<String>) -> ColumnSpec {
     ColumnSpec {
         name: name.into(),
-        typ: ColumnTypeSpec::Direct(Box::new(JsonColumnType)),
+        typ: Box::new(JsonColumnType),
+        reference_spec: None,
         is_pk: false,
         is_nullable: false,
         unique_constraints: vec![],


### PR DESCRIPTION
A field can be both a pk and reference column. The existing design didn't support this cleanly.

So refactor to have `ColumnSpec` hold an optional `ColumnReferenceSpec`. This left `ColumnTypeSpec` with only one variant (`Direct`), which then led to the removal of `ColumnTypeSpec`.