### PR TITLE
fix: Remove location sensitivity for foreign fields

### DIFF
--- a/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
@@ -513,6 +513,8 @@ fn compute_many_to_one_relation(
 
                     let field_alias = field.name.to_snake_case().to_plural();
 
+                    assert_eq!(self_column_ids.len(), foreign_pk_column_ids.len());
+
                     Some(ManyToOne::new(
                         self_column_ids
                             .into_iter()

--- a/crates/postgres-subsystem/postgres-core-builder/src/type_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/type_builder.rs
@@ -919,7 +919,7 @@ fn compute_many_to_one(
                 .get_column_id(foreign_table_id, column_name)
                 .ok_or(ModelBuildingError::Generic(format!(
                     "Column `{}` not found",
-                    field.column_names[0]
+                    column_name
                 )))
         })
         .collect();
@@ -977,7 +977,14 @@ fn compute_one_to_many_relation(
     )?;
 
     let relation = relation_id.deref(&building.database);
-    assert_eq!(relation.column_pairs.len(), foreign_pk_field_ids.len());
+    if relation.column_pairs.len() != foreign_pk_field_ids.len() {
+        return Err(ModelBuildingError::Generic(format!(
+            "Mismatch between number of columns in relation ({}) and number of foreign PK fields ({}) for field '{}'",
+            relation.column_pairs.len(),
+            foreign_pk_field_ids.len(),
+            field.name
+        )));
+    }
 
     Ok(PostgresRelation::ManyToOne {
         relation: ManyToOneRelation {

--- a/crates/postgres-subsystem/postgres-core-model/src/relation.rs
+++ b/crates/postgres-subsystem/postgres-core-model/src/relation.rs
@@ -52,7 +52,7 @@ pub struct ManyToOneRelation {
     // - cardinality: Unbounded
     // - foreign_pk_field_ids: [Venue.id]
     // - relation_id.self_column_id: concerts.venue_id
-    // - relation_id.foreign_pk_column_id: venues.id
+    // - relation_id.foreign_pk_column_ids: [venues.id]
     pub cardinality: RelationCardinality,
     pub foreign_entity_id: SerializableSlabIndex<EntityType>,
     pub foreign_pk_field_ids: Vec<EntityFieldId>,

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/create_data_param_mapper.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/create_data_param_mapper.rs
@@ -217,6 +217,8 @@ async fn map_self_column<'a>(
             let ManyToOne { column_pairs, .. } =
                 relation_id.deref(&subsystem.core_subsystem.database);
 
+            assert_eq!(column_pairs.len(), foreign_pk_field_ids.len());
+
             let foreign_type_pk_field_name = column_pairs
                 .iter()
                 .zip(foreign_pk_field_ids)

--- a/crates/postgres-subsystem/postgres-graphql-resolver/src/create_data_param_mapper.rs
+++ b/crates/postgres-subsystem/postgres-graphql-resolver/src/create_data_param_mapper.rs
@@ -217,7 +217,13 @@ async fn map_self_column<'a>(
             let ManyToOne { column_pairs, .. } =
                 relation_id.deref(&subsystem.core_subsystem.database);
 
-            assert_eq!(column_pairs.len(), foreign_pk_field_ids.len());
+            if column_pairs.len() != foreign_pk_field_ids.len() {
+                return Err(PostgresExecutionError::Generic(format!(
+                    "Mismatch between number of columns in relation ({}) and number of foreign PK fields ({})",
+                    column_pairs.len(),
+                    foreign_pk_field_ids.len()
+                )));
+            }
 
             let foreign_type_pk_field_name = column_pairs
                 .iter()

--- a/integration-tests/shared-fk/simple/schema-tests/introspection.expected.graphql
+++ b/integration-tests/shared-fk/simple/schema-tests/introspection.expected.graphql
@@ -1,0 +1,311 @@
+type Member {
+  memberId: String!
+  memberTenantId: String!
+  memberName: String
+  memberships(where: MembershipFilter, orderBy: [MembershipOrdering!], limit: Int, offset: Int): [Membership!]!
+  membershipsAgg(where: MembershipFilter): MembershipAgg
+}
+
+"""An aggregate for the `Member` type."""
+type MemberAgg {
+  memberId: StringAgg
+  memberTenantId: StringAgg
+  memberName: StringAgg
+}
+
+input MemberCreationInput {
+  memberId: String!
+  memberTenantId: String!
+  memberName: String
+  memberships: [MembershipCreationInputFromMember!]!
+}
+
+"""
+Predicate for the `Member` type parameter. 
+If a field is omitted, no filter is applied for that field.
+To check a field against null, use a `<field name>: null` filter
+"""
+input MemberFilter {
+  memberId: StringFilter
+  memberTenantId: StringFilter
+  memberName: StringFilter
+  memberships: MembershipFilter
+  and: [MemberFilter!]
+  or: [MemberFilter!]
+  not: MemberFilter
+}
+
+input MemberOrdering {
+  memberId: Ordering
+  memberTenantId: Ordering
+  memberName: Ordering
+}
+
+input MemberReferenceInput {
+  memberId: String!
+  memberTenantId: String!
+}
+
+input MemberUpdateInput {
+  memberId: String
+  memberTenantId: String
+  memberName: String
+  memberships: MembershipUpdateInputFromMember
+}
+
+type Membership {
+  membershipId: String!
+  membershipTenantId: String!
+  member: Member
+  membershipName: String
+}
+
+"""An aggregate for the `Membership` type."""
+type MembershipAgg {
+  membershipId: StringAgg
+  membershipTenantId: StringAgg
+  membershipName: StringAgg
+}
+
+input MembershipCreationInput {
+  membershipId: String!
+  membershipTenantId: String!
+  member: MemberReferenceInput
+  membershipName: String
+}
+
+input MembershipCreationInputFromMember {
+  membershipId: String!
+  membershipTenantId: String!
+  membershipName: String
+}
+
+"""
+Predicate for the `Membership` type parameter. 
+If a field is omitted, no filter is applied for that field.
+To check a field against null, use a `<field name>: null` filter
+"""
+input MembershipFilter {
+  membershipId: StringFilter
+  membershipTenantId: StringFilter
+  member: MemberFilter
+  membershipName: StringFilter
+  and: [MembershipFilter!]
+  or: [MembershipFilter!]
+  not: MembershipFilter
+}
+
+input MembershipOrdering {
+  membershipId: Ordering
+  membershipTenantId: Ordering
+  member: [MemberOrdering!]
+  membershipName: Ordering
+}
+
+input MembershipReferenceInput {
+  membershipId: String!
+  membershipTenantId: String!
+}
+
+input MembershipUpdateInput {
+  membershipId: String
+  membershipTenantId: String
+  member: MemberReferenceInput
+  membershipName: String
+}
+
+input MembershipUpdateInputFromMember {
+  create: [MembershipCreationInputFromMember!]
+  update: [MembershipUpdateInputFromMemberNested!]
+  delete: [MembershipReferenceInput!]
+}
+
+input MembershipUpdateInputFromMemberNested {
+  membershipId: String!
+  membershipTenantId: String!
+  membershipName: String
+}
+
+enum Ordering {
+  ASC
+  DESC
+}
+
+type StringAgg {
+  min: String
+  max: String
+  count: Int
+}
+
+input StringFilter {
+  eq: String
+  neq: String
+  lt: String
+  lte: String
+  gt: String
+  gte: String
+  like: String
+  ilike: String
+  startsWith: String
+  endsWith: String
+}
+
+type Tenant {
+  tenantId: String!
+  tenantName: String
+}
+
+"""An aggregate for the `Tenant` type."""
+type TenantAgg {
+  tenantId: StringAgg
+  tenantName: StringAgg
+}
+
+input TenantCreationInput {
+  tenantId: String!
+  tenantName: String
+}
+
+"""
+Predicate for the `Tenant` type parameter. 
+If a field is omitted, no filter is applied for that field.
+To check a field against null, use a `<field name>: null` filter
+"""
+input TenantFilter {
+  tenantId: StringFilter
+  tenantName: StringFilter
+  and: [TenantFilter!]
+  or: [TenantFilter!]
+  not: TenantFilter
+}
+
+input TenantOrdering {
+  tenantId: Ordering
+  tenantName: Ordering
+}
+
+input TenantUpdateInput {
+  tenantId: String
+  tenantName: String
+}
+
+type Query {
+  """Get a single `Member` given primary key fields"""
+  member(memberId: String!, memberTenantId: String!): Member
+
+  """
+  Get multiple `Member`s given the provided `where` filter, order by, limit, and offset
+  """
+  members(where: MemberFilter, orderBy: [MemberOrdering!], limit: Int, offset: Int): [Member!]!
+
+  """
+  Get the aggregate value of the selected fields over all `Member`s given the provided `where` filter
+  """
+  membersAgg(where: MemberFilter): MemberAgg!
+
+  """Get a single `Membership` given primary key fields"""
+  membership(membershipId: String!, membershipTenantId: String!): Membership
+
+  """
+  Get multiple `Membership`s given the provided `where` filter, order by, limit, and offset
+  """
+  memberships(where: MembershipFilter, orderBy: [MembershipOrdering!], limit: Int, offset: Int): [Membership!]!
+
+  """
+  Get the aggregate value of the selected fields over all `Membership`s given the provided `where` filter
+  """
+  membershipsAgg(where: MembershipFilter): MembershipAgg!
+
+  """Get a single `Tenant` given primary key fields"""
+  tenant(tenantId: String!): Tenant
+
+  """
+  Get multiple `Tenant`s given the provided `where` filter, order by, limit, and offset
+  """
+  tenants(where: TenantFilter, orderBy: [TenantOrdering!], limit: Int, offset: Int): [Tenant!]!
+
+  """
+  Get the aggregate value of the selected fields over all `Tenant`s given the provided `where` filter
+  """
+  tenantsAgg(where: TenantFilter): TenantAgg!
+}
+
+type Mutation {
+  """
+  Create a new Member. Check the `MemberCreationInput` type for the expected shape of the data.
+  """
+  createMember(data: MemberCreationInput!): Member!
+
+  """
+  Create multiple Members. Check the `MemberCreationInput` type for the expected shape of the data.
+  """
+  createMembers(data: [MemberCreationInput!]!): [Member!]!
+
+  """
+  Create a new Membership. Check the `MembershipCreationInput` type for the expected shape of the data.
+  """
+  createMembership(data: MembershipCreationInput!): Membership!
+
+  """
+  Create multiple Memberships. Check the `MembershipCreationInput` type for the expected shape of the data.
+  """
+  createMemberships(data: [MembershipCreationInput!]!): [Membership!]!
+
+  """
+  Create a new Tenant. Check the `TenantCreationInput` type for the expected shape of the data.
+  """
+  createTenant(data: TenantCreationInput!): Tenant!
+
+  """
+  Create multiple Tenants. Check the `TenantCreationInput` type for the expected shape of the data.
+  """
+  createTenants(data: [TenantCreationInput!]!): [Tenant!]!
+
+  """Delete the Member with the provided primary key."""
+  deleteMember(memberId: String!, memberTenantId: String!): Member
+
+  """Delete multiple Members matching the provided `where` filter."""
+  deleteMembers(where: MemberFilter): [Member!]!
+
+  """Delete the Membership with the provided primary key."""
+  deleteMembership(membershipId: String!, membershipTenantId: String!): Membership
+
+  """Delete multiple Memberships matching the provided `where` filter."""
+  deleteMemberships(where: MembershipFilter): [Membership!]!
+
+  """Delete the Tenant with the provided primary key."""
+  deleteTenant(tenantId: String!): Tenant
+
+  """Delete multiple Tenants matching the provided `where` filter."""
+  deleteTenants(where: TenantFilter): [Tenant!]!
+
+  """
+  Update the Member with the provided primary key with the provided data. Any fields not provided will remain unchanged.
+  """
+  updateMember(memberId: String!, memberTenantId: String!, data: MemberUpdateInput!): Member
+
+  """
+  Update multiple Members matching the provided `where` filter with the provided data. Any fields not provided will remain unchanged.
+  """
+  updateMembers(where: MemberFilter, data: MemberUpdateInput!): [Member!]!
+
+  """
+  Update the Membership with the provided primary key with the provided data. Any fields not provided will remain unchanged.
+  """
+  updateMembership(membershipId: String!, membershipTenantId: String!, data: MembershipUpdateInput!): Membership
+
+  """
+  Update multiple Memberships matching the provided `where` filter with the provided data. Any fields not provided will remain unchanged.
+  """
+  updateMemberships(where: MembershipFilter, data: MembershipUpdateInput!): [Membership!]!
+
+  """
+  Update the Tenant with the provided primary key with the provided data. Any fields not provided will remain unchanged.
+  """
+  updateTenant(tenantId: String!, data: TenantUpdateInput!): Tenant
+
+  """
+  Update multiple Tenants matching the provided `where` filter with the provided data. Any fields not provided will remain unchanged.
+  """
+  updateTenants(where: TenantFilter, data: TenantUpdateInput!): [Tenant!]!
+}

--- a/integration-tests/shared-fk/simple/src/index.exo
+++ b/integration-tests/shared-fk/simple/src/index.exo
@@ -1,0 +1,24 @@
+@postgres
+module Database {
+  @access(query=true, mutation=true)
+  type Member {
+    @pk memberId: String
+    @pk @column("member_tenant_id") memberTenantId: String
+    memberName: String?
+    memberships: Set<Membership>
+  }
+
+  @access(query=true, mutation=true)
+  type Membership {
+    @pk membershipId: String
+    @pk @column("membership_tenant_id") membershipTenantId: String
+    @column(mapping={memberId: "membership_member_id", memberTenantId: "membership_tenant_id"}) member: Member?
+    membershipName: String?
+  }
+
+  @access(query=true, mutation=true)
+  type Tenant {
+    @pk tenantId: String
+    tenantName: String?
+  }
+}

--- a/integration-tests/shared-fk/simple/tests/init.gql
+++ b/integration-tests/shared-fk/simple/tests/init.gql
@@ -1,0 +1,55 @@
+operation: |
+    mutation {
+        tenant1: createTenant(data: {tenantId: "tenant1", tenantName: "Tech Corp"}) {
+            tenantId
+        }
+        tenant2: createTenant(data: {tenantId: "tenant2", tenantName: "Finance Ltd"}) {
+            tenantId
+        }
+        
+        member1: createMember(data: {
+            memberId: "tenant1-member1", 
+            memberTenantId: "tenant1", 
+            memberName: "Alice Smith",
+            memberships: [
+                {
+                    membershipId: "tenant1-membership1",
+                    membershipTenantId: "tenant1",
+                    membershipName: "Premium"
+                }
+            ]
+        }) {
+            memberId
+            memberTenantId
+        }
+        member2: createMember(data: {
+            memberId: "tenant1-member2", 
+            memberTenantId: "tenant1", 
+            memberName: "Bob Johnson",
+            memberships: [
+                {
+                    membershipId: "tenant1-membership2",
+                    membershipTenantId: "tenant1",
+                    membershipName: "Basic"
+                }
+            ]
+        }) {
+            memberId
+            memberTenantId
+        }
+        member3: createMember(data: {
+            memberId: "tenant2-member1", 
+            memberTenantId: "tenant2", 
+            memberName: "Carol Davis",
+            memberships: [
+                {
+                    membershipId: "tenant2-membership1",
+                    membershipTenantId: "tenant2",
+                    membershipName: "Enterprise"
+                }
+            ]
+        }) {
+            memberId
+            memberTenantId
+        }
+    }

--- a/integration-tests/shared-fk/simple/tests/member-filtering.exotest
+++ b/integration-tests/shared-fk/simple/tests/member-filtering.exotest
@@ -1,0 +1,171 @@
+operation: |
+  fragment memberInfo on Member {
+    memberId
+    memberTenantId
+    memberName
+    memberships {
+      membershipId
+      membershipTenantId
+      membershipName
+    }
+  }
+  query {
+    allMembers: members(orderBy: {memberId: ASC}) {
+      ...memberInfo
+    }
+    byTenant: members(where: {memberTenantId: {eq: "tenant1"}}, orderBy: {memberId: ASC}) {
+      ...memberInfo
+    }
+    byName: members(where: {memberName: {like: "%Smith%"}}) {
+      ...memberInfo
+    }
+    byMembershipType: members(where: {memberships: {membershipName: {eq: "Premium"}}}) {
+      ...memberInfo
+    }
+    byMembershipTenant: members(where: {memberships: {membershipTenantId: {eq: "tenant2"}}}) {
+      ...memberInfo
+    }
+    tenant1MembersStartingWithA: members(where: {and: [{memberTenantId: {eq: "tenant1"}}, {memberName: {startsWith: "A"}}]}) {
+      ...memberInfo
+    }
+    singleMember: member(memberId: "tenant1-member1", memberTenantId: "tenant1") {
+      ...memberInfo
+    }
+  }
+response: |
+  {
+    "data": {
+      "allMembers": [
+        {
+          "memberId": "tenant1-member1",
+          "memberTenantId": "tenant1",
+          "memberName": "Alice Smith",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership1",
+              "membershipTenantId": "tenant1",
+              "membershipName": "Premium"
+            }
+          ]
+        },
+        {
+          "memberId": "tenant1-member2",
+          "memberTenantId": "tenant1",
+          "memberName": "Bob Johnson",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership2",
+              "membershipTenantId": "tenant1",
+              "membershipName": "Basic"
+            }
+          ]
+        },
+        {
+          "memberId": "tenant2-member1",
+          "memberTenantId": "tenant2",
+          "memberName": "Carol Davis",
+          "memberships": [
+            {
+              "membershipId": "tenant2-membership1",
+              "membershipTenantId": "tenant2",
+              "membershipName": "Enterprise"
+            }
+          ]
+        }
+      ],
+      "byTenant": [
+        {
+          "memberId": "tenant1-member1",
+          "memberTenantId": "tenant1",
+          "memberName": "Alice Smith",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership1",
+              "membershipTenantId": "tenant1",
+              "membershipName": "Premium"
+            }
+          ]
+        },
+        {
+          "memberId": "tenant1-member2",
+          "memberTenantId": "tenant1",
+          "memberName": "Bob Johnson",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership2",
+              "membershipTenantId": "tenant1",
+              "membershipName": "Basic"
+            }
+          ]
+        }
+      ],
+      "byName": [
+        {
+          "memberId": "tenant1-member1",
+          "memberTenantId": "tenant1",
+          "memberName": "Alice Smith",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership1",
+              "membershipTenantId": "tenant1",
+              "membershipName": "Premium"
+            }
+          ]
+        }
+      ],
+      "byMembershipType": [
+        {
+          "memberId": "tenant1-member1",
+          "memberTenantId": "tenant1",
+          "memberName": "Alice Smith",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership1",
+              "membershipTenantId": "tenant1",
+              "membershipName": "Premium"
+            }
+          ]
+        }
+      ],
+      "byMembershipTenant": [
+        {
+          "memberId": "tenant2-member1",
+          "memberTenantId": "tenant2",
+          "memberName": "Carol Davis",
+          "memberships": [
+            {
+              "membershipId": "tenant2-membership1",
+              "membershipTenantId": "tenant2",
+              "membershipName": "Enterprise"
+            }
+          ]
+        }
+      ],
+      "tenant1MembersStartingWithA": [
+        {
+          "memberId": "tenant1-member1",
+          "memberTenantId": "tenant1",
+          "memberName": "Alice Smith",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership1",
+              "membershipTenantId": "tenant1",
+              "membershipName": "Premium"
+            }
+          ]
+        }
+      ],
+      "singleMember": {
+        "memberId": "tenant1-member1",
+        "memberTenantId": "tenant1",
+        "memberName": "Alice Smith",
+        "memberships": [
+          {
+            "membershipId": "tenant1-membership1",
+            "membershipTenantId": "tenant1",
+            "membershipName": "Premium"
+          }
+        ]
+      }
+    }
+  }

--- a/integration-tests/shared-fk/simple/tests/member-update.exotest
+++ b/integration-tests/shared-fk/simple/tests/member-update.exotest
@@ -1,0 +1,32 @@
+operation: |
+  mutation {
+    updateMember1: updateMember(
+      memberId: "tenant1-member1", 
+      memberTenantId: "tenant1",
+      data: {memberId: "tenant1-member1", memberTenantId: "tenant1", memberName: "Alice Smith Updated"}
+    ) {
+      memberId
+      memberTenantId
+      memberName
+      memberships {
+        membershipId
+        membershipName
+      }
+    }
+  }
+response: |
+  {
+    "data": {
+      "updateMember1": {
+        "memberId": "tenant1-member1",
+        "memberTenantId": "tenant1",
+        "memberName": "Alice Smith Updated",
+        "memberships": [
+          {
+            "membershipId": "tenant1-membership1",
+            "membershipName": "Premium"
+          }
+        ]
+      }
+    }
+  }

--- a/integration-tests/shared-fk/simple/tests/membership-filtering.exotest
+++ b/integration-tests/shared-fk/simple/tests/membership-filtering.exotest
@@ -1,0 +1,121 @@
+operation: |
+  fragment membershipInfo on Membership {
+    membershipId
+      membershipTenantId
+      membershipName
+      member {
+        memberId
+        memberTenantId
+        memberName
+      }
+  }
+  query {
+    allMemberships: memberships(orderBy: {membershipId: ASC}) @unordered {
+      ...membershipInfo
+    }
+    byMemberAndTenant: memberships(where: {member: {memberId: {eq: "tenant1-member1"}, memberTenantId: {eq: "tenant1"}}}) @unordered {
+      ...membershipInfo
+    }
+    byMember: memberships(where: {member: {memberId: {eq: "tenant1-member1"}}}) @unordered {
+      ...membershipInfo
+    }
+    byTenant: memberships(where: {membershipTenantId: {eq: "tenant1"}}) @unordered {
+      ...membershipInfo
+    }
+    singleMembership: membership(membershipId: "tenant1-membership1", membershipTenantId: "tenant1") {
+      ...membershipInfo
+    }
+  }
+response: |
+  {
+    "data": {
+      "allMemberships": [
+        {
+          "membershipId": "tenant1-membership1",
+          "membershipTenantId": "tenant1",
+          "membershipName": "Premium",
+          "member": {
+            "memberId": "tenant1-member1",
+            "memberTenantId": "tenant1",
+            "memberName": "Alice Smith"
+          }
+        },
+        {
+          "membershipId": "tenant1-membership2",
+          "membershipTenantId": "tenant1",
+          "membershipName": "Basic",
+          "member": {
+            "memberId": "tenant1-member2",
+            "memberTenantId": "tenant1",
+            "memberName": "Bob Johnson"
+          }
+        },
+        {
+          "membershipId": "tenant2-membership1",
+          "membershipTenantId": "tenant2",
+          "membershipName": "Enterprise",
+          "member": {
+            "memberId": "tenant2-member1",
+            "memberTenantId": "tenant2",
+            "memberName": "Carol Davis"
+          }
+        }
+      ],
+      "byMemberAndTenant": [
+        {
+          "membershipId": "tenant1-membership1",
+          "membershipTenantId": "tenant1",
+          "membershipName": "Premium",
+          "member": {
+            "memberId": "tenant1-member1",
+            "memberTenantId": "tenant1",
+            "memberName": "Alice Smith"
+          }
+        }
+      ],
+      "byMember": [
+        {
+          "membershipId": "tenant1-membership1",
+          "membershipTenantId": "tenant1",
+          "membershipName": "Premium",
+          "member": {
+            "memberId": "tenant1-member1",
+            "memberTenantId": "tenant1",
+            "memberName": "Alice Smith"
+          }
+        }
+      ],
+      "byTenant": [
+        {
+          "membershipId": "tenant1-membership1",
+          "membershipTenantId": "tenant1",
+          "membershipName": "Premium",
+          "member": {
+            "memberId": "tenant1-member1",
+            "memberTenantId": "tenant1",
+            "memberName": "Alice Smith"
+          }
+        },
+        {
+          "membershipId": "tenant1-membership2",
+          "membershipTenantId": "tenant1",
+          "membershipName": "Basic",
+          "member": {
+            "memberId": "tenant1-member2",
+            "memberTenantId": "tenant1",
+            "memberName": "Bob Johnson"
+          }
+        }
+      ],
+      "singleMembership": {
+        "membershipId": "tenant1-membership1",
+        "membershipTenantId": "tenant1",
+        "membershipName": "Premium",
+        "member": {
+          "memberId": "tenant1-member1",
+          "memberTenantId": "tenant1",
+          "memberName": "Alice Smith"
+        }
+      }
+    }
+  }

--- a/integration-tests/shared-fk/simple/tests/membership-update.exotest
+++ b/integration-tests/shared-fk/simple/tests/membership-update.exotest
@@ -1,0 +1,30 @@
+operation: |
+  mutation {
+    updateMembership1: updateMembership(
+      membershipId: "tenant1-membership1", 
+      membershipTenantId: "tenant1",
+      data: {membershipId: "tenant1-membership1", membershipTenantId: "tenant1", membershipName: "Premium Plus"}
+    ) {
+      membershipId
+      membershipTenantId
+      membershipName
+      member {
+        memberId
+        memberName
+      }
+    }
+  }
+response: |
+  {
+    "data": {
+      "updateMembership1": {
+        "membershipId": "tenant1-membership1",
+        "membershipTenantId": "tenant1",
+        "membershipName": "Premium Plus",
+        "member": {
+          "memberId": "tenant1-member1",
+          "memberName": "Alice Smith"
+        }
+      }
+    }
+  }

--- a/integration-tests/shared-fk/simple/tests/tenant-filtering.exotest
+++ b/integration-tests/shared-fk/simple/tests/tenant-filtering.exotest
@@ -1,95 +1,32 @@
 operation: |
+  fragment tenantInfo on Tenant {
+    tenantId
+    tenantName
+  }
   query {
-    tenant1Members: members(where: {memberTenantId: {eq: "tenant1"}}, orderBy: {memberId: ASC}) {
-      memberId
-      memberTenantId
-      memberName
-      memberships {
-        membershipId
-        membershipName
-      }
+    tenant1: tenants(where: {tenantId: {eq: "tenant1"}}, orderBy: {tenantId: ASC}) {
+      ...tenantInfo
     }
-    tenant2Members: members(where: {memberTenantId: {eq: "tenant2"}}) {
-      memberId
-      memberTenantId
-      memberName
-      memberships {
-        membershipId
-        membershipName
-      }
-    }
-    tenant1Memberships: memberships(where: {membershipTenantId: {eq: "tenant1"}}, orderBy: {membershipId: ASC}) {
-      membershipId
-      membershipTenantId
-      membershipName
-      member {
-        memberId
-        memberName
-      }
+    tenant2: tenants(where: {tenantId: {eq: "tenant2"}}, orderBy: {tenantId: ASC}) {
+      ...tenantInfo
     }
     singleTenant: tenant(tenantId: "tenant1") {
-      tenantId
-      tenantName
+      ...tenantInfo
     }
   }
 response: |
   {
     "data": {
-      "tenant1Members": [
+      "tenant1": [
         {
-          "memberId": "tenant1-member1",
-          "memberTenantId": "tenant1",
-          "memberName": "Alice Smith",
-          "memberships": [
-            {
-              "membershipId": "tenant1-membership1",
-              "membershipName": "Premium"
-            }
-          ]
-        },
-        {
-          "memberId": "tenant1-member2",
-          "memberTenantId": "tenant1",
-          "memberName": "Bob Johnson",
-          "memberships": [
-            {
-              "membershipId": "tenant1-membership2",
-              "membershipName": "Basic"
-            }
-          ]
+          "tenantId": "tenant1",
+          "tenantName": "Tech Corp"
         }
       ],
-      "tenant2Members": [
+      "tenant2": [
         {
-          "memberId": "tenant2-member1",
-          "memberTenantId": "tenant2",
-          "memberName": "Carol Davis",
-          "memberships": [
-            {
-              "membershipId": "tenant2-membership1",
-              "membershipName": "Enterprise"
-            }
-          ]
-        }
-      ],
-      "tenant1Memberships": [
-        {
-          "membershipId": "tenant1-membership1",
-          "membershipTenantId": "tenant1",
-          "membershipName": "Premium",
-          "member": {
-            "memberId": "tenant1-member1",
-            "memberName": "Alice Smith"
-          }
-        },
-        {
-          "membershipId": "tenant1-membership2",
-          "membershipTenantId": "tenant1",
-          "membershipName": "Basic",
-          "member": {
-            "memberId": "tenant1-member2",
-            "memberName": "Bob Johnson"
-          }
+          "tenantId": "tenant2",
+          "tenantName": "Finance Ltd"
         }
       ],
       "singleTenant": {

--- a/integration-tests/shared-fk/simple/tests/tenant-filtering.exotest
+++ b/integration-tests/shared-fk/simple/tests/tenant-filtering.exotest
@@ -1,0 +1,100 @@
+operation: |
+  query {
+    tenant1Members: members(where: {memberTenantId: {eq: "tenant1"}}, orderBy: {memberId: ASC}) {
+      memberId
+      memberTenantId
+      memberName
+      memberships {
+        membershipId
+        membershipName
+      }
+    }
+    tenant2Members: members(where: {memberTenantId: {eq: "tenant2"}}) {
+      memberId
+      memberTenantId
+      memberName
+      memberships {
+        membershipId
+        membershipName
+      }
+    }
+    tenant1Memberships: memberships(where: {membershipTenantId: {eq: "tenant1"}}, orderBy: {membershipId: ASC}) {
+      membershipId
+      membershipTenantId
+      membershipName
+      member {
+        memberId
+        memberName
+      }
+    }
+    singleTenant: tenant(tenantId: "tenant1") {
+      tenantId
+      tenantName
+    }
+  }
+response: |
+  {
+    "data": {
+      "tenant1Members": [
+        {
+          "memberId": "tenant1-member1",
+          "memberTenantId": "tenant1",
+          "memberName": "Alice Smith",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership1",
+              "membershipName": "Premium"
+            }
+          ]
+        },
+        {
+          "memberId": "tenant1-member2",
+          "memberTenantId": "tenant1",
+          "memberName": "Bob Johnson",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership2",
+              "membershipName": "Basic"
+            }
+          ]
+        }
+      ],
+      "tenant2Members": [
+        {
+          "memberId": "tenant2-member1",
+          "memberTenantId": "tenant2",
+          "memberName": "Carol Davis",
+          "memberships": [
+            {
+              "membershipId": "tenant2-membership1",
+              "membershipName": "Enterprise"
+            }
+          ]
+        }
+      ],
+      "tenant1Memberships": [
+        {
+          "membershipId": "tenant1-membership1",
+          "membershipTenantId": "tenant1",
+          "membershipName": "Premium",
+          "member": {
+            "memberId": "tenant1-member1",
+            "memberName": "Alice Smith"
+          }
+        },
+        {
+          "membershipId": "tenant1-membership2",
+          "membershipTenantId": "tenant1",
+          "membershipName": "Basic",
+          "member": {
+            "memberId": "tenant1-member2",
+            "memberName": "Bob Johnson"
+          }
+        }
+      ],
+      "singleTenant": {
+        "tenantId": "tenant1",
+        "tenantName": "Tech Corp"
+      }
+    }
+  }

--- a/integration-tests/shared-fk/simple/tests/tenant-update.exotest
+++ b/integration-tests/shared-fk/simple/tests/tenant-update.exotest
@@ -1,0 +1,19 @@
+operation: |
+  mutation {
+    updateTenant1: updateTenant(
+      tenantId: "tenant1", 
+      data: {tenantId: "tenant1", tenantName: "Tech Corp Updated"}
+    ) {
+      tenantId
+      tenantName
+    }
+  }
+response: |
+  {
+    "data": {
+      "updateTenant1": {
+        "tenantId": "tenant1",
+        "tenantName": "Tech Corp Updated"
+      }
+    }
+  }

--- a/integration-tests/shared-fk/with-composite-field-pk/schema-tests/introspection.expected.graphql
+++ b/integration-tests/shared-fk/with-composite-field-pk/schema-tests/introspection.expected.graphql
@@ -1,0 +1,343 @@
+type Member {
+  memberId: String!
+  memberTenantId: String!
+  memberName: String
+  memberships(where: MembershipFilter, orderBy: [MembershipOrdering!], limit: Int, offset: Int): [Membership!]!
+  membershipsAgg(where: MembershipFilter): MembershipAgg
+}
+
+"""An aggregate for the `Member` type."""
+type MemberAgg {
+  memberId: StringAgg
+  memberTenantId: StringAgg
+  memberName: StringAgg
+}
+
+input MemberCreationInput {
+  memberId: String!
+  memberTenantId: String!
+  memberName: String
+  memberships: [MembershipCreationInputFromMember!]!
+}
+
+"""
+Predicate for the `Member` type parameter. 
+If a field is omitted, no filter is applied for that field.
+To check a field against null, use a `<field name>: null` filter
+"""
+input MemberFilter {
+  memberId: StringFilter
+  memberTenantId: StringFilter
+  memberName: StringFilter
+  memberships: MembershipFilter
+  and: [MemberFilter!]
+  or: [MemberFilter!]
+  not: MemberFilter
+}
+
+input MemberOrdering {
+  memberId: Ordering
+  memberTenantId: Ordering
+  memberName: Ordering
+}
+
+input MemberReferenceInput {
+  memberId: String!
+  memberTenantId: String!
+}
+
+input MemberUpdateInput {
+  memberId: String
+  memberTenantId: String
+  memberName: String
+  memberships: MembershipUpdateInputFromMember
+}
+
+type Membership {
+  membershipId: String!
+  tenant: Tenant!
+  member: Member
+  membershipName: String
+}
+
+"""An aggregate for the `Membership` type."""
+type MembershipAgg {
+  membershipId: StringAgg
+  tenant: TenantAgg
+  membershipName: StringAgg
+}
+
+input MembershipCreationInput {
+  membershipId: String!
+  tenant: TenantReferenceInput!
+  member: MemberReferenceInput
+  membershipName: String
+}
+
+input MembershipCreationInputFromMember {
+  membershipId: String!
+  tenant: TenantReferenceInput!
+  membershipName: String
+}
+
+input MembershipCreationInputFromTenant {
+  membershipId: String!
+  member: MemberReferenceInput
+  membershipName: String
+}
+
+"""
+Predicate for the `Membership` type parameter. 
+If a field is omitted, no filter is applied for that field.
+To check a field against null, use a `<field name>: null` filter
+"""
+input MembershipFilter {
+  membershipId: StringFilter
+  tenant: TenantFilter
+  member: MemberFilter
+  membershipName: StringFilter
+  and: [MembershipFilter!]
+  or: [MembershipFilter!]
+  not: MembershipFilter
+}
+
+input MembershipOrdering {
+  membershipId: Ordering
+  tenant: [TenantOrdering!]
+  member: [MemberOrdering!]
+  membershipName: Ordering
+}
+
+input MembershipReferenceInput {
+  membershipId: String!
+  tenant: TenantReferenceInput!
+}
+
+input MembershipUpdateInput {
+  membershipId: String
+  tenant: TenantReferenceInput
+  member: MemberReferenceInput
+  membershipName: String
+}
+
+input MembershipUpdateInputFromMember {
+  create: [MembershipCreationInputFromMember!]
+  update: [MembershipUpdateInputFromMemberNested!]
+  delete: [MembershipReferenceInput!]
+}
+
+input MembershipUpdateInputFromMemberNested {
+  membershipId: String!
+  tenant: TenantUpdateInput!
+  membershipName: String
+}
+
+input MembershipUpdateInputFromTenant {
+  create: [MembershipCreationInputFromTenant!]
+  update: [MembershipUpdateInputFromTenantNested!]
+  delete: [MembershipReferenceInput!]
+}
+
+input MembershipUpdateInputFromTenantNested {
+  membershipId: String!
+  member: MemberReferenceInput
+  membershipName: String
+}
+
+enum Ordering {
+  ASC
+  DESC
+}
+
+type StringAgg {
+  min: String
+  max: String
+  count: Int
+}
+
+input StringFilter {
+  eq: String
+  neq: String
+  lt: String
+  lte: String
+  gt: String
+  gte: String
+  like: String
+  ilike: String
+  startsWith: String
+  endsWith: String
+}
+
+type Tenant {
+  tenantId: String!
+  tenantName: String
+  memberships(where: MembershipFilter, orderBy: [MembershipOrdering!], limit: Int, offset: Int): [Membership!]!
+  membershipsAgg(where: MembershipFilter): MembershipAgg
+}
+
+"""An aggregate for the `Tenant` type."""
+type TenantAgg {
+  tenantId: StringAgg
+  tenantName: StringAgg
+}
+
+input TenantCreationInput {
+  tenantId: String!
+  tenantName: String
+  memberships: [MembershipCreationInputFromTenant!]!
+}
+
+"""
+Predicate for the `Tenant` type parameter. 
+If a field is omitted, no filter is applied for that field.
+To check a field against null, use a `<field name>: null` filter
+"""
+input TenantFilter {
+  tenantId: StringFilter
+  tenantName: StringFilter
+  memberships: MembershipFilter
+  and: [TenantFilter!]
+  or: [TenantFilter!]
+  not: TenantFilter
+}
+
+input TenantOrdering {
+  tenantId: Ordering
+  tenantName: Ordering
+}
+
+input TenantReferenceInput {
+  tenantId: String!
+}
+
+"""A predicate to filter the results for a `Tenant` type parameter."""
+input TenantUniqueFilter {
+  tenantId: String!
+}
+
+input TenantUpdateInput {
+  tenantId: String
+  tenantName: String
+  memberships: MembershipUpdateInputFromTenant
+}
+
+type Query {
+  """Get a single `Member` given primary key fields"""
+  member(memberId: String!, memberTenantId: String!): Member
+
+  """
+  Get multiple `Member`s given the provided `where` filter, order by, limit, and offset
+  """
+  members(where: MemberFilter, orderBy: [MemberOrdering!], limit: Int, offset: Int): [Member!]!
+
+  """
+  Get the aggregate value of the selected fields over all `Member`s given the provided `where` filter
+  """
+  membersAgg(where: MemberFilter): MemberAgg!
+
+  """Get a single `Membership` given primary key fields"""
+  membership(membershipId: String!, tenant: TenantUniqueFilter!): Membership
+
+  """
+  Get multiple `Membership`s given the provided `where` filter, order by, limit, and offset
+  """
+  memberships(where: MembershipFilter, orderBy: [MembershipOrdering!], limit: Int, offset: Int): [Membership!]!
+
+  """
+  Get the aggregate value of the selected fields over all `Membership`s given the provided `where` filter
+  """
+  membershipsAgg(where: MembershipFilter): MembershipAgg!
+
+  """Get a single `Tenant` given primary key fields"""
+  tenant(tenantId: String!): Tenant
+
+  """
+  Get multiple `Tenant`s given the provided `where` filter, order by, limit, and offset
+  """
+  tenants(where: TenantFilter, orderBy: [TenantOrdering!], limit: Int, offset: Int): [Tenant!]!
+
+  """
+  Get the aggregate value of the selected fields over all `Tenant`s given the provided `where` filter
+  """
+  tenantsAgg(where: TenantFilter): TenantAgg!
+}
+
+type Mutation {
+  """
+  Create a new Member. Check the `MemberCreationInput` type for the expected shape of the data.
+  """
+  createMember(data: MemberCreationInput!): Member!
+
+  """
+  Create multiple Members. Check the `MemberCreationInput` type for the expected shape of the data.
+  """
+  createMembers(data: [MemberCreationInput!]!): [Member!]!
+
+  """
+  Create a new Membership. Check the `MembershipCreationInput` type for the expected shape of the data.
+  """
+  createMembership(data: MembershipCreationInput!): Membership!
+
+  """
+  Create multiple Memberships. Check the `MembershipCreationInput` type for the expected shape of the data.
+  """
+  createMemberships(data: [MembershipCreationInput!]!): [Membership!]!
+
+  """
+  Create a new Tenant. Check the `TenantCreationInput` type for the expected shape of the data.
+  """
+  createTenant(data: TenantCreationInput!): Tenant!
+
+  """
+  Create multiple Tenants. Check the `TenantCreationInput` type for the expected shape of the data.
+  """
+  createTenants(data: [TenantCreationInput!]!): [Tenant!]!
+
+  """Delete the Member with the provided primary key."""
+  deleteMember(memberId: String!, memberTenantId: String!): Member
+
+  """Delete multiple Members matching the provided `where` filter."""
+  deleteMembers(where: MemberFilter): [Member!]!
+
+  """Delete the Membership with the provided primary key."""
+  deleteMembership(membershipId: String!, tenant: TenantUniqueFilter!): Membership
+
+  """Delete multiple Memberships matching the provided `where` filter."""
+  deleteMemberships(where: MembershipFilter): [Membership!]!
+
+  """Delete the Tenant with the provided primary key."""
+  deleteTenant(tenantId: String!): Tenant
+
+  """Delete multiple Tenants matching the provided `where` filter."""
+  deleteTenants(where: TenantFilter): [Tenant!]!
+
+  """
+  Update the Member with the provided primary key with the provided data. Any fields not provided will remain unchanged.
+  """
+  updateMember(memberId: String!, memberTenantId: String!, data: MemberUpdateInput!): Member
+
+  """
+  Update multiple Members matching the provided `where` filter with the provided data. Any fields not provided will remain unchanged.
+  """
+  updateMembers(where: MemberFilter, data: MemberUpdateInput!): [Member!]!
+
+  """
+  Update the Membership with the provided primary key with the provided data. Any fields not provided will remain unchanged.
+  """
+  updateMembership(membershipId: String!, tenant: TenantUniqueFilter!, data: MembershipUpdateInput!): Membership
+
+  """
+  Update multiple Memberships matching the provided `where` filter with the provided data. Any fields not provided will remain unchanged.
+  """
+  updateMemberships(where: MembershipFilter, data: MembershipUpdateInput!): [Membership!]!
+
+  """
+  Update the Tenant with the provided primary key with the provided data. Any fields not provided will remain unchanged.
+  """
+  updateTenant(tenantId: String!, data: TenantUpdateInput!): Tenant
+
+  """
+  Update multiple Tenants matching the provided `where` filter with the provided data. Any fields not provided will remain unchanged.
+  """
+  updateTenants(where: TenantFilter, data: TenantUpdateInput!): [Tenant!]!
+}

--- a/integration-tests/shared-fk/with-composite-field-pk/src/index.exo
+++ b/integration-tests/shared-fk/with-composite-field-pk/src/index.exo
@@ -1,0 +1,25 @@
+@postgres
+module Database {
+  @access(query=true, mutation=true)
+  type Member {
+    @pk memberId: String
+    @pk @column("member_tenant_id") memberTenantId: String
+    memberName: String?
+    memberships: Set<Membership>
+  }
+
+  @access(query=true, mutation=true)
+  type Membership {
+    @pk membershipId: String
+    @pk @column("membership_tenant_id") tenant: Tenant
+    @column(mapping={memberId: "membership_member_id", memberTenantId: "membership_tenant_id"}) member: Member?
+    membershipName: String?
+  }
+
+  @access(query=true, mutation=true)
+  type Tenant {
+    @pk tenantId: String
+    tenantName: String?
+    memberships: Set<Membership>
+  }
+}

--- a/integration-tests/shared-fk/with-composite-field-pk/tests/init.gql
+++ b/integration-tests/shared-fk/with-composite-field-pk/tests/init.gql
@@ -1,0 +1,55 @@
+operation: |
+    mutation {
+        tenant1: createTenant(data: {tenantId: "tenant1", tenantName: "Tech Corp", memberships: []}) {
+            tenantId
+        }
+        tenant2: createTenant(data: {tenantId: "tenant2", tenantName: "Finance Ltd", memberships: []}) {
+            tenantId
+        }
+        
+        member1: createMember(data: {
+            memberId: "tenant1-member1", 
+            memberTenantId: "tenant1", 
+            memberName: "Alice Smith",
+            memberships: [
+                {
+                    membershipId: "tenant1-membership1",
+                    tenant: {tenantId: "tenant1"},
+                    membershipName: "Premium"
+                }
+            ]
+        }) {
+            memberId
+            memberTenantId
+        }
+        member2: createMember(data: {
+            memberId: "tenant1-member2", 
+            memberTenantId: "tenant1", 
+            memberName: "Bob Johnson",
+            memberships: [
+                {
+                    membershipId: "tenant1-membership2",
+                    tenant: {tenantId: "tenant1"},
+                    membershipName: "Basic"
+                }
+            ]
+        }) {
+            memberId
+            memberTenantId
+        }
+        member3: createMember(data: {
+            memberId: "tenant2-member1", 
+            memberTenantId: "tenant2", 
+            memberName: "Carol Davis",
+            memberships: [
+                {
+                    membershipId: "tenant2-membership1",
+                    tenant: {tenantId: "tenant2"},
+                    membershipName: "Enterprise"
+                }
+            ]
+        }) {
+            memberId
+            memberTenantId
+        }
+    }

--- a/integration-tests/shared-fk/with-composite-field-pk/tests/member-filtering.exotest
+++ b/integration-tests/shared-fk/with-composite-field-pk/tests/member-filtering.exotest
@@ -1,0 +1,193 @@
+operation: |
+  fragment memberInfo on Member {
+    memberId
+    memberTenantId
+    memberName
+    memberships {
+      membershipId
+      tenant {
+        tenantId
+      }
+      membershipName
+    }
+  }
+  query {
+    allMembers: members(orderBy: {memberId: ASC}) {
+      ...memberInfo
+    }
+    byTenant: members(where: {memberTenantId: {eq: "tenant1"}}, orderBy: {memberId: ASC}) {
+      ...memberInfo
+    }
+    byName: members(where: {memberName: {like: "%Smith%"}}) {
+      ...memberInfo
+    }
+    byMembershipType: members(where: {memberships: {membershipName: {eq: "Premium"}}}) {
+      ...memberInfo
+    }
+    byMembershipTenant: members(where: {memberships: {tenant: {tenantId: {eq: "tenant2"}}}}) {
+      ...memberInfo
+    }
+    tenant1MembersStartingWithA: members(where: {and: [{memberTenantId: {eq: "tenant1"}}, {memberName: {startsWith: "A"}}]}) {
+      ...memberInfo
+    }
+    singleMember: member(memberId: "tenant1-member1", memberTenantId: "tenant1") {
+      ...memberInfo
+    }
+  }
+response: |
+  {
+    "data": {
+      "allMembers": [
+        {
+          "memberId": "tenant1-member1",
+          "memberTenantId": "tenant1",
+          "memberName": "Alice Smith",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership1",
+              "tenant": {
+                "tenantId": "tenant1"
+              },
+              "membershipName": "Premium"
+            }
+          ]
+        },
+        {
+          "memberId": "tenant1-member2",
+          "memberTenantId": "tenant1",
+          "memberName": "Bob Johnson",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership2",
+              "tenant": {
+                "tenantId": "tenant1"
+              },
+              "membershipName": "Basic"
+            }
+          ]
+        },
+        {
+          "memberId": "tenant2-member1",
+          "memberTenantId": "tenant2",
+          "memberName": "Carol Davis",
+          "memberships": [
+            {
+              "membershipId": "tenant2-membership1",
+              "tenant": {
+                "tenantId": "tenant2"
+              },
+              "membershipName": "Enterprise"
+            }
+          ]
+        }
+      ],
+      "byTenant": [
+        {
+          "memberId": "tenant1-member1",
+          "memberTenantId": "tenant1",
+          "memberName": "Alice Smith",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership1",
+              "tenant": {
+                "tenantId": "tenant1"
+              },
+              "membershipName": "Premium"
+            }
+          ]
+        },
+        {
+          "memberId": "tenant1-member2",
+          "memberTenantId": "tenant1",
+          "memberName": "Bob Johnson",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership2",
+              "tenant": {
+                "tenantId": "tenant1"
+              },
+              "membershipName": "Basic"
+            }
+          ]
+        }
+      ],
+      "byName": [
+        {
+          "memberId": "tenant1-member1",
+          "memberTenantId": "tenant1",
+          "memberName": "Alice Smith",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership1",
+              "tenant": {
+                "tenantId": "tenant1"
+              },
+              "membershipName": "Premium"
+            }
+          ]
+        }
+      ],
+      "byMembershipType": [
+        {
+          "memberId": "tenant1-member1",
+          "memberTenantId": "tenant1",
+          "memberName": "Alice Smith",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership1",
+              "tenant": {
+                "tenantId": "tenant1"
+              },
+              "membershipName": "Premium"
+            }
+          ]
+        }
+      ],
+      "byMembershipTenant": [
+        {
+          "memberId": "tenant2-member1",
+          "memberTenantId": "tenant2",
+          "memberName": "Carol Davis",
+          "memberships": [
+            {
+              "membershipId": "tenant2-membership1",
+              "tenant": {
+                "tenantId": "tenant2"
+              },
+              "membershipName": "Enterprise"
+            }
+          ]
+        }
+      ],
+      "tenant1MembersStartingWithA": [
+        {
+          "memberId": "tenant1-member1",
+          "memberTenantId": "tenant1",
+          "memberName": "Alice Smith",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership1",
+              "tenant": {
+                "tenantId": "tenant1"
+              },
+              "membershipName": "Premium"
+            }
+          ]
+        }
+      ],
+      "singleMember": {
+        "memberId": "tenant1-member1",
+        "memberTenantId": "tenant1",
+        "memberName": "Alice Smith",
+        "memberships": [
+          {
+            "membershipId": "tenant1-membership1",
+            "tenant": {
+              "tenantId": "tenant1"
+            },
+            "membershipName": "Premium"
+          }
+        ]
+      }
+    }
+  }

--- a/integration-tests/shared-fk/with-composite-field-pk/tests/member-update.exotest
+++ b/integration-tests/shared-fk/with-composite-field-pk/tests/member-update.exotest
@@ -1,0 +1,32 @@
+operation: |
+  mutation {
+    updateMember1: updateMember(
+      memberId: "tenant1-member1", 
+      memberTenantId: "tenant1",
+      data: {memberId: "tenant1-member1", memberTenantId: "tenant1", memberName: "Alice Smith Updated"}
+    ) {
+      memberId
+      memberTenantId
+      memberName
+      memberships {
+        membershipId
+        membershipName
+      }
+    }
+  }
+response: |
+  {
+    "data": {
+      "updateMember1": {
+        "memberId": "tenant1-member1",
+        "memberTenantId": "tenant1",
+        "memberName": "Alice Smith Updated",
+        "memberships": [
+          {
+            "membershipId": "tenant1-membership1",
+            "membershipName": "Premium"
+          }
+        ]
+      }
+    }
+  }

--- a/integration-tests/shared-fk/with-composite-field-pk/tests/membership-filtering.exotest
+++ b/integration-tests/shared-fk/with-composite-field-pk/tests/membership-filtering.exotest
@@ -1,15 +1,15 @@
 operation: |
   fragment membershipInfo on Membership {
     membershipId
-      tenant {
-        tenantId
-      }
-      membershipName
-      member {
-        memberId
-        memberTenantId
-        memberName
-      }
+    tenant {
+      tenantId
+    }
+    membershipName
+    member {
+      memberId
+      memberTenantId
+      memberName
+    }
   }
   query {
     allMemberships: memberships(orderBy: {membershipId: ASC}) @unordered {

--- a/integration-tests/shared-fk/with-composite-field-pk/tests/membership-filtering.exotest
+++ b/integration-tests/shared-fk/with-composite-field-pk/tests/membership-filtering.exotest
@@ -1,0 +1,144 @@
+operation: |
+  fragment membershipInfo on Membership {
+    membershipId
+      tenant {
+        tenantId
+      }
+      membershipName
+      member {
+        memberId
+        memberTenantId
+        memberName
+      }
+  }
+  query {
+    allMemberships: memberships(orderBy: {membershipId: ASC}) @unordered {
+      ...membershipInfo
+    }
+    byMemberAndTenantMatching: memberships(where: {member: {memberId: {eq: "tenant1-member1"}, memberTenantId: {eq: "tenant1"}}, tenant: {tenantId: {eq: "tenant1"}}}) @unordered {
+      ...membershipInfo
+    }
+    byMemberAndTenantNotMatching: memberships(where: {member: {memberId: {eq: "tenant1-member1"}, memberTenantId: {eq: "tenant1"}}, tenant: {tenantId: {eq: "tenant2"}}}) @unordered {
+      ...membershipInfo
+    }
+    byMember: memberships(where: {member: {memberId: {eq: "tenant1-member1"}}}) @unordered {
+      ...membershipInfo
+    }
+    byTenant: memberships(where: {tenant: {tenantId: {eq: "tenant1"}}}) @unordered {
+      ...membershipInfo
+    }
+    singleMembership: membership(membershipId: "tenant1-membership1", tenant: {tenantId: "tenant1"}) {
+      ...membershipInfo
+    }
+  }
+response: |
+  {
+    "data": {
+      "allMemberships": [
+        {
+          "membershipId": "tenant1-membership1",
+          "tenant": {
+            "tenantId": "tenant1"
+          },
+          "membershipName": "Premium",
+          "member": {
+            "memberId": "tenant1-member1",
+            "memberTenantId": "tenant1",
+            "memberName": "Alice Smith"
+          }
+        },
+        {
+          "membershipId": "tenant1-membership2",
+          "tenant": {
+            "tenantId": "tenant1"
+          },
+          "membershipName": "Basic",
+          "member": {
+            "memberId": "tenant1-member2",
+            "memberTenantId": "tenant1",
+            "memberName": "Bob Johnson"
+          }
+        },
+        {
+          "membershipId": "tenant2-membership1",
+          "tenant": {
+            "tenantId": "tenant2"
+          },
+          "membershipName": "Enterprise",
+          "member": {
+            "memberId": "tenant2-member1",
+            "memberTenantId": "tenant2",
+            "memberName": "Carol Davis"
+          }
+        }
+      ],
+      "byMemberAndTenantMatching": [
+        {
+          "membershipId": "tenant1-membership1",
+          "tenant": {
+            "tenantId": "tenant1"
+          },
+          "membershipName": "Premium",
+          "member": {
+            "memberId": "tenant1-member1",
+            "memberTenantId": "tenant1",
+            "memberName": "Alice Smith"
+          }
+        }
+      ],
+      "byMemberAndTenantNotMatching": [
+      ],
+      "byMember": [
+        {
+          "membershipId": "tenant1-membership1",
+          "tenant": {
+            "tenantId": "tenant1"
+          },
+          "membershipName": "Premium",
+          "member": {
+            "memberId": "tenant1-member1",
+            "memberTenantId": "tenant1",
+            "memberName": "Alice Smith"
+          }
+        }
+      ],
+      "byTenant": [
+        {
+          "membershipId": "tenant1-membership1",
+          "tenant": {
+            "tenantId": "tenant1"
+          },
+          "membershipName": "Premium",
+          "member": {
+            "memberId": "tenant1-member1",
+            "memberTenantId": "tenant1",
+            "memberName": "Alice Smith"
+          }
+        },
+        {
+          "membershipId": "tenant1-membership2",
+          "tenant": {
+            "tenantId": "tenant1"
+          },
+          "membershipName": "Basic",
+          "member": {
+            "memberId": "tenant1-member2",
+            "memberTenantId": "tenant1",
+            "memberName": "Bob Johnson"
+          }
+        }
+      ],
+      "singleMembership": {
+        "membershipId": "tenant1-membership1",
+        "tenant": {
+          "tenantId": "tenant1"
+        },
+        "membershipName": "Premium",
+        "member": {
+          "memberId": "tenant1-member1",
+          "memberTenantId": "tenant1",
+          "memberName": "Alice Smith"
+        }
+      }
+    }
+  }

--- a/integration-tests/shared-fk/with-composite-field-pk/tests/membership-update.exotest
+++ b/integration-tests/shared-fk/with-composite-field-pk/tests/membership-update.exotest
@@ -1,0 +1,34 @@
+operation: |
+  mutation {
+    updateMembership1: updateMembership(
+      membershipId: "tenant1-membership1", 
+      tenant: {tenantId: "tenant1"},
+      data: {membershipId: "tenant1-membership1", tenant: {tenantId: "tenant1"}, membershipName: "Premium Plus"}
+    ) {
+      membershipId
+      tenant {
+        tenantId
+      }
+      membershipName
+      member {
+        memberId
+        memberName
+      }
+    }
+  }
+response: |
+  {
+    "data": {
+      "updateMembership1": {
+        "membershipId": "tenant1-membership1",
+        "tenant": {
+          "tenantId": "tenant1"
+        },
+        "membershipName": "Premium Plus",
+        "member": {
+          "memberId": "tenant1-member1",
+          "memberName": "Alice Smith"
+        }
+      }
+    }
+  }

--- a/integration-tests/shared-fk/with-composite-field-pk/tests/tenant-filtering.exotest
+++ b/integration-tests/shared-fk/with-composite-field-pk/tests/tenant-filtering.exotest
@@ -1,0 +1,106 @@
+operation: |
+  query {
+    tenant1Members: members(where: {memberTenantId: {eq: "tenant1"}}, orderBy: {memberId: ASC}) {
+      memberId
+      memberTenantId
+      memberName
+      memberships {
+        membershipId
+        membershipName
+      }
+    }
+    tenant2Members: members(where: {memberTenantId: {eq: "tenant2"}}) {
+      memberId
+      memberTenantId
+      memberName
+      memberships {
+        membershipId
+        membershipName
+      }
+    }
+    tenant1Memberships: memberships(where: {tenant: {tenantId: {eq: "tenant1"}}}, orderBy: {membershipId: ASC}) {
+      membershipId
+      tenant {
+        tenantId
+      }
+      membershipName
+      member {
+        memberId
+        memberName
+      }
+    }
+    singleTenant: tenant(tenantId: "tenant1") {
+      tenantId
+      tenantName
+    }
+  }
+response: |
+  {
+    "data": {
+      "tenant1Members": [
+        {
+          "memberId": "tenant1-member1",
+          "memberTenantId": "tenant1",
+          "memberName": "Alice Smith",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership1",
+              "membershipName": "Premium"
+            }
+          ]
+        },
+        {
+          "memberId": "tenant1-member2",
+          "memberTenantId": "tenant1",
+          "memberName": "Bob Johnson",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership2",
+              "membershipName": "Basic"
+            }
+          ]
+        }
+      ],
+      "tenant2Members": [
+        {
+          "memberId": "tenant2-member1",
+          "memberTenantId": "tenant2",
+          "memberName": "Carol Davis",
+          "memberships": [
+            {
+              "membershipId": "tenant2-membership1",
+              "membershipName": "Enterprise"
+            }
+          ]
+        }
+      ],
+      "tenant1Memberships": [
+        {
+          "membershipId": "tenant1-membership1",
+          "tenant": {
+            "tenantId": "tenant1"
+          },
+          "membershipName": "Premium",
+          "member": {
+            "memberId": "tenant1-member1",
+            "memberName": "Alice Smith"
+          }
+        },
+        {
+          "membershipId": "tenant1-membership2",
+          "tenant": {
+            "tenantId": "tenant1"
+          },
+          "membershipName": "Basic",
+          "member": {
+            "memberId": "tenant1-member2",
+            "memberName": "Bob Johnson"
+          }
+        }
+      ],
+      "singleTenant": {
+        "tenantId": "tenant1",
+        "tenantName": "Tech Corp"
+      }
+    }
+  }

--- a/integration-tests/shared-fk/with-composite-field-pk/tests/tenant-filtering.exotest
+++ b/integration-tests/shared-fk/with-composite-field-pk/tests/tenant-filtering.exotest
@@ -1,106 +1,121 @@
 operation: |
-  query {
-    tenant1Members: members(where: {memberTenantId: {eq: "tenant1"}}, orderBy: {memberId: ASC}) {
-      memberId
-      memberTenantId
-      memberName
-      memberships {
-        membershipId
-        membershipName
-      }
-    }
-    tenant2Members: members(where: {memberTenantId: {eq: "tenant2"}}) {
-      memberId
-      memberTenantId
-      memberName
-      memberships {
-        membershipId
-        membershipName
-      }
-    }
-    tenant1Memberships: memberships(where: {tenant: {tenantId: {eq: "tenant1"}}}, orderBy: {membershipId: ASC}) {
+  fragment tenantInfo on Tenant {
+    tenantId
+    tenantName
+    memberships {
       membershipId
+      membershipName
       tenant {
         tenantId
+        tenantName
       }
-      membershipName
       member {
         memberId
+        memberTenantId
         memberName
       }
     }
+  }
+  query {
+    tenant1: tenants(where: {tenantId: {eq: "tenant1"}}, orderBy: {tenantId: ASC}) {
+      ...tenantInfo
+    }
+    tenant2: tenants(where: {tenantId: {eq: "tenant2"}}) {
+      ...tenantInfo
+    }
     singleTenant: tenant(tenantId: "tenant1") {
-      tenantId
-      tenantName
+      ...tenantInfo
     }
   }
 response: |
   {
     "data": {
-      "tenant1Members": [
+      "tenant1": [
         {
-          "memberId": "tenant1-member1",
-          "memberTenantId": "tenant1",
-          "memberName": "Alice Smith",
+          "tenantId": "tenant1",
+          "tenantName": "Tech Corp",
           "memberships": [
             {
               "membershipId": "tenant1-membership1",
-              "membershipName": "Premium"
-            }
-          ]
-        },
-        {
-          "memberId": "tenant1-member2",
-          "memberTenantId": "tenant1",
-          "memberName": "Bob Johnson",
-          "memberships": [
+              "membershipName": "Premium",
+              "tenant": {
+                "tenantId": "tenant1",
+                "tenantName": "Tech Corp"
+              },
+              "member": {
+                "memberId": "tenant1-member1",
+                "memberTenantId": "tenant1",
+                "memberName": "Alice Smith"
+              }
+            },
             {
               "membershipId": "tenant1-membership2",
-              "membershipName": "Basic"
+              "membershipName": "Basic",
+              "tenant": {
+                "tenantId": "tenant1",
+                "tenantName": "Tech Corp"
+              },
+              "member": {
+                "memberId": "tenant1-member2",
+                "memberTenantId": "tenant1",
+                "memberName": "Bob Johnson"
+              }
             }
           ]
         }
       ],
-      "tenant2Members": [
+      "tenant2": [
         {
-          "memberId": "tenant2-member1",
-          "memberTenantId": "tenant2",
-          "memberName": "Carol Davis",
+          "tenantId": "tenant2",
+          "tenantName": "Finance Ltd",
           "memberships": [
             {
               "membershipId": "tenant2-membership1",
-              "membershipName": "Enterprise"
+              "membershipName": "Enterprise",
+              "tenant": {
+                "tenantId": "tenant2",
+                "tenantName": "Finance Ltd"
+              },
+              "member": {
+                "memberId": "tenant2-member1",
+                "memberTenantId": "tenant2",
+                "memberName": "Carol Davis"
+              }
             }
           ]
-        }
-      ],
-      "tenant1Memberships": [
-        {
-          "membershipId": "tenant1-membership1",
-          "tenant": {
-            "tenantId": "tenant1"
-          },
-          "membershipName": "Premium",
-          "member": {
-            "memberId": "tenant1-member1",
-            "memberName": "Alice Smith"
-          }
-        },
-        {
-          "membershipId": "tenant1-membership2",
-          "tenant": {
-            "tenantId": "tenant1"
-          },
-          "membershipName": "Basic",
-          "member": {
-            "memberId": "tenant1-member2",
-            "memberName": "Bob Johnson"
-          }
         }
       ],
       "singleTenant": {
         "tenantId": "tenant1",
-        "tenantName": "Tech Corp"
+        "tenantName": "Tech Corp",
+        "memberships": [
+          {
+            "membershipId": "tenant1-membership1",
+            "membershipName": "Premium",
+            "tenant": {
+              "tenantId": "tenant1",
+              "tenantName": "Tech Corp"
+            },
+            "member": {
+              "memberId": "tenant1-member1",
+              "memberTenantId": "tenant1",
+              "memberName": "Alice Smith"
+            }
+          },
+          {
+            "membershipId": "tenant1-membership2",
+            "membershipName": "Basic",
+            "tenant": {
+              "tenantId": "tenant1",
+              "tenantName": "Tech Corp"
+            },
+            "member": {
+              "memberId": "tenant1-member2",
+              "memberTenantId": "tenant1",
+              "memberName": "Bob Johnson"
+            }
+          }
+        ]
       }
     }
   }

--- a/integration-tests/shared-fk/with-composite-field-pk/tests/tenant-update.exotest
+++ b/integration-tests/shared-fk/with-composite-field-pk/tests/tenant-update.exotest
@@ -1,0 +1,19 @@
+operation: |
+  mutation {
+    updateTenant1: updateTenant(
+      tenantId: "tenant1", 
+      data: {tenantId: "tenant1", tenantName: "Tech Corp Updated"}
+    ) {
+      tenantId
+      tenantName
+    }
+  }
+response: |
+  {
+    "data": {
+      "updateTenant1": {
+        "tenantId": "tenant1",
+        "tenantName": "Tech Corp Updated"
+      }
+    }
+  }

--- a/integration-tests/shared-fk/with-muliple-composite-fields/schema-tests/introspection.expected.graphql
+++ b/integration-tests/shared-fk/with-muliple-composite-fields/schema-tests/introspection.expected.graphql
@@ -73,29 +73,29 @@ input MemberUpdateInputFromTenantNested {
 
 type Membership {
   membershipId: String!
-  tenant: Tenant!
   member: Member
   membershipName: String
+  tenant: Tenant!
 }
 
 """An aggregate for the `Membership` type."""
 type MembershipAgg {
   membershipId: StringAgg
-  tenant: TenantAgg
   membershipName: StringAgg
+  tenant: TenantAgg
 }
 
 input MembershipCreationInput {
   membershipId: String!
-  tenant: TenantReferenceInput!
   member: MemberReferenceInput
   membershipName: String
+  tenant: TenantReferenceInput!
 }
 
 input MembershipCreationInputFromMember {
   membershipId: String!
-  tenant: TenantReferenceInput!
   membershipName: String
+  tenant: TenantReferenceInput!
 }
 
 input MembershipCreationInputFromTenant {
@@ -111,9 +111,9 @@ To check a field against null, use a `<field name>: null` filter
 """
 input MembershipFilter {
   membershipId: StringFilter
-  tenant: TenantFilter
   member: MemberFilter
   membershipName: StringFilter
+  tenant: TenantFilter
   and: [MembershipFilter!]
   or: [MembershipFilter!]
   not: MembershipFilter
@@ -121,9 +121,9 @@ input MembershipFilter {
 
 input MembershipOrdering {
   membershipId: Ordering
-  tenant: [TenantOrdering!]
   member: [MemberOrdering!]
   membershipName: Ordering
+  tenant: [TenantOrdering!]
 }
 
 input MembershipReferenceInput {
@@ -133,9 +133,9 @@ input MembershipReferenceInput {
 
 input MembershipUpdateInput {
   membershipId: String
-  tenant: TenantReferenceInput
   member: MemberReferenceInput
   membershipName: String
+  tenant: TenantReferenceInput
 }
 
 input MembershipUpdateInputFromMember {
@@ -146,8 +146,8 @@ input MembershipUpdateInputFromMember {
 
 input MembershipUpdateInputFromMemberNested {
   membershipId: String!
-  tenant: TenantUpdateInput!
   membershipName: String
+  tenant: TenantUpdateInput!
 }
 
 input MembershipUpdateInputFromTenant {

--- a/integration-tests/shared-fk/with-muliple-composite-fields/schema-tests/introspection.expected.graphql
+++ b/integration-tests/shared-fk/with-muliple-composite-fields/schema-tests/introspection.expected.graphql
@@ -1,0 +1,366 @@
+type Member {
+  memberId: String!
+  tenant: Tenant!
+  memberName: String
+  memberships(where: MembershipFilter, orderBy: [MembershipOrdering!], limit: Int, offset: Int): [Membership!]!
+  membershipsAgg(where: MembershipFilter): MembershipAgg
+}
+
+"""An aggregate for the `Member` type."""
+type MemberAgg {
+  memberId: StringAgg
+  tenant: TenantAgg
+  memberName: StringAgg
+}
+
+input MemberCreationInput {
+  memberId: String!
+  tenant: TenantReferenceInput!
+  memberName: String
+  memberships: [MembershipCreationInputFromMember!]!
+}
+
+input MemberCreationInputFromTenant {
+  memberId: String!
+  memberName: String
+  memberships: [MembershipCreationInputFromMember!]!
+}
+
+"""
+Predicate for the `Member` type parameter. 
+If a field is omitted, no filter is applied for that field.
+To check a field against null, use a `<field name>: null` filter
+"""
+input MemberFilter {
+  memberId: StringFilter
+  tenant: TenantFilter
+  memberName: StringFilter
+  memberships: MembershipFilter
+  and: [MemberFilter!]
+  or: [MemberFilter!]
+  not: MemberFilter
+}
+
+input MemberOrdering {
+  memberId: Ordering
+  tenant: [TenantOrdering!]
+  memberName: Ordering
+}
+
+input MemberReferenceInput {
+  memberId: String!
+  tenant: TenantReferenceInput!
+}
+
+input MemberUpdateInput {
+  memberId: String
+  tenant: TenantReferenceInput
+  memberName: String
+  memberships: MembershipUpdateInputFromMember
+}
+
+input MemberUpdateInputFromTenant {
+  create: [MemberCreationInputFromTenant!]
+  update: [MemberUpdateInputFromTenantNested!]
+  delete: [MemberReferenceInput!]
+}
+
+input MemberUpdateInputFromTenantNested {
+  memberId: String!
+  memberName: String
+  memberships: MembershipUpdateInputFromMember
+}
+
+type Membership {
+  membershipId: String!
+  tenant: Tenant!
+  member: Member
+  membershipName: String
+}
+
+"""An aggregate for the `Membership` type."""
+type MembershipAgg {
+  membershipId: StringAgg
+  tenant: TenantAgg
+  membershipName: StringAgg
+}
+
+input MembershipCreationInput {
+  membershipId: String!
+  tenant: TenantReferenceInput!
+  member: MemberReferenceInput
+  membershipName: String
+}
+
+input MembershipCreationInputFromMember {
+  membershipId: String!
+  tenant: TenantReferenceInput!
+  membershipName: String
+}
+
+input MembershipCreationInputFromTenant {
+  membershipId: String!
+  member: MemberReferenceInput
+  membershipName: String
+}
+
+"""
+Predicate for the `Membership` type parameter. 
+If a field is omitted, no filter is applied for that field.
+To check a field against null, use a `<field name>: null` filter
+"""
+input MembershipFilter {
+  membershipId: StringFilter
+  tenant: TenantFilter
+  member: MemberFilter
+  membershipName: StringFilter
+  and: [MembershipFilter!]
+  or: [MembershipFilter!]
+  not: MembershipFilter
+}
+
+input MembershipOrdering {
+  membershipId: Ordering
+  tenant: [TenantOrdering!]
+  member: [MemberOrdering!]
+  membershipName: Ordering
+}
+
+input MembershipReferenceInput {
+  membershipId: String!
+  tenant: TenantReferenceInput!
+}
+
+input MembershipUpdateInput {
+  membershipId: String
+  tenant: TenantReferenceInput
+  member: MemberReferenceInput
+  membershipName: String
+}
+
+input MembershipUpdateInputFromMember {
+  create: [MembershipCreationInputFromMember!]
+  update: [MembershipUpdateInputFromMemberNested!]
+  delete: [MembershipReferenceInput!]
+}
+
+input MembershipUpdateInputFromMemberNested {
+  membershipId: String!
+  tenant: TenantUpdateInput!
+  membershipName: String
+}
+
+input MembershipUpdateInputFromTenant {
+  create: [MembershipCreationInputFromTenant!]
+  update: [MembershipUpdateInputFromTenantNested!]
+  delete: [MembershipReferenceInput!]
+}
+
+input MembershipUpdateInputFromTenantNested {
+  membershipId: String!
+  member: MemberReferenceInput
+  membershipName: String
+}
+
+enum Ordering {
+  ASC
+  DESC
+}
+
+type StringAgg {
+  min: String
+  max: String
+  count: Int
+}
+
+input StringFilter {
+  eq: String
+  neq: String
+  lt: String
+  lte: String
+  gt: String
+  gte: String
+  like: String
+  ilike: String
+  startsWith: String
+  endsWith: String
+}
+
+type Tenant {
+  tenantId: String!
+  tenantName: String
+  memberships(where: MembershipFilter, orderBy: [MembershipOrdering!], limit: Int, offset: Int): [Membership!]!
+  members(where: MemberFilter, orderBy: [MemberOrdering!], limit: Int, offset: Int): [Member!]!
+  membershipsAgg(where: MembershipFilter): MembershipAgg
+  membersAgg(where: MemberFilter): MemberAgg
+}
+
+"""An aggregate for the `Tenant` type."""
+type TenantAgg {
+  tenantId: StringAgg
+  tenantName: StringAgg
+}
+
+input TenantCreationInput {
+  tenantId: String!
+  tenantName: String
+  memberships: [MembershipCreationInputFromTenant!]!
+  members: [MemberCreationInputFromTenant!]!
+}
+
+"""
+Predicate for the `Tenant` type parameter. 
+If a field is omitted, no filter is applied for that field.
+To check a field against null, use a `<field name>: null` filter
+"""
+input TenantFilter {
+  tenantId: StringFilter
+  tenantName: StringFilter
+  memberships: MembershipFilter
+  members: MemberFilter
+  and: [TenantFilter!]
+  or: [TenantFilter!]
+  not: TenantFilter
+}
+
+input TenantOrdering {
+  tenantId: Ordering
+  tenantName: Ordering
+}
+
+input TenantReferenceInput {
+  tenantId: String!
+}
+
+"""A predicate to filter the results for a `Tenant` type parameter."""
+input TenantUniqueFilter {
+  tenantId: String!
+}
+
+input TenantUpdateInput {
+  tenantId: String
+  tenantName: String
+  memberships: MembershipUpdateInputFromTenant
+  members: MemberUpdateInputFromTenant
+}
+
+type Query {
+  """Get a single `Member` given primary key fields"""
+  member(memberId: String!, tenant: TenantUniqueFilter!): Member
+
+  """
+  Get multiple `Member`s given the provided `where` filter, order by, limit, and offset
+  """
+  members(where: MemberFilter, orderBy: [MemberOrdering!], limit: Int, offset: Int): [Member!]!
+
+  """
+  Get the aggregate value of the selected fields over all `Member`s given the provided `where` filter
+  """
+  membersAgg(where: MemberFilter): MemberAgg!
+
+  """Get a single `Membership` given primary key fields"""
+  membership(membershipId: String!, tenant: TenantUniqueFilter!): Membership
+
+  """
+  Get multiple `Membership`s given the provided `where` filter, order by, limit, and offset
+  """
+  memberships(where: MembershipFilter, orderBy: [MembershipOrdering!], limit: Int, offset: Int): [Membership!]!
+
+  """
+  Get the aggregate value of the selected fields over all `Membership`s given the provided `where` filter
+  """
+  membershipsAgg(where: MembershipFilter): MembershipAgg!
+
+  """Get a single `Tenant` given primary key fields"""
+  tenant(tenantId: String!): Tenant
+
+  """
+  Get multiple `Tenant`s given the provided `where` filter, order by, limit, and offset
+  """
+  tenants(where: TenantFilter, orderBy: [TenantOrdering!], limit: Int, offset: Int): [Tenant!]!
+
+  """
+  Get the aggregate value of the selected fields over all `Tenant`s given the provided `where` filter
+  """
+  tenantsAgg(where: TenantFilter): TenantAgg!
+}
+
+type Mutation {
+  """
+  Create a new Member. Check the `MemberCreationInput` type for the expected shape of the data.
+  """
+  createMember(data: MemberCreationInput!): Member!
+
+  """
+  Create multiple Members. Check the `MemberCreationInput` type for the expected shape of the data.
+  """
+  createMembers(data: [MemberCreationInput!]!): [Member!]!
+
+  """
+  Create a new Membership. Check the `MembershipCreationInput` type for the expected shape of the data.
+  """
+  createMembership(data: MembershipCreationInput!): Membership!
+
+  """
+  Create multiple Memberships. Check the `MembershipCreationInput` type for the expected shape of the data.
+  """
+  createMemberships(data: [MembershipCreationInput!]!): [Membership!]!
+
+  """
+  Create a new Tenant. Check the `TenantCreationInput` type for the expected shape of the data.
+  """
+  createTenant(data: TenantCreationInput!): Tenant!
+
+  """
+  Create multiple Tenants. Check the `TenantCreationInput` type for the expected shape of the data.
+  """
+  createTenants(data: [TenantCreationInput!]!): [Tenant!]!
+
+  """Delete the Member with the provided primary key."""
+  deleteMember(memberId: String!, tenant: TenantUniqueFilter!): Member
+
+  """Delete multiple Members matching the provided `where` filter."""
+  deleteMembers(where: MemberFilter): [Member!]!
+
+  """Delete the Membership with the provided primary key."""
+  deleteMembership(membershipId: String!, tenant: TenantUniqueFilter!): Membership
+
+  """Delete multiple Memberships matching the provided `where` filter."""
+  deleteMemberships(where: MembershipFilter): [Membership!]!
+
+  """Delete the Tenant with the provided primary key."""
+  deleteTenant(tenantId: String!): Tenant
+
+  """Delete multiple Tenants matching the provided `where` filter."""
+  deleteTenants(where: TenantFilter): [Tenant!]!
+
+  """
+  Update the Member with the provided primary key with the provided data. Any fields not provided will remain unchanged.
+  """
+  updateMember(memberId: String!, tenant: TenantUniqueFilter!, data: MemberUpdateInput!): Member
+
+  """
+  Update multiple Members matching the provided `where` filter with the provided data. Any fields not provided will remain unchanged.
+  """
+  updateMembers(where: MemberFilter, data: MemberUpdateInput!): [Member!]!
+
+  """
+  Update the Membership with the provided primary key with the provided data. Any fields not provided will remain unchanged.
+  """
+  updateMembership(membershipId: String!, tenant: TenantUniqueFilter!, data: MembershipUpdateInput!): Membership
+
+  """
+  Update multiple Memberships matching the provided `where` filter with the provided data. Any fields not provided will remain unchanged.
+  """
+  updateMemberships(where: MembershipFilter, data: MembershipUpdateInput!): [Membership!]!
+
+  """
+  Update the Tenant with the provided primary key with the provided data. Any fields not provided will remain unchanged.
+  """
+  updateTenant(tenantId: String!, data: TenantUpdateInput!): Tenant
+
+  """
+  Update multiple Tenants matching the provided `where` filter with the provided data. Any fields not provided will remain unchanged.
+  """
+  updateTenants(where: TenantFilter, data: TenantUpdateInput!): [Tenant!]!
+}

--- a/integration-tests/shared-fk/with-muliple-composite-fields/src/index.exo
+++ b/integration-tests/shared-fk/with-muliple-composite-fields/src/index.exo
@@ -11,9 +11,10 @@ module Database {
   @access(query=true, mutation=true)
   type Membership {
     @pk membershipId: String
-    @pk @column("membership_tenant_id") tenant: Tenant
     @column(mapping={memberId: "membership_member_id", tenant: "membership_tenant_id"}) member: Member?
     membershipName: String?
+    // Keeping this after the member field to test that the relation is found correctly
+    @pk @column("membership_tenant_id") tenant: Tenant
   }
 
   @access(query=true, mutation=true)

--- a/integration-tests/shared-fk/with-muliple-composite-fields/src/index.exo
+++ b/integration-tests/shared-fk/with-muliple-composite-fields/src/index.exo
@@ -1,0 +1,26 @@
+@postgres
+module Database {
+  @access(query=true, mutation=true)
+  type Member {
+    @pk memberId: String
+    @pk @column("member_tenant_id") tenant: Tenant
+    memberName: String?
+    memberships: Set<Membership>
+  }
+
+  @access(query=true, mutation=true)
+  type Membership {
+    @pk membershipId: String
+    @pk @column("membership_tenant_id") tenant: Tenant
+    @column(mapping={memberId: "membership_member_id", tenant: "membership_tenant_id"}) member: Member?
+    membershipName: String?
+  }
+
+  @access(query=true, mutation=true)
+  type Tenant {
+    @pk tenantId: String
+    tenantName: String?
+    memberships: Set<Membership>
+    members: Set<Member>
+  }
+}

--- a/integration-tests/shared-fk/with-muliple-composite-fields/tests/init.gql
+++ b/integration-tests/shared-fk/with-muliple-composite-fields/tests/init.gql
@@ -1,0 +1,61 @@
+operation: |
+    mutation {
+        tenant1: createTenant(data: {tenantId: "tenant1", tenantName: "Tech Corp", memberships: [], members: []}) {
+            tenantId
+        }
+        tenant2: createTenant(data: {tenantId: "tenant2", tenantName: "Finance Ltd", memberships: [], members: []}) {
+            tenantId
+        }
+        
+        member1: createMember(data: {
+            memberId: "tenant1-member1", 
+            tenant: {tenantId: "tenant1"}, 
+            memberName: "Alice Smith",
+            memberships: [
+                {
+                    membershipId: "tenant1-membership1",
+                    tenant: {tenantId: "tenant1"},
+                    membershipName: "Premium"
+                }
+            ]
+        }) {
+            memberId
+            tenant {
+                tenantId
+            }
+        }
+        member2: createMember(data: {
+            memberId: "tenant1-member2", 
+            tenant: {tenantId: "tenant1"}, 
+            memberName: "Bob Johnson",
+            memberships: [
+                {
+                    membershipId: "tenant1-membership2",
+                    tenant: {tenantId: "tenant1"},
+                    membershipName: "Basic"
+                }
+            ]
+        }) {
+            memberId
+            tenant {
+                tenantId
+            }
+        }
+        member3: createMember(data: {
+            memberId: "tenant2-member1", 
+            tenant: {tenantId: "tenant2"}, 
+            memberName: "Carol Davis",
+            memberships: [
+                {
+                    membershipId: "tenant2-membership1",
+                    tenant: {tenantId: "tenant2"},
+                    membershipName: "Enterprise"
+                }
+            ]
+        }) {
+            memberId
+            tenant {
+                tenantId
+            }
+        }
+    }

--- a/integration-tests/shared-fk/with-muliple-composite-fields/tests/member-filtering.exotest
+++ b/integration-tests/shared-fk/with-muliple-composite-fields/tests/member-filtering.exotest
@@ -3,14 +3,23 @@ operation: |
     memberId
     tenant {
       tenantId
+      tenantName
     }
     memberName
     memberships {
       membershipId
       tenant {
         tenantId
+        tenantName
       }
       membershipName
+      member {
+        memberId
+        tenant {
+          tenantId
+        }
+        memberName
+      }
     }
   }
   query {
@@ -32,7 +41,16 @@ operation: |
     tenant1MembersStartingWithA: members(where: {and: [{tenant: {tenantId: {eq: "tenant1"}}}, {memberName: {startsWith: "A"}}]}) {
       ...memberInfo
     }
-    singleMember: member(memberId: "tenant1-member1", tenant: {tenantId: "tenant1"}) {
+    tenant1Member1: member(memberId: "tenant1-member1", tenant: {tenantId: "tenant1"}) {
+      ...memberInfo
+    }
+    tenant1Member2: member(memberId: "tenant1-member2", tenant: {tenantId: "tenant1"}) {
+      ...memberInfo
+    }
+    tenant2Member1: member(memberId: "tenant2-member1", tenant: {tenantId: "tenant2"}) {
+      ...memberInfo
+    }
+    nonExisting: member(memberId: "tenant1-member1", tenant: {tenantId: "tenant2"}) {
       ...memberInfo
     }
   }
@@ -43,48 +61,75 @@ response: |
         {
           "memberId": "tenant1-member1",
           "tenant": {
-          "tenantId": "tenant1"
-        },
+            "tenantId": "tenant1",
+            "tenantName": "Tech Corp"
+          },
           "memberName": "Alice Smith",
           "memberships": [
             {
               "membershipId": "tenant1-membership1",
               "tenant": {
-                "tenantId": "tenant1"
+                "tenantId": "tenant1",
+                "tenantName": "Tech Corp"
               },
-              "membershipName": "Premium"
+              "membershipName": "Premium",
+              "member": {
+                "memberId": "tenant1-member1",
+                "tenant": {
+                  "tenantId": "tenant1"
+                },
+                "memberName": "Alice Smith"
+              }
             }
           ]
         },
         {
           "memberId": "tenant1-member2",
           "tenant": {
-          "tenantId": "tenant1"
-        },
+            "tenantId": "tenant1",
+            "tenantName": "Tech Corp"
+          },
           "memberName": "Bob Johnson",
           "memberships": [
             {
               "membershipId": "tenant1-membership2",
               "tenant": {
-                "tenantId": "tenant1"
+                "tenantId": "tenant1",
+                "tenantName": "Tech Corp"
               },
-              "membershipName": "Basic"
+              "membershipName": "Basic",
+              "member": {
+                "memberId": "tenant1-member2",
+                "tenant": {
+                  "tenantId": "tenant1"
+                },
+                "memberName": "Bob Johnson"
+              }
             }
           ]
         },
         {
           "memberId": "tenant2-member1",
           "tenant": {
-          "tenantId": "tenant2"
-        },
+            "tenantId": "tenant2",
+            "tenantName": "Finance Ltd"
+          },
           "memberName": "Carol Davis",
           "memberships": [
             {
               "membershipId": "tenant2-membership1",
               "tenant": {
-                "tenantId": "tenant2"
+                "tenantId": "tenant2",
+                "tenantName": "Finance Ltd"
               },
-              "membershipName": "Enterprise"
+              "membershipName": "Enterprise",
+              "member": {
+                "memberId": "tenant2-member1",
+                "tenant": {
+                  "tenantId": "tenant2"
+                },
+                "memberName": "Carol Davis"
+              }
             }
           ]
         }
@@ -93,32 +138,50 @@ response: |
         {
           "memberId": "tenant1-member1",
           "tenant": {
-          "tenantId": "tenant1"
-        },
+            "tenantId": "tenant1",
+            "tenantName": "Tech Corp"
+          },
           "memberName": "Alice Smith",
           "memberships": [
             {
               "membershipId": "tenant1-membership1",
               "tenant": {
-                "tenantId": "tenant1"
+                "tenantId": "tenant1",
+                "tenantName": "Tech Corp"
               },
-              "membershipName": "Premium"
+              "membershipName": "Premium",
+              "member": {
+                "memberId": "tenant1-member1",
+                "tenant": {
+                  "tenantId": "tenant1"
+                },
+                "memberName": "Alice Smith"
+              }
             }
           ]
         },
         {
           "memberId": "tenant1-member2",
           "tenant": {
-          "tenantId": "tenant1"
-        },
+            "tenantId": "tenant1",
+            "tenantName": "Tech Corp"
+          },
           "memberName": "Bob Johnson",
           "memberships": [
             {
               "membershipId": "tenant1-membership2",
               "tenant": {
-                "tenantId": "tenant1"
+                "tenantId": "tenant1",
+                "tenantName": "Tech Corp"
               },
-              "membershipName": "Basic"
+              "membershipName": "Basic",
+              "member": {
+                "memberId": "tenant1-member2",
+                "tenant": {
+                  "tenantId": "tenant1"
+                },
+                "memberName": "Bob Johnson"
+              }
             }
           ]
         }
@@ -127,16 +190,25 @@ response: |
         {
           "memberId": "tenant1-member1",
           "tenant": {
-          "tenantId": "tenant1"
-        },
+            "tenantId": "tenant1",
+            "tenantName": "Tech Corp"
+          },
           "memberName": "Alice Smith",
           "memberships": [
             {
               "membershipId": "tenant1-membership1",
               "tenant": {
-                "tenantId": "tenant1"
+                "tenantId": "tenant1",
+                "tenantName": "Tech Corp"
               },
-              "membershipName": "Premium"
+              "membershipName": "Premium",
+              "member": {
+                "memberId": "tenant1-member1",
+                "tenant": {
+                  "tenantId": "tenant1"
+                },
+                "memberName": "Alice Smith"
+              }
             }
           ]
         }
@@ -145,16 +217,25 @@ response: |
         {
           "memberId": "tenant1-member1",
           "tenant": {
-          "tenantId": "tenant1"
-        },
+            "tenantId": "tenant1",
+            "tenantName": "Tech Corp"
+          },
           "memberName": "Alice Smith",
           "memberships": [
             {
               "membershipId": "tenant1-membership1",
               "tenant": {
-                "tenantId": "tenant1"
+                "tenantId": "tenant1",
+                "tenantName": "Tech Corp"
               },
-              "membershipName": "Premium"
+              "membershipName": "Premium",
+              "member": {
+                "memberId": "tenant1-member1",
+                "tenant": {
+                  "tenantId": "tenant1"
+                },
+                "memberName": "Alice Smith"
+              }
             }
           ]
         }
@@ -163,16 +244,25 @@ response: |
         {
           "memberId": "tenant2-member1",
           "tenant": {
-          "tenantId": "tenant2"
-        },
+            "tenantId": "tenant2",
+            "tenantName": "Finance Ltd"
+          },
           "memberName": "Carol Davis",
           "memberships": [
             {
               "membershipId": "tenant2-membership1",
               "tenant": {
-                "tenantId": "tenant2"
+                "tenantId": "tenant2",
+                "tenantName": "Finance Ltd"
               },
-              "membershipName": "Enterprise"
+              "membershipName": "Enterprise",
+              "member": {
+                "memberId": "tenant2-member1",
+                "tenant": {
+                  "tenantId": "tenant2"
+                },
+                "memberName": "Carol Davis"
+              }
             }
           ]
         }
@@ -181,35 +271,104 @@ response: |
         {
           "memberId": "tenant1-member1",
           "tenant": {
-          "tenantId": "tenant1"
-        },
+            "tenantId": "tenant1",
+            "tenantName": "Tech Corp"
+          },
           "memberName": "Alice Smith",
           "memberships": [
             {
               "membershipId": "tenant1-membership1",
               "tenant": {
-                "tenantId": "tenant1"
+                "tenantId": "tenant1",
+                "tenantName": "Tech Corp"
               },
-              "membershipName": "Premium"
+              "membershipName": "Premium",
+              "member": {
+                "memberId": "tenant1-member1",
+                "tenant": {
+                  "tenantId": "tenant1"
+                },
+                "memberName": "Alice Smith"
+              }
             }
           ]
         }
       ],
-      "singleMember": {
+      "tenant1Member1": {
         "memberId": "tenant1-member1",
         "tenant": {
-          "tenantId": "tenant1"
+          "tenantId": "tenant1",
+          "tenantName": "Tech Corp"
         },
         "memberName": "Alice Smith",
         "memberships": [
           {
             "membershipId": "tenant1-membership1",
             "tenant": {
-              "tenantId": "tenant1"
+              "tenantId": "tenant1",
+              "tenantName": "Tech Corp"
             },
-            "membershipName": "Premium"
+            "membershipName": "Premium",
+            "member": {
+              "memberId": "tenant1-member1",
+              "tenant": {
+                "tenantId": "tenant1"
+              },
+              "memberName": "Alice Smith"
+            }
           }
         ]
-      }
+      },
+      "tenant1Member2": {
+        "memberId": "tenant1-member2",
+        "tenant": {
+          "tenantId": "tenant1",
+          "tenantName": "Tech Corp"
+        },
+        "memberName": "Bob Johnson",
+        "memberships": [
+          {
+            "membershipId": "tenant1-membership2",
+            "tenant": {
+              "tenantId": "tenant1",
+              "tenantName": "Tech Corp"
+            },
+            "membershipName": "Basic",
+            "member": {
+              "memberId": "tenant1-member2",
+              "tenant": {
+                "tenantId": "tenant1"
+              },
+              "memberName": "Bob Johnson"
+            }
+          }
+        ]
+      },
+      "tenant2Member1": {
+        "memberId": "tenant2-member1",
+        "tenant": {
+          "tenantId": "tenant2",
+          "tenantName": "Finance Ltd"
+        },
+        "memberName": "Carol Davis",
+        "memberships": [
+          {
+            "membershipId": "tenant2-membership1",
+            "tenant": {
+              "tenantId": "tenant2",
+              "tenantName": "Finance Ltd"
+            },
+            "membershipName": "Enterprise",
+            "member": {
+              "memberId": "tenant2-member1",
+              "tenant": {
+                "tenantId": "tenant2"
+              },
+              "memberName": "Carol Davis"
+            }
+          }
+        ]
+      },
+      "nonExisting": null
     }
   }

--- a/integration-tests/shared-fk/with-muliple-composite-fields/tests/member-filtering.exotest
+++ b/integration-tests/shared-fk/with-muliple-composite-fields/tests/member-filtering.exotest
@@ -1,0 +1,215 @@
+operation: |
+  fragment memberInfo on Member {
+    memberId
+    tenant {
+      tenantId
+    }
+    memberName
+    memberships {
+      membershipId
+      tenant {
+        tenantId
+      }
+      membershipName
+    }
+  }
+  query {
+    allMembers: members(orderBy: {memberId: ASC}) {
+      ...memberInfo
+    }
+    byTenant: members(where: {tenant: {tenantId: {eq: "tenant1"}}}, orderBy: {memberId: ASC}) {
+      ...memberInfo
+    }
+    byName: members(where: {memberName: {like: "%Smith%"}}) {
+      ...memberInfo
+    }
+    byMembershipType: members(where: {memberships: {membershipName: {eq: "Premium"}}}) {
+      ...memberInfo
+    }
+    byMembershipTenant: members(where: {memberships: {tenant: {tenantId: {eq: "tenant2"}}}}) {
+      ...memberInfo
+    }
+    tenant1MembersStartingWithA: members(where: {and: [{tenant: {tenantId: {eq: "tenant1"}}}, {memberName: {startsWith: "A"}}]}) {
+      ...memberInfo
+    }
+    singleMember: member(memberId: "tenant1-member1", tenant: {tenantId: "tenant1"}) {
+      ...memberInfo
+    }
+  }
+response: |
+  {
+    "data": {
+      "allMembers": [
+        {
+          "memberId": "tenant1-member1",
+          "tenant": {
+          "tenantId": "tenant1"
+        },
+          "memberName": "Alice Smith",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership1",
+              "tenant": {
+                "tenantId": "tenant1"
+              },
+              "membershipName": "Premium"
+            }
+          ]
+        },
+        {
+          "memberId": "tenant1-member2",
+          "tenant": {
+          "tenantId": "tenant1"
+        },
+          "memberName": "Bob Johnson",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership2",
+              "tenant": {
+                "tenantId": "tenant1"
+              },
+              "membershipName": "Basic"
+            }
+          ]
+        },
+        {
+          "memberId": "tenant2-member1",
+          "tenant": {
+          "tenantId": "tenant2"
+        },
+          "memberName": "Carol Davis",
+          "memberships": [
+            {
+              "membershipId": "tenant2-membership1",
+              "tenant": {
+                "tenantId": "tenant2"
+              },
+              "membershipName": "Enterprise"
+            }
+          ]
+        }
+      ],
+      "byTenant": [
+        {
+          "memberId": "tenant1-member1",
+          "tenant": {
+          "tenantId": "tenant1"
+        },
+          "memberName": "Alice Smith",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership1",
+              "tenant": {
+                "tenantId": "tenant1"
+              },
+              "membershipName": "Premium"
+            }
+          ]
+        },
+        {
+          "memberId": "tenant1-member2",
+          "tenant": {
+          "tenantId": "tenant1"
+        },
+          "memberName": "Bob Johnson",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership2",
+              "tenant": {
+                "tenantId": "tenant1"
+              },
+              "membershipName": "Basic"
+            }
+          ]
+        }
+      ],
+      "byName": [
+        {
+          "memberId": "tenant1-member1",
+          "tenant": {
+          "tenantId": "tenant1"
+        },
+          "memberName": "Alice Smith",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership1",
+              "tenant": {
+                "tenantId": "tenant1"
+              },
+              "membershipName": "Premium"
+            }
+          ]
+        }
+      ],
+      "byMembershipType": [
+        {
+          "memberId": "tenant1-member1",
+          "tenant": {
+          "tenantId": "tenant1"
+        },
+          "memberName": "Alice Smith",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership1",
+              "tenant": {
+                "tenantId": "tenant1"
+              },
+              "membershipName": "Premium"
+            }
+          ]
+        }
+      ],
+      "byMembershipTenant": [
+        {
+          "memberId": "tenant2-member1",
+          "tenant": {
+          "tenantId": "tenant2"
+        },
+          "memberName": "Carol Davis",
+          "memberships": [
+            {
+              "membershipId": "tenant2-membership1",
+              "tenant": {
+                "tenantId": "tenant2"
+              },
+              "membershipName": "Enterprise"
+            }
+          ]
+        }
+      ],
+      "tenant1MembersStartingWithA": [
+        {
+          "memberId": "tenant1-member1",
+          "tenant": {
+          "tenantId": "tenant1"
+        },
+          "memberName": "Alice Smith",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership1",
+              "tenant": {
+                "tenantId": "tenant1"
+              },
+              "membershipName": "Premium"
+            }
+          ]
+        }
+      ],
+      "singleMember": {
+        "memberId": "tenant1-member1",
+        "tenant": {
+          "tenantId": "tenant1"
+        },
+        "memberName": "Alice Smith",
+        "memberships": [
+          {
+            "membershipId": "tenant1-membership1",
+            "tenant": {
+              "tenantId": "tenant1"
+            },
+            "membershipName": "Premium"
+          }
+        ]
+      }
+    }
+  }

--- a/integration-tests/shared-fk/with-muliple-composite-fields/tests/member-update.exotest
+++ b/integration-tests/shared-fk/with-muliple-composite-fields/tests/member-update.exotest
@@ -1,0 +1,36 @@
+operation: |
+  mutation {
+    updateMember1: updateMember(
+      memberId: "tenant1-member1", 
+      tenant: {tenantId: "tenant1"},
+      data: {memberId: "tenant1-member1", tenant: {tenantId: "tenant1"}, memberName: "Alice Smith Updated"}
+    ) {
+      memberId
+      tenant {
+        tenantId
+      }
+      memberName
+      memberships {
+        membershipId
+        membershipName
+      }
+    }
+  }
+response: |
+  {
+    "data": {
+      "updateMember1": {
+        "memberId": "tenant1-member1",
+        "tenant": {
+          "tenantId": "tenant1"
+        },
+        "memberName": "Alice Smith Updated",
+        "memberships": [
+          {
+            "membershipId": "tenant1-membership1",
+            "membershipName": "Premium"
+          }
+        ]
+      }
+    }
+  }

--- a/integration-tests/shared-fk/with-muliple-composite-fields/tests/membership-filtering.exotest
+++ b/integration-tests/shared-fk/with-muliple-composite-fields/tests/membership-filtering.exotest
@@ -1,0 +1,162 @@
+operation: |
+  fragment membershipInfo on Membership {
+    membershipId
+      tenant {
+        tenantId
+      }
+      membershipName
+      member {
+        memberId
+        tenant {
+          tenantId
+        }
+        memberName
+      }
+  }
+  query {
+    allMemberships: memberships(orderBy: {membershipId: ASC}) @unordered {
+      ...membershipInfo
+    }
+    byMemberAndTenantMatching: memberships(where: {member: {memberId: {eq: "tenant1-member1"}, tenant: {tenantId: {eq: "tenant1"}}}, tenant: {tenantId: {eq: "tenant1"}}}) @unordered {
+      ...membershipInfo
+    }
+    byMemberAndTenantNotMatching: memberships(where: {member: {memberId: {eq: "tenant1-member1"}, tenant: {tenantId: {eq: "tenant1"}}}, tenant: {tenantId: {eq: "tenant2"}}}) @unordered {
+      ...membershipInfo
+    }
+    byMember: memberships(where: {member: {memberId: {eq: "tenant1-member1"}}}) @unordered {
+      ...membershipInfo
+    }
+    byTenant: memberships(where: {tenant: {tenantId: {eq: "tenant1"}}}) @unordered {
+      ...membershipInfo
+    }
+    singleMembership: membership(membershipId: "tenant1-membership1", tenant: {tenantId: "tenant1"}) {
+      ...membershipInfo
+    }
+  }
+response: |
+  {
+    "data": {
+      "allMemberships": [
+        {
+          "membershipId": "tenant1-membership1",
+          "tenant": {
+            "tenantId": "tenant1"
+          },
+          "membershipName": "Premium",
+          "member": {
+            "memberId": "tenant1-member1",
+            "tenant": {
+            "tenantId": "tenant1"
+          },
+            "memberName": "Alice Smith"
+          }
+        },
+        {
+          "membershipId": "tenant1-membership2",
+          "tenant": {
+            "tenantId": "tenant1"
+          },
+          "membershipName": "Basic",
+          "member": {
+            "memberId": "tenant1-member2",
+            "tenant": {
+            "tenantId": "tenant1"
+          },
+            "memberName": "Bob Johnson"
+          }
+        },
+        {
+          "membershipId": "tenant2-membership1",
+          "tenant": {
+            "tenantId": "tenant2"
+          },
+          "membershipName": "Enterprise",
+          "member": {
+            "memberId": "tenant2-member1",
+            "tenant": {
+            "tenantId": "tenant2"
+          },
+            "memberName": "Carol Davis"
+          }
+        }
+      ],
+      "byMemberAndTenantMatching": [
+        {
+          "membershipId": "tenant1-membership1",
+          "tenant": {
+            "tenantId": "tenant1"
+          },
+          "membershipName": "Premium",
+          "member": {
+            "memberId": "tenant1-member1",
+            "tenant": {
+            "tenantId": "tenant1"
+          },
+            "memberName": "Alice Smith"
+          }
+        }
+      ],
+      "byMemberAndTenantNotMatching": [
+      ],
+      "byMember": [
+        {
+          "membershipId": "tenant1-membership1",
+          "tenant": {
+            "tenantId": "tenant1"
+          },
+          "membershipName": "Premium",
+          "member": {
+            "memberId": "tenant1-member1",
+            "tenant": {
+            "tenantId": "tenant1"
+          },
+            "memberName": "Alice Smith"
+          }
+        }
+      ],
+      "byTenant": [
+        {
+          "membershipId": "tenant1-membership1",
+          "tenant": {
+            "tenantId": "tenant1"
+          },
+          "membershipName": "Premium",
+          "member": {
+            "memberId": "tenant1-member1",
+            "tenant": {
+            "tenantId": "tenant1"
+          },
+            "memberName": "Alice Smith"
+          }
+        },
+        {
+          "membershipId": "tenant1-membership2",
+          "tenant": {
+            "tenantId": "tenant1"
+          },
+          "membershipName": "Basic",
+          "member": {
+            "memberId": "tenant1-member2",
+            "tenant": {
+            "tenantId": "tenant1"
+          },
+            "memberName": "Bob Johnson"
+          }
+        }
+      ],
+      "singleMembership": {
+        "membershipId": "tenant1-membership1",
+        "tenant": {
+          "tenantId": "tenant1"
+        },
+        "membershipName": "Premium",
+        "member": {
+          "memberId": "tenant1-member1",
+          "tenant": {
+            "tenantId": "tenant1"
+          },
+          "memberName": "Alice Smith"
+        }
+      }
+    }
+  }

--- a/integration-tests/shared-fk/with-muliple-composite-fields/tests/membership-update.exotest
+++ b/integration-tests/shared-fk/with-muliple-composite-fields/tests/membership-update.exotest
@@ -1,0 +1,34 @@
+operation: |
+  mutation {
+    updateMembership1: updateMembership(
+      membershipId: "tenant1-membership1", 
+      tenant: {tenantId: "tenant1"},
+      data: {membershipId: "tenant1-membership1", tenant: {tenantId: "tenant1"}, membershipName: "Premium Plus"}
+    ) {
+      membershipId
+      tenant {
+        tenantId
+      }
+      membershipName
+      member {
+        memberId
+        memberName
+      }
+    }
+  }
+response: |
+  {
+    "data": {
+      "updateMembership1": {
+        "membershipId": "tenant1-membership1",
+        "tenant": {
+          "tenantId": "tenant1"
+        },
+        "membershipName": "Premium Plus",
+        "member": {
+          "memberId": "tenant1-member1",
+          "memberName": "Alice Smith"
+        }
+      }
+    }
+  }

--- a/integration-tests/shared-fk/with-muliple-composite-fields/tests/tenant-filtering.exotest
+++ b/integration-tests/shared-fk/with-muliple-composite-fields/tests/tenant-filtering.exotest
@@ -1,0 +1,116 @@
+operation: |
+  query {
+    tenant1Members: members(where: {tenant: {tenantId: {eq: "tenant1"}}}, orderBy: {memberId: ASC}) {
+      memberId
+      tenant {
+        tenantId
+      }
+      memberName
+      memberships {
+        membershipId
+        membershipName
+      }
+    }
+    tenant2Members: members(where: {tenant: {tenantId: {eq: "tenant2"}}}) {
+      memberId
+      tenant {
+        tenantId
+      }
+      memberName
+      memberships {
+        membershipId
+        membershipName
+      }
+    }
+    tenant1Memberships: memberships(where: {tenant: {tenantId: {eq: "tenant1"}}}, orderBy: {membershipId: ASC}) {
+      membershipId
+      tenant {
+        tenantId
+      }
+      membershipName
+      member {
+        memberId
+        memberName
+      }
+    }
+    singleTenant: tenant(tenantId: "tenant1") {
+      tenantId
+      tenantName
+    }
+  }
+response: |
+  {
+    "data": {
+      "tenant1Members": [
+        {
+          "memberId": "tenant1-member1",
+          "tenant": {
+            "tenantId": "tenant1"
+          },
+          "memberName": "Alice Smith",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership1",
+              "membershipName": "Premium"
+            }
+          ]
+        },
+        {
+          "memberId": "tenant1-member2",
+          "tenant": {
+            "tenantId": "tenant1"
+          },
+          "memberName": "Bob Johnson",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership2",
+              "membershipName": "Basic"
+            }
+          ]
+        }
+      ],
+      "tenant2Members": [
+        {
+          "memberId": "tenant2-member1",
+          "tenant": {
+            "tenantId": "tenant2"
+          },
+          "memberName": "Carol Davis",
+          "memberships": [
+            {
+              "membershipId": "tenant2-membership1",
+              "membershipName": "Enterprise"
+            }
+          ]
+        }
+      ],
+      "tenant1Memberships": [
+        {
+          "membershipId": "tenant1-membership1",
+          "tenant": {
+            "tenantId": "tenant1"
+          },
+          "membershipName": "Premium",
+          "member": {
+            "memberId": "tenant1-member1",
+            "memberName": "Alice Smith"
+          }
+        },
+        {
+          "membershipId": "tenant1-membership2",
+          "tenant": {
+            "tenantId": "tenant1"
+          },
+          "membershipName": "Basic",
+          "member": {
+            "memberId": "tenant1-member2",
+            "memberName": "Bob Johnson"
+          }
+        }
+      ],
+      "singleTenant": {
+        "tenantId": "tenant1",
+        "tenantName": "Tech Corp"
+      }
+    }
+  }

--- a/integration-tests/shared-fk/with-muliple-composite-fields/tests/tenant-filtering.exotest
+++ b/integration-tests/shared-fk/with-muliple-composite-fields/tests/tenant-filtering.exotest
@@ -1,116 +1,320 @@
 operation: |
-  query {
-    tenant1Members: members(where: {tenant: {tenantId: {eq: "tenant1"}}}, orderBy: {memberId: ASC}) {
-      memberId
-      tenant {
-        tenantId
-      }
-      memberName
-      memberships {
-        membershipId
-        membershipName
-      }
-    }
-    tenant2Members: members(where: {tenant: {tenantId: {eq: "tenant2"}}}) {
-      memberId
-      tenant {
-        tenantId
-      }
-      memberName
-      memberships {
-        membershipId
-        membershipName
-      }
-    }
-    tenant1Memberships: memberships(where: {tenant: {tenantId: {eq: "tenant1"}}}, orderBy: {membershipId: ASC}) {
+  fragment tenantInfo on Tenant {
+    tenantId
+    tenantName
+    memberships @unordered {
       membershipId
+      membershipName
       tenant {
         tenantId
+        tenantName
       }
-      membershipName
       member {
         memberId
+        tenant {
+          tenantId
+        }
         memberName
       }
     }
+    members {
+      memberId
+      tenant {
+        tenantId
+      }
+      memberName
+      memberships @unordered {
+        membershipId
+        membershipName
+      }
+    }
+  }
+  query {
+    allTenants: tenants(orderBy: {tenantId: ASC}) @unordered {
+      ...tenantInfo
+    }
+    tenant1: tenants(where: {tenantId: {eq: "tenant1"}}, orderBy: {tenantId: ASC}) {
+      ...tenantInfo
+    }
+    tenant2: tenants(where: {tenantId: {eq: "tenant2"}}) {
+      ...tenantInfo
+    }
     singleTenant: tenant(tenantId: "tenant1") {
-      tenantId
-      tenantName
+      ...tenantInfo
     }
   }
 response: |
   {
     "data": {
-      "tenant1Members": [
+      "allTenants": [
         {
-          "memberId": "tenant1-member1",
-          "tenant": {
-            "tenantId": "tenant1"
-          },
-          "memberName": "Alice Smith",
+          "tenantId": "tenant1",
+          "tenantName": "Tech Corp",
           "memberships": [
             {
               "membershipId": "tenant1-membership1",
-              "membershipName": "Premium"
+              "membershipName": "Premium",
+              "tenant": {
+                "tenantId": "tenant1",
+                "tenantName": "Tech Corp"
+              },
+              "member": {
+                "memberId": "tenant1-member1",
+                "tenant": {
+                  "tenantId": "tenant1"
+                },
+                "memberName": "Alice Smith"
+              }
+            },
+            {
+              "membershipId": "tenant1-membership2",
+              "membershipName": "Basic",
+              "tenant": {
+                "tenantId": "tenant1",
+                "tenantName": "Tech Corp"
+              },
+              "member": {
+                "memberId": "tenant1-member2",
+                "tenant": {
+                  "tenantId": "tenant1"
+                },
+                "memberName": "Bob Johnson"
+              }
+            }
+          ],
+          "members": [
+            {
+              "memberId": "tenant1-member1",
+              "tenant": {
+                "tenantId": "tenant1"
+              },
+              "memberName": "Alice Smith",
+              "memberships": [
+                {
+                  "membershipId": "tenant1-membership1",
+                  "membershipName": "Premium"
+                }
+              ]
+            },
+            {
+              "memberId": "tenant1-member2",
+              "tenant": {
+                "tenantId": "tenant1"
+              },
+              "memberName": "Bob Johnson",
+              "memberships": [
+                {
+                  "membershipId": "tenant1-membership2",
+                  "membershipName": "Basic"
+                }
+              ]
             }
           ]
         },
         {
-          "memberId": "tenant1-member2",
-          "tenant": {
-            "tenantId": "tenant1"
-          },
-          "memberName": "Bob Johnson",
-          "memberships": [
-            {
-              "membershipId": "tenant1-membership2",
-              "membershipName": "Basic"
-            }
-          ]
-        }
-      ],
-      "tenant2Members": [
-        {
-          "memberId": "tenant2-member1",
-          "tenant": {
-            "tenantId": "tenant2"
-          },
-          "memberName": "Carol Davis",
+          "tenantId": "tenant2",
+          "tenantName": "Finance Ltd",
           "memberships": [
             {
               "membershipId": "tenant2-membership1",
-              "membershipName": "Enterprise"
+              "membershipName": "Enterprise",
+              "tenant": {
+                "tenantId": "tenant2",
+                "tenantName": "Finance Ltd"
+              },
+              "member": {
+                "memberId": "tenant2-member1",
+                "tenant": {
+                  "tenantId": "tenant2"
+                },
+                "memberName": "Carol Davis"
+              }
+            }
+          ],
+          "members": [
+            {
+              "memberId": "tenant2-member1",
+              "tenant": {
+                "tenantId": "tenant2"
+              },
+              "memberName": "Carol Davis",
+              "memberships": [
+                {
+                  "membershipId": "tenant2-membership1",
+                  "membershipName": "Enterprise"
+                }
+              ]
             }
           ]
         }
       ],
-      "tenant1Memberships": [
+      "tenant1": [
         {
-          "membershipId": "tenant1-membership1",
-          "tenant": {
-            "tenantId": "tenant1"
-          },
-          "membershipName": "Premium",
-          "member": {
-            "memberId": "tenant1-member1",
-            "memberName": "Alice Smith"
-          }
-        },
+          "tenantId": "tenant1",
+          "tenantName": "Tech Corp",
+          "memberships": [
+            {
+              "membershipId": "tenant1-membership1",
+              "membershipName": "Premium",
+              "tenant": {
+                "tenantId": "tenant1",
+                "tenantName": "Tech Corp"
+              },
+              "member": {
+                "memberId": "tenant1-member1",
+                "tenant": {
+                  "tenantId": "tenant1"
+                },
+                "memberName": "Alice Smith"
+              }
+            },
+            {
+              "membershipId": "tenant1-membership2",
+              "membershipName": "Basic",
+              "tenant": {
+                "tenantId": "tenant1",
+                "tenantName": "Tech Corp"
+              },
+              "member": {
+                "memberId": "tenant1-member2",
+                "tenant": {
+                  "tenantId": "tenant1"
+                },
+                "memberName": "Bob Johnson"
+              }
+            }
+          ],
+          "members": [
+            {
+              "memberId": "tenant1-member1",
+              "tenant": {
+                "tenantId": "tenant1"
+              },
+              "memberName": "Alice Smith",
+              "memberships": [
+                {
+                  "membershipId": "tenant1-membership1",
+                  "membershipName": "Premium"
+                }
+              ]
+            },
+            {
+              "memberId": "tenant1-member2",
+              "tenant": {
+                "tenantId": "tenant1"
+              },
+              "memberName": "Bob Johnson",
+              "memberships": [
+                {
+                  "membershipId": "tenant1-membership2",
+                  "membershipName": "Basic"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "tenant2": [
         {
-          "membershipId": "tenant1-membership2",
-          "tenant": {
-            "tenantId": "tenant1"
-          },
-          "membershipName": "Basic",
-          "member": {
-            "memberId": "tenant1-member2",
-            "memberName": "Bob Johnson"
-          }
+          "tenantId": "tenant2",
+          "tenantName": "Finance Ltd",
+          "memberships": [
+            {
+              "membershipId": "tenant2-membership1",
+              "membershipName": "Enterprise",
+              "tenant": {
+                "tenantId": "tenant2",
+                "tenantName": "Finance Ltd"
+              },
+              "member": {
+                "memberId": "tenant2-member1",
+                "tenant": {
+                  "tenantId": "tenant2"
+                },
+                "memberName": "Carol Davis"
+              }
+            }
+          ],
+          "members": [
+            {
+              "memberId": "tenant2-member1",
+              "tenant": {
+                "tenantId": "tenant2"
+              },
+              "memberName": "Carol Davis",
+              "memberships": [
+                {
+                  "membershipId": "tenant2-membership1",
+                  "membershipName": "Enterprise"
+                }
+              ]
+            }
+          ]
         }
       ],
       "singleTenant": {
         "tenantId": "tenant1",
-        "tenantName": "Tech Corp"
+        "tenantName": "Tech Corp",
+        "memberships": [
+          {
+            "membershipId": "tenant1-membership1",
+            "membershipName": "Premium",
+            "tenant": {
+              "tenantId": "tenant1",
+              "tenantName": "Tech Corp"
+            },
+            "member": {
+              "memberId": "tenant1-member1",
+              "tenant": {
+                "tenantId": "tenant1"
+              },
+              "memberName": "Alice Smith"
+            }
+          },
+          {
+            "membershipId": "tenant1-membership2",
+            "membershipName": "Basic",
+            "tenant": {
+              "tenantId": "tenant1",
+              "tenantName": "Tech Corp"
+            },
+            "member": {
+              "memberId": "tenant1-member2",
+              "tenant": {
+                "tenantId": "tenant1"
+              },
+              "memberName": "Bob Johnson"
+            }
+          }
+        ],
+        "members": [
+          {
+            "memberId": "tenant1-member1",
+            "tenant": {
+              "tenantId": "tenant1"
+            },
+            "memberName": "Alice Smith",
+            "memberships": [
+              {
+                "membershipId": "tenant1-membership1",
+                "membershipName": "Premium"
+              }
+            ]
+          },
+          {
+            "memberId": "tenant1-member2",
+            "tenant": {
+              "tenantId": "tenant1"
+            },
+            "memberName": "Bob Johnson",
+            "memberships": [
+              {
+                "membershipId": "tenant1-membership2",
+                "membershipName": "Basic"
+              }
+            ]
+          }
+        ]
       }
     }
   }

--- a/integration-tests/shared-fk/with-muliple-composite-fields/tests/tenant-update.exotest
+++ b/integration-tests/shared-fk/with-muliple-composite-fields/tests/tenant-update.exotest
@@ -1,0 +1,19 @@
+operation: |
+  mutation {
+    updateTenant1: updateTenant(
+      tenantId: "tenant1", 
+      data: {tenantId: "tenant1", tenantName: "Tech Corp Updated"}
+    ) {
+      tenantId
+      tenantName
+    }
+  }
+response: |
+  {
+    "data": {
+      "updateTenant1": {
+        "tenantId": "tenant1",
+        "tenantName": "Tech Corp Updated"
+      }
+    }
+  }

--- a/libs/exo-sql/src/asql/column_path.rs
+++ b/libs/exo-sql/src/asql/column_path.rs
@@ -303,6 +303,8 @@ impl PhysicalColumnPath {
 
     #[cfg(test)]
     pub fn from_columns(columns: Vec<ColumnId>, database: &Database) -> Self {
+        use crate::{get_mto_relation_for_columns, get_otm_relation_for_columns};
+
         assert!(
             !columns.is_empty(),
             "Cannot create a column path from an empty list of columns"
@@ -318,14 +320,12 @@ impl PhysicalColumnPath {
                     let next_table = next_column_id.table_id;
 
                     if next_table == column_id.table_id {
-                        column_id
-                            .get_otm_relation(database)
+                        get_otm_relation_for_columns(&[*column_id], database)
                             .unwrap()
                             .deref(database)
                             .column_path_link()
                     } else {
-                        column_id
-                            .get_mto_relation(database)
+                        get_mto_relation_for_columns(&[*column_id], database)
                             .unwrap()
                             .deref(database)
                             .column_path_link()

--- a/libs/exo-sql/src/lib.rs
+++ b/libs/exo-sql/src/lib.rs
@@ -73,7 +73,10 @@ pub use sql::{
     limit::Limit,
     offset::Offset,
     order::Ordering,
-    physical_column::{ColumnId, ColumnReference, PhysicalColumn},
+    physical_column::{
+        ColumnId, ColumnReference, PhysicalColumn, get_mto_relation_for_columns,
+        get_otm_relation_for_columns,
+    },
     physical_column_type::{
         ArrayColumnType, BlobColumnType, BooleanColumnType, DateColumnType, EnumColumnType,
         FloatBits, FloatColumnType, IntBits, IntColumnType, JsonColumnType, NumericColumnType,

--- a/libs/exo-sql/src/transform/pg/insert/multi_statement_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/insert/multi_statement_strategy.rs
@@ -195,13 +195,14 @@ fn insert_self_row<'a>(
                 .collect::<Vec<_>>();
 
             // Only add parent columns that are not already present in the row
-            let existing_column_names: Vec<_> = columns.iter().map(|col| &col.name).collect();
+            let existing_column_names: std::collections::HashSet<_> =
+                columns.iter().map(|col| &col.name).collect();
 
             for (col_index, parent_column_id) in parent_column_ids.iter().enumerate() {
                 let parent_column = parent_column_id.get_column(database);
 
                 // Check if this column is already present in the row by name
-                if !existing_column_names.contains(&&parent_column.name) {
+                if !existing_column_names.contains(&parent_column.name) {
                     columns.push(parent_column);
                     proxy_values.push(ProxyColumn::Template {
                         col_index,

--- a/libs/exo-sql/src/transform/pg/insert/multi_statement_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/insert/multi_statement_strategy.rs
@@ -188,19 +188,26 @@ fn insert_self_row<'a>(
 
     match parent_step {
         Some((parent_step_id, parent_column_ids)) => {
-            for parent_column_id in parent_column_ids.iter() {
-                columns.push(parent_column_id.get_column(database));
-            }
+            // Convert values to proxy values before adding parent columns
             let mut proxy_values = values
                 .into_iter()
                 .map(ProxyColumn::Concrete)
                 .collect::<Vec<_>>();
 
-            for col_index in 0..parent_column_ids.len() {
-                proxy_values.push(ProxyColumn::Template {
-                    col_index,
-                    step_id: parent_step_id,
-                });
+            // Only add parent columns that are not already present in the row
+            let existing_column_names: Vec<_> = columns.iter().map(|col| &col.name).collect();
+
+            for (col_index, parent_column_id) in parent_column_ids.iter().enumerate() {
+                let parent_column = parent_column_id.get_column(database);
+
+                // Check if this column is already present in the row by name
+                if !existing_column_names.contains(&&parent_column.name) {
+                    columns.push(parent_column);
+                    proxy_values.push(ProxyColumn::Template {
+                        col_index,
+                        step_id: parent_step_id,
+                    });
+                }
             }
 
             let insert = TemplateSQLOperation::Insert(TemplateInsert {

--- a/libs/exo-sql/src/transform/pg/select/select_transformer.rs
+++ b/libs/exo-sql/src/transform/pg/select/select_transformer.rs
@@ -163,6 +163,7 @@ mod tests {
                 AliasedSelectionElement, Selection, SelectionCardinality, SelectionElement,
             },
         },
+        get_mto_relation_for_columns, get_otm_relation_for_columns,
         sql::{SQLParamContainer, predicate::Predicate},
         transform::{pg::Postgres, test_util::TestSetup, transformer::SelectTransformer},
     };
@@ -301,9 +302,11 @@ mod tests {
                                 "venue".to_string(),
                                 SelectionElement::SubSelect(
                                     RelationId::OneToMany(
-                                        concerts_venue_id_column
-                                            .get_otm_relation(&database)
-                                            .unwrap(),
+                                        get_otm_relation_for_columns(
+                                            &[concerts_venue_id_column],
+                                            &database,
+                                        )
+                                        .unwrap(),
                                     ),
                                     Box::new(AbstractSelect {
                                         table_id: venues_table,
@@ -363,9 +366,11 @@ mod tests {
                                 "concerts".to_string(),
                                 SelectionElement::SubSelect(
                                     RelationId::OneToMany(
-                                        concerts_venue_id_column
-                                            .get_otm_relation(&database)
-                                            .unwrap(),
+                                        get_otm_relation_for_columns(
+                                            &[concerts_venue_id_column],
+                                            &database,
+                                        )
+                                        .unwrap(),
                                     ),
                                     Box::new(AbstractSelect {
                                         table_id: concerts_table,
@@ -426,9 +431,11 @@ mod tests {
                                 "concerts".to_string(),
                                 SelectionElement::SubSelect(
                                     RelationId::OneToMany(
-                                        concerts_venue_id_column
-                                            .get_otm_relation(&database)
-                                            .unwrap(),
+                                        get_otm_relation_for_columns(
+                                            &[concerts_venue_id_column],
+                                            &database,
+                                        )
+                                        .unwrap(),
                                     ),
                                     Box::new(AbstractSelect {
                                         table_id: concerts_table,
@@ -658,9 +665,11 @@ mod tests {
                                 "parent_venue".to_string(),
                                 SelectionElement::SubSelect(
                                     RelationId::ManyToOne(
-                                        venues_parent_venue_id_column
-                                            .get_mto_relation(&database)
-                                            .unwrap(),
+                                        get_mto_relation_for_columns(
+                                            &[venues_parent_venue_id_column],
+                                            &database,
+                                        )
+                                        .unwrap(),
                                     ),
                                     Box::new(AbstractSelect {
                                         table_id: venues_table,

--- a/libs/exo-sql/src/transform/pg/update/multi_statement_strategy.rs
+++ b/libs/exo-sql/src/transform/pg/update/multi_statement_strategy.rs
@@ -334,6 +334,7 @@ mod tests {
             selection::{AliasedSelectionElement, Selection, SelectionElement},
             update::NestedAbstractUpdate,
         },
+        get_otm_relation_for_columns,
         sql::{SQLParamContainer, column::Column, predicate::Predicate},
         transform::{test_util::TestSetup, transformer::UpdateTransformer},
     };
@@ -416,10 +417,12 @@ mod tests {
                 let predicate = AbstractPredicate::eq(venue_id_path, literal);
 
                 let nested_abs_update = NestedAbstractUpdate {
-                    nesting_relation: concerts_venue_id_column
-                        .get_otm_relation(&database)
-                        .unwrap()
-                        .deref(&database),
+                    nesting_relation: get_otm_relation_for_columns(
+                        &[concerts_venue_id_column],
+                        &database,
+                    )
+                    .unwrap()
+                    .deref(&database),
                     update: AbstractUpdate {
                         table_id: concerts_table,
                         predicate: Predicate::True,


### PR DESCRIPTION
With shared foreign key (see integration-tests/shared-fk/with-muliple-composite-fields/src/index.exo), we do not want to be sensitive to a field postion when finding relationship. This change fixes it by checking for all columns of a field to find a relationship (not just any column, which was okay when we didn't support shared foreign column).