### PR TITLE
fix: handle importing tables with composite foreign keys

### DIFF
--- a/crates/cli/src/commands/schema/import/test-data/composite-pk/index.expected.exo
+++ b/crates/cli/src/commands/schema/import/test-data/composite-pk/index.expected.exo
@@ -1,0 +1,18 @@
+@postgres
+module Database {
+  @access(query=true, mutation=false)
+  type Address {
+    @pk street: String
+    @pk city: String
+    @pk state: String
+    @pk zip: Int
+    people: Set<Person>?
+  }
+
+  @access(query=true, mutation=false)
+  type Person {
+    @pk name: String
+    age: Int
+    address: Address?
+  }
+}

--- a/crates/cli/src/commands/schema/import/test-data/composite-pk/schema.sql
+++ b/crates/cli/src/commands/schema/import/test-data/composite-pk/schema.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "people" (
+	"name" TEXT PRIMARY KEY,
+	"age" INT NOT NULL,
+	"address_street" TEXT,
+	"address_city" TEXT,
+	"address_state" TEXT,
+	"address_zip" INT
+);
+
+CREATE TABLE "addresses" (
+	"street" TEXT,
+	"city" TEXT,
+	"state" TEXT,
+	"zip" INT,
+	PRIMARY KEY ("street", "city", "state", "zip")
+);
+
+ALTER TABLE "people" ADD CONSTRAINT "people_address_fk" FOREIGN KEY ("address_city", "address_state", "address_street", "address_zip") REFERENCES "addresses" ("city", "state", "street", "zip");
+

--- a/libs/exo-sql/src/schema/constraint.rs
+++ b/libs/exo-sql/src/schema/constraint.rs
@@ -16,16 +16,19 @@ use crate::{
     SchemaObjectName, database_error::DatabaseError, sql::connect::database_client::DatabaseClient,
 };
 
+#[derive(Debug)]
 pub(super) struct PrimaryKeyConstraint {
     pub(super) _constraint_name: String,
     pub(super) columns: Vec<String>,
 }
 
+#[derive(Debug)]
 pub(super) struct ForeignKeyConstraintColumnPair {
     pub(super) self_column: String,
     pub(super) foreign_column: String,
 }
 
+#[derive(Debug)]
 pub(super) struct ForeignKeyConstraint {
     pub(super) constraint_name: String,
     pub(super) column_pairs: Vec<ForeignKeyConstraintColumnPair>,
@@ -38,6 +41,7 @@ pub(super) struct UniqueConstraint {
     pub(super) columns: Vec<String>,
 }
 
+#[derive(Debug)]
 pub(super) struct Constraints {
     pub(super) primary_key: Option<PrimaryKeyConstraint>,
     pub(super) foreign_constraints: Vec<ForeignKeyConstraint>,


### PR DESCRIPTION
When importing tables with composite foreign keys (multiple columns referencing the same table), we were creating duplicate reference fields - one for each column in the composite key. This change picks only the first column from each group, preventing duplicate fields in the generated model.