### PR TITLE
feat: Support customizing column names for composite pk foreign keys

### DIFF
--- a/crates/builder/grammar/grammar.js
+++ b/crates/builder/grammar/grammar.js
@@ -177,6 +177,7 @@ module.exports = grammar({
       prec(relational_level, $.relational_op),
       $.selection,
       $.literal,
+      $.object_literal,
     ),
     parenthetical: $ => seq("(", field("expression", $.expression), ")"),
     selection: $ => choice(
@@ -275,6 +276,16 @@ module.exports = grammar({
       $.literal_number,
       $.literal_boolean,
       $.literal_null
+    ),
+    object_literal: $ => seq(
+      "{",
+      optional(commaSep($.object_pair)),
+      "}"
+    ),
+    object_pair: $ => seq(
+      field("key", choice($.term, $.literal_str)),
+      ":",
+      field("value", $.expression)
     ),
     comment: $ => choice(
       seq('//', /.*/),

--- a/crates/builder/src/builder/interceptor_weaver.rs
+++ b/crates/builder/src/builder/interceptor_weaver.rs
@@ -90,6 +90,9 @@ fn matches(expr: &AstExpr<Typed>, operation_name: &str, operation_kind: Operatio
             panic!("List not supported in interceptor expression")
         }
         AstExpr::NullLiteral(_) => panic!("NullLiteral not supported in interceptor expression"),
+        AstExpr::ObjectLiteral(_, _) => {
+            panic!("ObjectLiteral not supported in interceptor expression")
+        }
     }
 }
 

--- a/crates/builder/src/typechecker/expression.rs
+++ b/crates/builder/src/typechecker/expression.rs
@@ -32,6 +32,12 @@ impl TypecheckFrom<AstExpr<Untyped>> for AstExpr<Typed> {
             AstExpr::NumberLiteral(v, s) => AstExpr::NumberLiteral(v.clone(), *s),
             AstExpr::StringList(v, s) => AstExpr::StringList(v.clone(), s.clone()),
             AstExpr::NullLiteral(s) => AstExpr::NullLiteral(*s),
+            AstExpr::ObjectLiteral(m, s) => AstExpr::ObjectLiteral(
+                m.iter()
+                    .map(|(k, v)| (k.clone(), AstExpr::shallow(v)))
+                    .collect(),
+                *s,
+            ),
         }
     }
 
@@ -52,7 +58,8 @@ impl TypecheckFrom<AstExpr<Untyped>> for AstExpr<Typed> {
             | AstExpr::StringLiteral(_, _)
             | AstExpr::BooleanLiteral(_, _)
             | AstExpr::NumberLiteral(_, _)
-            | AstExpr::NullLiteral(_) => false,
+            | AstExpr::NullLiteral(_)
+            | AstExpr::ObjectLiteral(_, _) => false,
         }
     }
 }

--- a/crates/core-subsystem/core-model-builder/src/ast/ast_types.rs
+++ b/crates/core-subsystem/core-model-builder/src/ast/ast_types.rs
@@ -349,6 +349,13 @@ pub enum AstExpr<T: NodeTypedness> {
         #[serde(default = "default_span")]
         Span,
     ),
+    ObjectLiteral(
+        HashMap<String, AstExpr<T>>,
+        #[serde(skip_serializing)]
+        #[serde(skip_deserializing)]
+        #[serde(default = "default_span")]
+        Span,
+    ),
 }
 
 impl<T: NodeTypedness> AstExpr<T> {
@@ -372,6 +379,7 @@ impl<T: NodeTypedness> AstExpr<T> {
                 }
                 span
             }
+            AstExpr::ObjectLiteral(_, s) => *s,
         }
     }
 }

--- a/crates/core-subsystem/core-model-builder/src/typechecker/expression.rs
+++ b/crates/core-subsystem/core-model-builder/src/typechecker/expression.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use core_model::primitive_type::{self, PrimitiveType};
+use core_model::primitive_type::{self, JsonType, PrimitiveType};
 
 use crate::ast::ast_types::AstExpr;
 
@@ -36,6 +36,7 @@ impl AstExpr<Typed> {
                 PrimitiveType::Plain(primitive_type::STRING_TYPE),
             ))),
             AstExpr::NullLiteral(_) => Type::Null,
+            AstExpr::ObjectLiteral(_, _) => Type::Primitive(PrimitiveType::Plain(&JsonType)),
         }
     }
 

--- a/crates/postgres-subsystem/postgres-builder/src/plugin.rs
+++ b/crates/postgres-subsystem/postgres-builder/src/plugin.rs
@@ -69,7 +69,10 @@ impl SubsystemBuilder for PostgresSubsystemBuilder {
                     targets: &[AnnotationTarget::Field],
                     no_params: false,
                     single_params: true,
-                    mapped_params: None,
+                    mapped_params: Some(&[MappedAnnotationParamSpec {
+                        name: "mapping",
+                        optional: true,
+                    }]),
                 },
             ),
             (

--- a/crates/postgres-subsystem/postgres-core-builder/src/access/database_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/access/database_builder.rs
@@ -222,6 +222,9 @@ fn compute_primitive_db_expr(
         AstExpr::StringList(_, _) => Err(ModelBuildingError::Generic(
             "Access expressions do not support lists yet".to_string(),
         )),
+        AstExpr::ObjectLiteral(_, _) => Err(ModelBuildingError::Generic(
+            "Access expressions do not support object literals".to_string(),
+        )),
         AstExpr::LogicalOp(_) => unreachable!(), // Parser ensures that the two sides are primitive expressions
         AstExpr::RelationalOp(_) => unreachable!(), // Parser ensures that the two sides are primitive expressions
     }

--- a/crates/postgres-subsystem/postgres-core-builder/src/access/precheck_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/access/precheck_builder.rs
@@ -197,6 +197,9 @@ pub fn compute_precheck_predicate_expression(
         AstExpr::NullLiteral(_) => Err(ModelBuildingError::Generic(
             "Top-level expression cannot be a null literal".to_string(),
         )),
+        AstExpr::ObjectLiteral(_, _) => Err(ModelBuildingError::Generic(
+            "Top-level expression cannot be an object literal".to_string(),
+        )),
     }
 }
 
@@ -306,6 +309,9 @@ fn compute_primitive_precheck_expr(
         )),
         AstExpr::StringList(_, _) => Err(ModelBuildingError::Generic(
             "Access expressions do not support lists yet".to_string(),
+        )),
+        AstExpr::ObjectLiteral(_, _) => Err(ModelBuildingError::Generic(
+            "Access expressions do not support object literals".to_string(),
         )),
         AstExpr::LogicalOp(_) => unreachable!(), // Parser ensures that the two sides are primitive expressions
         AstExpr::RelationalOp(_) => unreachable!(), // Parser ensures that the two sides are primitive expressions

--- a/crates/subsystem-util/subsystem-model-builder-util/src/builder/access_utils.rs
+++ b/crates/subsystem-util/subsystem-model-builder-util/src/builder/access_utils.rs
@@ -130,6 +130,9 @@ fn compute_primitive_expr(
         AstExpr::StringList(_, _) => Err(ModelBuildingError::Generic(
             "Module access expressions do not support lists yet".to_string(),
         )),
+        AstExpr::ObjectLiteral(_, _) => Err(ModelBuildingError::Generic(
+            "Module access expressions do not support object literals".to_string(),
+        )),
         AstExpr::LogicalOp(_) => unreachable!(), // Parser has already ensures that the two sides are primitive expressions
         AstExpr::RelationalOp(_) => unreachable!(), // Parser has already ensures that the two sides are primitive expressions
     }

--- a/docs/docs/postgres/customizing-types.md
+++ b/docs/docs/postgres/customizing-types.md
@@ -227,6 +227,8 @@ module ConcertModule {
 }
 ```
 
+If you use a [composite primary key](#composite-primary-key), you can specify a mapping for the foreign key columns as we will see [later](#customizing-foreign-key-column-names) using a variant of the `@column` annotation.
+
 ### Assigning primary key
 
 The `@pk` annotation designates the primary key of a type. Typically, you will mark one of the fields as the primary key, but Exograph supports composite primary keys as well.
@@ -325,6 +327,43 @@ module PeopleDatabase {
 ```
 
 Other than marking multiple fields with `@pk`, all other aspects of the primary key are the same as for a single primary key.
+
+### Customizing foreign key column names
+
+When you introduce a field of a type with composite primary key (such as the `address` field in the `Person` type in the above example), Exograph automatically generates column names by combining the field name with each primary key field. For example, the generated column names in the `people` table would be `address_street`, `address_city`, `address_state`, and `address_zip`.
+
+You can customize these column names using the `@column(mapping=...)` annotation with an object literal that maps each primary key field to a custom column name. For example, if you want to map the `address` field to the `addr_street`, `addr_city`, `addr_state`, and `addr_zip` columns, you can use the following definition:
+
+```exo
+@postgres
+module PeopleDatabase {
+  type Person {
+    @pk firstName: String
+    @pk lastName: String
+    age: Int
+    @column(mapping={street: "addr_street", city: "addr_city", state: "addr_state", zip: "addr_zip"}) 
+    address: Address?
+  }
+
+  type Address {
+    @pk street: String
+    @pk city: String
+    @pk state: String
+    @pk zip: Int
+    info: String?
+  }
+}
+```
+
+With this setup, the foreign key columns in the `people` table will be named `addr_street`, `addr_city`, `addr_state`, and `addr_zip` instead of the default names.
+
+You can also provide a partial mapping. Any primary key fields not specified in the mapping will use the default naming convention:
+
+```exo
+@column(mapping={zip: "postal_code"}) address: Address?
+```
+
+This would generate columns `address_street`, `address_city`, `address_state`, and `postal_code`.
 
 ### Specifying a default value
 

--- a/integration-tests/composite-pk/scalars/no-auth-custom-columns/schema-tests
+++ b/integration-tests/composite-pk/scalars/no-auth-custom-columns/schema-tests
@@ -1,0 +1,1 @@
+../no-auth/schema-tests

--- a/integration-tests/composite-pk/scalars/no-auth-custom-columns/src/index.exo
+++ b/integration-tests/composite-pk/scalars/no-auth-custom-columns/src/index.exo
@@ -1,0 +1,20 @@
+@postgres
+module PeopleDatabase {
+  @access(true)
+  type Person {
+    @pk firstName: String
+    @pk lastName: String
+    age: Int
+    @column(mapping={zip: "azip", city: "acity", state: "astate", street: "astreet"}) address: Address?
+  }
+
+  @access(true)
+  type Address {
+    @pk street: String
+    @pk city: String
+    @pk state: String
+    @pk zip: Int
+    info: String?
+    people: Set<Person>?
+  }
+}

--- a/integration-tests/composite-pk/scalars/no-auth-custom-columns/tests
+++ b/integration-tests/composite-pk/scalars/no-auth-custom-columns/tests
@@ -1,0 +1,1 @@
+../no-auth/tests


### PR DESCRIPTION
You can customize column names using the `@column(mapping=...)` annotation with an object literal that maps each primary key field to a custom column name. For example, if you want to map the `address` field to the `addr_street`, `addr_city`, `addr_state`, and `addr_zip` columns, you can use the following definition:

```exo
@postgres
module PeopleDatabase {
  type Person {
    @pk firstName: String
    @pk lastName: String
    age: Int
    @column(mapping={street: "addr_street", city: "addr_city", state: "addr_state", zip: "addr_zip"})
    address: Address?
  }

  type Address {
    @pk street: String
    @pk city: String
    @pk state: String
    @pk zip: Int
    info: String?
  }
}
```

With this setup, the foreign key columns in the `people` table will be named `addr_street`, `addr_city`, `addr_state`, and `addr_zip` instead of the default names.

You can also provide a partial mapping. Any primary key fields not specified in the mapping will use the default naming convention:

```exo
@column(mapping={zip: "postal_code"}) address: Address?
```

This would generate columns `address_street`, `address_city`, `address_state`, and `postal_code`.