### PR TITLE
feat: Support UUID generation with `uuid_generate_v4`.

### DIFF
--- a/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
@@ -27,7 +27,7 @@ use core_model::{
 use core_model_builder::ast::ast_types::{FieldSelection, FieldSelectionElement};
 use core_model_builder::{ast::ast_types::AstExpr, error::ModelBuildingError};
 
-use exo_sql::schema::column_spec::{ColumnAutoincrement, ColumnDefault};
+use exo_sql::schema::column_spec::{ColumnAutoincrement, ColumnDefault, UuidGenerationMethod};
 use exo_sql::{
     ArrayColumnType, BooleanColumnType, ColumnId, EnumColumnType, JsonColumnType, ManyToOne,
     PhysicalColumn, PhysicalColumnType, PhysicalIndex, PhysicalTable, TableId,
@@ -317,7 +317,9 @@ fn default_value(field: &ResolvedField) -> Option<ColumnDefault> {
                         Some(ColumnDefault::CurrentTimestamp)
                     }
                 } else if string == "gen_random_uuid()" {
-                    Some(ColumnDefault::Uuid)
+                    Some(ColumnDefault::Uuid(UuidGenerationMethod::GenRandomUuid))
+                } else if string == "uuid_generate_v4()" {
+                    Some(ColumnDefault::Uuid(UuidGenerationMethod::UuidGenerateV4))
                 } else {
                     Some(ColumnDefault::Function(string.to_string()))
                 }

--- a/crates/postgres-subsystem/postgres-core-builder/src/resolved_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/resolved_builder.rs
@@ -54,6 +54,7 @@ use heck::ToSnakeCase;
 const DEFAULT_FN_AUTO_INCREMENT: &str = "autoIncrement";
 const DEFAULT_FN_CURRENT_TIME: &str = "now";
 const DEFAULT_FN_GENERATE_UUID: &str = "generate_uuid";
+const DEFAULT_FN_UUID_GENERATE_V4: &str = "uuidGenerateV4";
 
 /// Represents the different ways a field's column name(s) can be configured
 #[derive(Debug, Clone, PartialEq)]
@@ -464,6 +465,24 @@ fn resolve_field_default_type(
                 }
 
                 ResolvedFieldDefault::PostgresFunction("gen_random_uuid()".to_string())
+            }
+            DEFAULT_FN_UUID_GENERATE_V4 => {
+                if field_underlying_type != primitive_type::UuidType::NAME {
+                    errors.push(Diagnostic {
+                        level: Level::Error,
+                        message: format!(
+                            "{DEFAULT_FN_UUID_GENERATE_V4}() can only be used on Uuids"
+                        ),
+                        code: Some("C000".to_string()),
+                        spans: vec![SpanLabel {
+                            span: default_value.span,
+                            style: SpanStyle::Primary,
+                            label: None,
+                        }],
+                    });
+                }
+
+                ResolvedFieldDefault::PostgresFunction("uuid_generate_v4()".to_string())
             }
             _ => {
                 errors.push(Diagnostic {

--- a/docs/docs/postgres/customizing-types.md
+++ b/docs/docs/postgres/customizing-types.md
@@ -278,14 +278,21 @@ In either case, both the `Concert` and `Venue` types will use the the specified 
 
 #### Auto-generated Uuid key
 
-To use the primary key of Uuid type, specify the field's type to be `Uuid` type with the default value of `generate_uuid()`. In the following example, the `id` field is the primary key, and it will be automatically assigned a value when you create a new concert. Behind the scenes, Exograph will use the `UUID` type in PostgreSQL.
+To use the primary key of Uuid type, specify the field's type to be `Uuid` type with a default value. Exograph supports two UUID generation methods:
+
+- `generate_uuid()` - uses PostgreSQL's `gen_random_uuid()` function (requires `pgcrypto` extension)
+- `uuidGenerateV4()` - uses PostgreSQL's `uuid_generate_v4()` function (requires `uuid-ossp` extension)
 
 ```exo
 type Concert {
   @pk id: Uuid = generate_uuid()
+  // OR
+  @pk id: Uuid = uuidGenerateV4()
   ...
 }
 ```
+
+In both cases, the `id` field will be automatically assigned a UUID value when you create a new concert. Exograph automatically adds the required PostgreSQL extension.
 
 #### User-assignable primary key
 
@@ -367,7 +374,7 @@ This would generate columns `address_street`, `address_city`, `address_state`, a
 
 ### Specifying a default value
 
-The default value of a column is specified using an assignment in the field definition. For example, as we have seen in the [previous section](#assigning-primary-key), you can set the default value of an `Int` field to `autoIncrement()` to make it auto-incrementing and the default value of a `Uuid` field to `generate_uuid()` to make it auto-generated.
+The default value of a column is specified using an assignment in the field definition. For example, as we have seen in the [previous section](#assigning-primary-key), you can set the default value of an `Int` field to `autoIncrement()` to make it auto-incrementing and the default value of a `Uuid` field to `generate_uuid()` or `uuidGenerateV4()` to make it auto-generated.
 
 Similarly, you can set the default value of a scalar column to a constant value. For example, if you want to set the default value of the `price` field to `50`, you can use the following definition:
 
@@ -429,6 +436,8 @@ You may use the `@update` annotation to track other aspects. For example, if you
 type Concert {
   ...
   @update modificationVersion: Uuid = generate_uuid()
+  // OR
+  @update modificationVersion: Uuid = uuidGenerateV4()
 }
 ```
 

--- a/docs/docs/postgres/operations/mutations.md
+++ b/docs/docs/postgres/operations/mutations.md
@@ -17,7 +17,7 @@ As discussed in the [customizing types](../customizing-types.md) section, if you
 Both create mutations use the same input type of the `<EntityName>CreateInput` form. For example, for the `createConcert` mutation, the input type is `ConcertCreationInput`. It has all the fields of the entity type. However, if the primary key is of the `Int` type set to `autoIncrement()`, it will not be in the input type. Every field marked optional in your type definition is also optional in the input type. The singular form mutation takes this type, whereas the multiple entity version takes an array.
 
 :::tip Special treatment for `Uuid` primary keys
-If your entity type has a primary key of the `Uuid` type, it may still be supplied in the input data. This allows client-generated UUIDs. If the client does not provide the primary key, Exograph will generate one (due to the default value of `generate_uuid()`).
+If your entity type has a primary key of the `Uuid` type, it may still be supplied in the input data. This allows client-generated UUIDs. If the client does not provide the primary key, Exograph will generate one (due to the default value of `generate_uuid()` or `uuidGenerateV4()`).
 :::
 
 ### Creating a single entity

--- a/integration-tests/todo-uuid-v4/schema-tests
+++ b/integration-tests/todo-uuid-v4/schema-tests
@@ -1,0 +1,1 @@
+../todo-uuid-pk/schema-tests/

--- a/integration-tests/todo-uuid-v4/src/index.exo
+++ b/integration-tests/todo-uuid-v4/src/index.exo
@@ -1,0 +1,26 @@
+context AuthContext {
+  @jwt("sub") id: Uuid
+  @jwt("role") role: String = "user"
+}
+
+@postgres
+module TodoDatabase {
+  @access(self.user.id == AuthContext.id || AuthContext.role == "admin")
+  type Todo {
+    @pk id: Uuid = uuidGenerateV4()
+    title: String
+    completed: Boolean
+    user: User = AuthContext.id
+  }
+
+  @access(AuthContext.role == "admin")
+  type User {
+    @pk id: Uuid = uuidGenerateV4()
+    @unique email: String
+    firstName: String
+    lastName: String
+    profileImageUrl: String
+    role: String = "user"
+    todos: Set<Todo>?
+  }
+}

--- a/integration-tests/todo-uuid-v4/tests
+++ b/integration-tests/todo-uuid-v4/tests
@@ -1,0 +1,1 @@
+../todo-uuid-pk/tests


### PR DESCRIPTION
In addition to already supported  `gen_random_uuid()` (using `generate_uuid()` as the default value), this change now supports `uuid_generate_v4()` (using `uuidGenerateV4()` as the default value).