### PR TITLE
Allow default values for decimal fields

### DIFF
--- a/crates/builder/src/typechecker/field.rs
+++ b/crates/builder/src/typechecker/field.rs
@@ -85,7 +85,7 @@ impl TypecheckFrom<AstField<Untyped>> for AstField<Typed> {
             };
 
             match *expr {
-                AstExpr::StringLiteral(_, _) => assert_type(&["String"]),
+                AstExpr::StringLiteral(_, _) => assert_type(&["String", "Decimal"]),
                 AstExpr::BooleanLiteral(_, _) => assert_type(&["Boolean"]),
                 AstExpr::NumberLiteral(_, _) => assert_type(&["Int", "Float"]),
                 AstExpr::FieldSelection(_) => {

--- a/integration-tests/arbitrary-precision/schema-tests/introspection.expected.graphql
+++ b/integration-tests/arbitrary-precision/schema-tests/introspection.expected.graphql
@@ -29,7 +29,7 @@ type FooAgg {
 }
 
 input FooCreationInput {
-  verylong: Decimal!
+  verylong: Decimal
 }
 
 """

--- a/integration-tests/arbitrary-precision/src/index.exo
+++ b/integration-tests/arbitrary-precision/src/index.exo
@@ -6,6 +6,6 @@ module FooModule {
     @pk id: Int = autoIncrement();
     
     @precision(40) @scale(30)
-    verylong: Decimal
+    verylong: Decimal = "1.20"
   }
 }

--- a/integration-tests/arbitrary-precision/tests/verylong.exotest
+++ b/integration-tests/arbitrary-precision/tests/verylong.exotest
@@ -3,6 +3,9 @@ operation: |
     string_test: createFoo(data: { verylong: $verylong_string }) {
       verylong
     }
+    default_test: createFoo(data: {}) {
+      verylong
+    }
   }
 variable: |
   {
@@ -15,5 +18,8 @@ response: |
         // @scale is 30, so we should round off at 30 digits
         "verylong": "1.000000000000000000000000123457" 
       },
+      "default_test": {
+        "verylong": "1.200000000000000000000000000000"
+      }
     }
   }

--- a/integration-tests/default-values/scalar/schema-tests/introspection.expected.graphql
+++ b/integration-tests/default-values/scalar/schema-tests/introspection.expected.graphql
@@ -7,12 +7,32 @@ input BooleanFilter {
   neq: Boolean
 }
 
+scalar Decimal
+
+type DecimalAgg {
+  min: Decimal
+  max: Decimal
+  sum: Decimal
+  avg: Decimal
+  count: Int
+}
+
+input DecimalFilter {
+  eq: Decimal
+  neq: Decimal
+  lt: Decimal
+  lte: Decimal
+  gt: Decimal
+  gte: Decimal
+}
+
 type Event {
   id: Int!
   timestamp: Instant!
   category: String!
   priority: Int!
   price: Float!
+  decimalPrice: Decimal!
   message: String!
   is_system: Boolean!
   clientId: String!
@@ -26,6 +46,7 @@ type EventAgg {
   category: StringAgg
   priority: IntAgg
   price: FloatAgg
+  decimalPrice: DecimalAgg
   message: StringAgg
   is_system: BooleanAgg
   clientId: StringAgg
@@ -37,6 +58,7 @@ input EventCreationInput {
   category: String
   priority: Int
   price: Float
+  decimalPrice: Decimal
   message: String!
   is_system: Boolean
   clientId: String
@@ -54,6 +76,7 @@ input EventFilter {
   category: StringFilter
   priority: IntFilter
   price: FloatFilter
+  decimalPrice: DecimalFilter
   message: StringFilter
   is_system: BooleanFilter
   clientId: StringFilter
@@ -69,6 +92,7 @@ input EventOrdering {
   category: Ordering
   priority: Ordering
   price: Ordering
+  decimalPrice: Ordering
   message: Ordering
   is_system: Ordering
   clientId: Ordering
@@ -81,6 +105,7 @@ input EventUpdateInput {
   category: String
   priority: Int
   price: Float
+  decimalPrice: Decimal
   message: String
   is_system: Boolean
   clientId: String

--- a/integration-tests/default-values/scalar/src/index.exo
+++ b/integration-tests/default-values/scalar/src/index.exo
@@ -13,6 +13,7 @@ module EventModule {
         category: String = "INFO"
         priority: Int = 0
         price: Float = 10.0
+        decimalPrice: Decimal = "10.00"
         message: String
         is_system: Boolean = true
         clientId: String = ClientContext.id

--- a/integration-tests/default-values/scalar/tests/query-default-values.exotest
+++ b/integration-tests/default-values/scalar/tests/query-default-values.exotest
@@ -5,6 +5,8 @@ operation: |
             timestamp
             category
             priority
+            price
+            decimalPrice
             message
             is_system
             clientId
@@ -36,6 +38,8 @@ response: |
           },
           "category": "INFO",
           "priority": 0,
+          "price": 10.0,
+          "decimalPrice": "10.00",
           "message": "Corrected error, no actions required.",
           "is_system": true,
           "clientId": "test-client1",

--- a/libs/exo-sql/src/schema/column_spec.rs
+++ b/libs/exo-sql/src/schema/column_spec.rs
@@ -13,7 +13,7 @@ use crate::database_error::DatabaseError;
 use crate::sql::connect::database_client::DatabaseClient;
 use crate::sql::physical_column_type::{
     ArrayColumnType, BooleanColumnType, DateColumnType, EnumColumnType, IntBits, IntColumnType,
-    PhysicalColumnType, StringColumnType, TimestampColumnType, VectorColumnType,
+    NumericColumnType, PhysicalColumnType, StringColumnType, TimestampColumnType, VectorColumnType,
 };
 use crate::{Database, PhysicalColumn, SchemaObjectName};
 
@@ -192,6 +192,7 @@ impl ColumnDefault {
                     || physical_type
                         .as_any()
                         .is::<crate::sql::physical_column_type::FloatColumnType>()
+                    || physical_type.as_any().is::<NumericColumnType>()
                 {
                     match default_value.parse() {
                         Ok(value) => Ok(ColumnDefault::Number(value)),

--- a/libs/exo-sql/src/sql/insert.rs
+++ b/libs/exo-sql/src/sql/insert.rs
@@ -18,6 +18,7 @@ use super::{
     transaction::{TransactionContext, TransactionStepId},
 };
 
+// TODO: Add a check to ensure that columns and each row of values_seq have the same length.
 /// An insert operation.
 #[derive(Debug)]
 pub struct Insert<'a> {

--- a/libs/exo-sql/src/sql/insert.rs
+++ b/libs/exo-sql/src/sql/insert.rs
@@ -39,17 +39,23 @@ impl ExpressionBuilder for Insert<'_> {
         builder.push_str("INSERT INTO ");
         self.table.build(database, builder);
 
-        builder.push_str(" (");
-        builder.without_fully_qualified_column_names(|builder| {
-            builder.push_elems(database, &self.columns, ", ");
-        });
+        if self.columns.is_empty() {
+            // If none of the columns have been provided, we can use DEFAULT VALUES.
+            // This can happen if all fields of a type have a default value and no explicit values are provided.
+            builder.push_str(" DEFAULT VALUES");
+        } else {
+            builder.push_str(" (");
+            builder.without_fully_qualified_column_names(|builder| {
+                builder.push_elems(database, &self.columns, ", ");
+            });
 
-        builder.push_str(") VALUES (");
+            builder.push_str(") VALUES (");
 
-        builder.push_iter(self.values_seq.iter(), "), (", |builder, values| {
-            builder.push_elems(database, values, ", ");
-        });
-        builder.push(')');
+            builder.push_iter(self.values_seq.iter(), "), (", |builder, values| {
+                builder.push_elems(database, values, ", ");
+            });
+            builder.push(')');
+        }
 
         if !self.returning.is_empty() {
             builder.push_str(" RETURNING ");


### PR DESCRIPTION
We now allow specifying default values for decimal fields (as string to retain precision) such as:

```
    type Event {
        @pk id: Int = autoIncrement()
        price: Decimal = "10.00"
    }
```

Also take care of inserting a type where all fields have a default and no explicit data fields are provided.