### PR TITLE
fix: Remove ordering dependency for shared foreign key setup

### DIFF
--- a/crates/postgres-subsystem/postgres-core-builder/src/type_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/type_builder.rs
@@ -736,14 +736,14 @@ fn create_relation(
     resolved_env: &ResolvedTypeEnv,
     expand_foreign_relations: bool,
 ) -> Result<PostgresRelation, ModelBuildingError> {
-    fn placeholder_relation() -> Result<PostgresRelation, ModelBuildingError> {
+    fn placeholder_relation(is_pk: bool) -> Result<PostgresRelation, ModelBuildingError> {
         // Create an impossible value (will be filled later when expanding relations)
         Ok(PostgresRelation::Scalar {
             column_id: ColumnId {
                 table_id: SerializableSlabIndex::from_idx(usize::MAX),
                 column_index: usize::MAX,
             },
-            is_pk: false,
+            is_pk,
         })
     }
 
@@ -789,7 +789,7 @@ fn create_relation(
                                 building,
                             )
                         } else {
-                            placeholder_relation()
+                            placeholder_relation(field.is_pk)
                         }
                     }
                 }
@@ -836,7 +836,7 @@ fn create_relation(
                                         building,
                                     )
                                 } else {
-                                    placeholder_relation()
+                                    placeholder_relation(field.is_pk)
                                 }
                             }
                             (FieldType::Plain(_), Some(Cardinality::ZeroOrOne)) => {
@@ -849,7 +849,7 @@ fn create_relation(
                                         building,
                                     )
                                 } else {
-                                    placeholder_relation()
+                                    placeholder_relation(field.is_pk)
                                 }
                             }
                             (
@@ -865,7 +865,7 @@ fn create_relation(
                                         building,
                                     )
                                 } else {
-                                    placeholder_relation()
+                                    placeholder_relation(field.is_pk)
                                 }
                             }
                             (FieldType::Plain(_), Some(Cardinality::One)) => {

--- a/integration-tests/shared-fk/with-muliple-composite-fields/src/index.exo
+++ b/integration-tests/shared-fk/with-muliple-composite-fields/src/index.exo
@@ -1,13 +1,7 @@
 @postgres
 module Database {
-  @access(query=true, mutation=true)
-  type Member {
-    @pk memberId: String
-    @pk @column("member_tenant_id") tenant: Tenant
-    memberName: String?
-    memberships: Set<Membership>
-  }
-
+  // Keep this type before the Member type to test that the relation is created even when the
+  // `Member` type is defined after it. Especially important, since we want to treat Member.tenant as PK
   @access(query=true, mutation=true)
   type Membership {
     @pk membershipId: String
@@ -15,6 +9,14 @@ module Database {
     membershipName: String?
     // Keeping this after the member field to test that the relation is found correctly
     @pk @column("membership_tenant_id") tenant: Tenant
+  }
+
+  @access(query=true, mutation=true)
+  type Member {
+    @pk memberId: String
+    @pk @column("member_tenant_id") tenant: Tenant
+    memberName: String?
+    memberships: Set<Membership>
   }
 
   @access(query=true, mutation=true)


### PR DESCRIPTION
In a complex setup, setting up relationships created a mismatch between the expected and actual number of fields. Specifically, all of the following conditions must be met to encounter this issue:

1. A referring type (`Membership`) is lexically ordered before the referred type (`Member`)
2. The referring type has a field (`Membership.member`) whose column (`membership_tenant_id`) refers to the referred type's PK (`Member.tenant`)
3. The PK field (`Member.tenant`) is a non-scalar type

```exo
@access(query=true, mutation=true)
type Membership {
  @pk membershipId: String
  @column(mapping={memberId: "membership_member_id", tenant: "membership_tenant_id"}) member: Member?
    ...
}

@access(query=true, mutation=true)
type Member {
  @pk memberId: String
  @pk @column("member_tenant_id") tenant: Tenant
   ...
}
```

This change fixes the issue by setting up the `is_pk` property of relationship correctly even for non-scalar types (we were already setting up correctly for scalar types).