### PR TITLE
Add default value support for more types

### DIFF
--- a/crates/builder/src/typechecker/field.rs
+++ b/crates/builder/src/typechecker/field.rs
@@ -85,7 +85,16 @@ impl TypecheckFrom<AstField<Untyped>> for AstField<Typed> {
             };
 
             match *expr {
-                AstExpr::StringLiteral(_, _) => assert_type(&["String", "Decimal"]),
+                AstExpr::StringLiteral(_, _) => assert_type(&[
+                    "String",
+                    "Decimal",
+                    "LocalDate",
+                    "LocalTime",
+                    "LocalDateTime",
+                    "Json",
+                    "Uuid",
+                    "Blob",
+                ]),
                 AstExpr::BooleanLiteral(_, _) => assert_type(&["Boolean"]),
                 AstExpr::NumberLiteral(_, _) => assert_type(&["Int", "Float"]),
                 AstExpr::FieldSelection(_) => {

--- a/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
@@ -287,10 +287,23 @@ fn default_value(field: &ResolvedField) -> Option<ColumnDefault> {
         .and_then(|default_value| match default_value {
             ResolvedFieldDefault::Value(val) => match &**val {
                 AstExpr::StringLiteral(string, _) => {
+                    let type_name = field.typ.innermost().type_name.as_str();
+
                     // For Decimal fields, use ColumnDefault::Number to allow proper casting
-                    if field.typ.innermost().type_name.as_str() == primitive_type::DecimalType::NAME
-                    {
+                    if type_name == primitive_type::DecimalType::NAME {
                         Some(ColumnDefault::Number(string.clone()))
+                    } else if type_name == primitive_type::LocalDateType::NAME {
+                        Some(ColumnDefault::Date(string.clone()))
+                    } else if type_name == primitive_type::LocalTimeType::NAME {
+                        Some(ColumnDefault::Time(string.clone()))
+                    } else if type_name == primitive_type::LocalDateTimeType::NAME {
+                        Some(ColumnDefault::DateTime(string.clone()))
+                    } else if type_name == primitive_type::JsonType::NAME {
+                        Some(ColumnDefault::Json(string.clone()))
+                    } else if type_name == primitive_type::UuidType::NAME {
+                        Some(ColumnDefault::UuidLiteral(string.clone()))
+                    } else if type_name == primitive_type::BlobType::NAME {
+                        Some(ColumnDefault::Blob(string.clone()))
                     } else {
                         let value = match field.type_hint {
                             None => ColumnDefault::Text(string.clone()),

--- a/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
@@ -303,7 +303,7 @@ fn default_value(field: &ResolvedField) -> Option<ColumnDefault> {
                     } else if type_name == primitive_type::UuidType::NAME {
                         Some(ColumnDefault::UuidLiteral(string.clone()))
                     } else if type_name == primitive_type::BlobType::NAME {
-                        Some(ColumnDefault::Blob(string.clone()))
+                        Some(ColumnDefault::Function(string.clone()))
                     } else {
                         let value = match field.type_hint {
                             None => ColumnDefault::Text(string.clone()),

--- a/integration-tests/default-values/scalar/schema-tests/introspection.expected.graphql
+++ b/integration-tests/default-values/scalar/schema-tests/introspection.expected.graphql
@@ -1,12 +1,3 @@
-scalar Blob
-
-type BlobAgg {
-  count: Int
-}
-
-"""A single value to match against using the equal operator."""
-scalar BlobFilter
-
 type BooleanAgg {
   count: Int
 }
@@ -51,7 +42,6 @@ type Event {
   eventDateTime: LocalDateTime!
   metadata: Json!
   eventId: Uuid!
-  payload: Blob!
 }
 
 """An aggregate for the `Event` type."""
@@ -71,7 +61,6 @@ type EventAgg {
   eventDateTime: LocalDateTimeAgg
   metadata: JsonAgg
   eventId: UuidAgg
-  payload: BlobAgg
 }
 
 input EventCreationInput {
@@ -89,7 +78,6 @@ input EventCreationInput {
   eventDateTime: LocalDateTime
   metadata: Json
   eventId: Uuid
-  payload: Blob
 }
 
 """
@@ -113,7 +101,6 @@ input EventFilter {
   eventDateTime: LocalDateTimeFilter
   metadata: JsonFilter
   eventId: UuidFilter
-  payload: BlobFilter
   and: [EventFilter!]
   or: [EventFilter!]
   not: EventFilter
@@ -135,7 +122,6 @@ input EventOrdering {
   eventDateTime: Ordering
   metadata: Ordering
   eventId: Ordering
-  payload: Ordering
 }
 
 input EventUpdateInput {
@@ -154,7 +140,6 @@ input EventUpdateInput {
   eventDateTime: LocalDateTime
   metadata: Json
   eventId: Uuid
-  payload: Blob
 }
 
 type FloatAgg {

--- a/integration-tests/default-values/scalar/schema-tests/introspection.expected.graphql
+++ b/integration-tests/default-values/scalar/schema-tests/introspection.expected.graphql
@@ -1,3 +1,12 @@
+scalar Blob
+
+type BlobAgg {
+  count: Int
+}
+
+"""A single value to match against using the equal operator."""
+scalar BlobFilter
+
 type BooleanAgg {
   count: Int
 }
@@ -37,6 +46,12 @@ type Event {
   is_system: Boolean!
   clientId: String!
   orgId: String
+  eventDate: LocalDate!
+  eventTime: LocalTime!
+  eventDateTime: LocalDateTime!
+  metadata: Json!
+  eventId: Uuid!
+  payload: Blob!
 }
 
 """An aggregate for the `Event` type."""
@@ -51,6 +66,12 @@ type EventAgg {
   is_system: BooleanAgg
   clientId: StringAgg
   orgId: StringAgg
+  eventDate: LocalDateAgg
+  eventTime: LocalTimeAgg
+  eventDateTime: LocalDateTimeAgg
+  metadata: JsonAgg
+  eventId: UuidAgg
+  payload: BlobAgg
 }
 
 input EventCreationInput {
@@ -63,6 +84,12 @@ input EventCreationInput {
   is_system: Boolean
   clientId: String
   orgId: String
+  eventDate: LocalDate
+  eventTime: LocalTime
+  eventDateTime: LocalDateTime
+  metadata: Json
+  eventId: Uuid
+  payload: Blob
 }
 
 """
@@ -81,6 +108,12 @@ input EventFilter {
   is_system: BooleanFilter
   clientId: StringFilter
   orgId: StringFilter
+  eventDate: LocalDateFilter
+  eventTime: LocalTimeFilter
+  eventDateTime: LocalDateTimeFilter
+  metadata: JsonFilter
+  eventId: UuidFilter
+  payload: BlobFilter
   and: [EventFilter!]
   or: [EventFilter!]
   not: EventFilter
@@ -97,6 +130,12 @@ input EventOrdering {
   is_system: Ordering
   clientId: Ordering
   orgId: Ordering
+  eventDate: Ordering
+  eventTime: Ordering
+  eventDateTime: Ordering
+  metadata: Ordering
+  eventId: Ordering
+  payload: Ordering
 }
 
 input EventUpdateInput {
@@ -110,6 +149,12 @@ input EventUpdateInput {
   is_system: Boolean
   clientId: String
   orgId: String
+  eventDate: LocalDate
+  eventTime: LocalTime
+  eventDateTime: LocalDateTime
+  metadata: Json
+  eventId: Uuid
+  payload: Blob
 }
 
 type FloatAgg {
@@ -205,6 +250,65 @@ input ItemUpdateInput {
   purchasePrice: Float
 }
 
+scalar Json
+
+type JsonAgg {
+  count: Int
+}
+
+input JsonFilter {
+  contains: Json
+  containedBy: Json
+  matchKey: Json
+  matchAllKeys: Json
+  matchAnyKey: Json
+}
+
+scalar LocalDate
+
+type LocalDateAgg {
+  count: Int
+}
+
+input LocalDateFilter {
+  eq: LocalDate
+  neq: LocalDate
+  lt: LocalDate
+  lte: LocalDate
+  gt: LocalDate
+  gte: LocalDate
+}
+
+scalar LocalDateTime
+
+type LocalDateTimeAgg {
+  count: Int
+}
+
+input LocalDateTimeFilter {
+  eq: LocalDateTime
+  neq: LocalDateTime
+  lt: LocalDateTime
+  lte: LocalDateTime
+  gt: LocalDateTime
+  gte: LocalDateTime
+}
+
+scalar LocalTime
+
+type LocalTimeAgg {
+  count: Int
+}
+
+input LocalTimeFilter {
+  eq: LocalTime
+  neq: LocalTime
+  lt: LocalTime
+  lte: LocalTime
+  gt: LocalTime
+  gte: LocalTime
+}
+
 enum Ordering {
   ASC
   DESC
@@ -227,6 +331,17 @@ input StringFilter {
   ilike: String
   startsWith: String
   endsWith: String
+}
+
+scalar Uuid
+
+type UuidAgg {
+  count: Int
+}
+
+input UuidFilter {
+  eq: Uuid
+  neq: Uuid
 }
 
 type Query {

--- a/integration-tests/default-values/scalar/src/index.exo
+++ b/integration-tests/default-values/scalar/src/index.exo
@@ -23,7 +23,6 @@ module EventModule {
         eventDateTime: LocalDateTime = "2024-01-01T14:30:00"
         metadata: Json = "{}"
         eventId: Uuid = "550e8400-e29b-41d4-a716-446655440000"
-        payload: Blob = "default_payload"
     }
 
     @access(self.purchasePrice > 0.0)

--- a/integration-tests/default-values/scalar/src/index.exo
+++ b/integration-tests/default-values/scalar/src/index.exo
@@ -18,6 +18,12 @@ module EventModule {
         is_system: Boolean = true
         clientId: String = ClientContext.id
         orgId: String? = ClientContext.org
+        eventDate: LocalDate = "2024-01-01"
+        eventTime: LocalTime = "14:30:00"
+        eventDateTime: LocalDateTime = "2024-01-01T14:30:00"
+        metadata: Json = "{}"
+        eventId: Uuid = "550e8400-e29b-41d4-a716-446655440000"
+        payload: Blob = "default_payload"
     }
 
     @access(self.purchasePrice > 0.0)

--- a/integration-tests/default-values/scalar/tests/query-default-values.exotest
+++ b/integration-tests/default-values/scalar/tests/query-default-values.exotest
@@ -16,7 +16,6 @@ operation: |
             eventDateTime
             metadata
             eventId
-            payload
         }
     }
 variable: |
@@ -54,8 +53,7 @@ response: |
           "eventTime": "14:30:00",
           "eventDateTime": "2024-01-01T14:30:00",
           "metadata": {},
-          "eventId": "550e8400-e29b-41d4-a716-446655440000",
-          "payload": "ZGVmYXVsdF9wYXlsb2Fk"
+          "eventId": "550e8400-e29b-41d4-a716-446655440000"
         }
       }
     }

--- a/integration-tests/default-values/scalar/tests/query-default-values.exotest
+++ b/integration-tests/default-values/scalar/tests/query-default-values.exotest
@@ -11,6 +11,12 @@ operation: |
             is_system
             clientId
             orgId
+            eventDate
+            eventTime
+            eventDateTime
+            metadata
+            eventId
+            payload
         }
     }
 variable: |
@@ -43,7 +49,13 @@ response: |
           "message": "Corrected error, no actions required.",
           "is_system": true,
           "clientId": "test-client1",
-          "orgId": "test-org1"
+          "orgId": "test-org1",
+          "eventDate": "2024-01-01",
+          "eventTime": "14:30:00",
+          "eventDateTime": "2024-01-01T14:30:00",
+          "metadata": {},
+          "eventId": "550e8400-e29b-41d4-a716-446655440000",
+          "payload": "ZGVmYXVsdF9wYXlsb2Fk"
         }
       }
     }


### PR DESCRIPTION
Following the default value support for `Decimal`, this change supports the same for `LocalDate`, `LocalTime`, `LocalDateTime`, `Json`, `Uuid`, and `Blob`.