### PR TITLE
chore: Remove unneeded `pgcrypto` extension

### DIFF
--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-sync-field/scope-all-schemas/down.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-sync-field/scope-all-schemas/down.sql
@@ -5,6 +5,3 @@
 DROP TRIGGER exograph_on_update_concerts on "concerts";
 
 DROP FUNCTION exograph_update_concerts;
-
--- DROP EXTENSION IF EXISTS "pgcrypto";
-

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-sync-field/scope-all-schemas/new.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-sync-field/scope-all-schemas/new.sql
@@ -1,5 +1,3 @@
-CREATE EXTENSION IF NOT EXISTS "pgcrypto";
-
 CREATE TABLE "concerts" (
 	"id" SERIAL PRIMARY KEY,
 	"title" TEXT NOT NULL,
@@ -10,4 +8,3 @@ CREATE TABLE "concerts" (
 CREATE FUNCTION exograph_update_concerts() RETURNS TRIGGER AS $$ BEGIN NEW.updated_at = now(); NEW.modification_id = gen_random_uuid(); RETURN NEW; END; $$ language 'plpgsql';
 
 CREATE TRIGGER exograph_on_update_concerts BEFORE UPDATE ON concerts FOR EACH ROW EXECUTE FUNCTION exograph_update_concerts();
-

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-sync-field/scope-all-schemas/old.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-sync-field/scope-all-schemas/old.sql
@@ -2,4 +2,3 @@ CREATE TABLE "concerts" (
 	"id" SERIAL PRIMARY KEY,
 	"title" TEXT NOT NULL
 );
-

--- a/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-sync-field/scope-all-schemas/up.sql
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration-test-data/add-update-sync-field/scope-all-schemas/up.sql
@@ -1,5 +1,3 @@
-CREATE EXTENSION IF NOT EXISTS "pgcrypto";
-
 ALTER TABLE "concerts" ADD "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now();
 
 ALTER TABLE "concerts" ADD "modification_id" uuid NOT NULL DEFAULT gen_random_uuid();
@@ -7,4 +5,3 @@ ALTER TABLE "concerts" ADD "modification_id" uuid NOT NULL DEFAULT gen_random_uu
 CREATE FUNCTION exograph_update_concerts() RETURNS TRIGGER AS $$ BEGIN NEW.updated_at = now(); NEW.modification_id = gen_random_uuid(); RETURN NEW; END; $$ language 'plpgsql';
 
 CREATE TRIGGER exograph_on_update_concerts BEFORE UPDATE ON concerts FOR EACH ROW EXECUTE FUNCTION exograph_update_concerts();
-

--- a/crates/postgres-subsystem/postgres-core-model/src/migration_tests.rs
+++ b/crates/postgres-subsystem/postgres-core-model/src/migration_tests.rs
@@ -398,10 +398,14 @@ fn assert_sql_eq(
         actual.write(&mut buffer, false).unwrap();
         let actual_sql = String::from_utf8(buffer.into_inner()).unwrap();
 
-        if actual_sql.lines().count() == expected.lines().count()
+        // Remove trailing newlines to normalize the output (for Windows compatibility)
+        let actual_sql = actual_sql.trim();
+        let expected_sql = expected.trim();
+
+        if actual_sql.lines().count() == expected_sql.lines().count()
             && actual_sql
                 .lines()
-                .zip(expected.lines())
+                .zip(expected_sql.lines())
                 .all(|(a, e)| a.trim() == e.trim())
         {
             remove_previous_file();
@@ -443,7 +447,11 @@ fn assert_sql_eq(
     };
 
     let (expected_sql, expected_destructive_indices) = {
-        let expected_sql = expected.split(";\n").map(|s| s.trim()).collect::<Vec<_>>();
+        let expected_sql = expected
+            .trim()
+            .split(";\n")
+            .map(|s| s.trim())
+            .collect::<Vec<_>>();
         let expected_sql_destructive_indices = expected_sql
             .iter()
             .enumerate()
@@ -503,6 +511,9 @@ fn dump_migration_path(folder: &Path, kind: TestKind) -> Result<PathBuf, std::io
 }
 
 fn assert_sql_str_eq(actual: &str, expected: &str, message: &str) -> Result<(), String> {
+    let actual = actual.trim();
+    let expected = expected.trim();
+
     // Line-ending insensitive comparison (for Windows compatibility)
     if actual.lines().count() == expected.lines().count()
         && (actual.lines().zip(expected.lines())).all(|(a, e)| a.trim() == e.trim())
@@ -520,9 +531,7 @@ fn assert_sql_str_eq(actual: &str, expected: &str, message: &str) -> Result<(), 
         if actual_sql.len() != expected_sql.len() {
             return Err(format!(
                 "{}: Actual SQL length {} is different from expected SQL length {}",
-                message,
-                actual_sql.len(),
-                expected_sql.len(),
+                message, actual, expected,
             ));
         }
 

--- a/docs/docs/postgres/customizing-types.md
+++ b/docs/docs/postgres/customizing-types.md
@@ -280,7 +280,7 @@ In either case, both the `Concert` and `Venue` types will use the the specified 
 
 To use the primary key of Uuid type, specify the field's type to be `Uuid` type with a default value. Exograph supports two UUID generation methods:
 
-- `generate_uuid()` - uses PostgreSQL's `gen_random_uuid()` function (requires `pgcrypto` extension)
+- `generate_uuid()` - uses PostgreSQL's `gen_random_uuid()` function (built into PostgreSQL 13+)
 - `uuidGenerateV4()` - uses PostgreSQL's `uuid_generate_v4()` function (requires `uuid-ossp` extension)
 
 ```exo
@@ -292,7 +292,7 @@ type Concert {
 }
 ```
 
-In both cases, the `id` field will be automatically assigned a UUID value when you create a new concert. Exograph automatically adds the required PostgreSQL extension.
+In both cases, the `id` field will be automatically assigned a UUID value when you create a new concert. Exograph automatically adds the required PostgreSQL extension as needed.
 
 #### User-assignable primary key
 


### PR DESCRIPTION
Since Postgres 13, using `gen_random_uuid` doesn't require installing the `pgcrypto` extension.