### PR TITLE
fix(import): Prevent multiple fields for a relation 

### DIFF
--- a/crates/cli/src/commands/schema/import/column_processor.rs
+++ b/crates/cli/src/commands/schema/import/column_processor.rs
@@ -182,6 +182,7 @@ pub fn write_foreign_key_reference(
     context: &ImportContext,
     database_spec: &DatabaseSpec,
     table_spec: &TableSpec,
+    processed_fields: &mut HashSet<String>,
     filter: &dyn Fn(&ColumnSpec) -> bool,
 ) -> Result<()> {
     for (_, references) in table_spec.foreign_key_references() {
@@ -190,6 +191,10 @@ pub fn write_foreign_key_reference(
         }
 
         if !filter(references[0].0) {
+            continue;
+        }
+
+        if !processed_fields.insert(references[0].0.name.clone()) {
             continue;
         }
 

--- a/crates/cli/src/commands/schema/import/table_processor.rs
+++ b/crates/cli/src/commands/schema/import/table_processor.rs
@@ -59,11 +59,18 @@ impl ModelProcessor<DatabaseSpec, ()> for TableSpec {
 
         // First write the primary key fields
         write_scalar_fields(writer, self, context, &mut processed_fields, &is_pk)?;
-        write_foreign_key_reference(writer, context, parent, self, &is_pk)?;
+        write_foreign_key_reference(writer, context, parent, self, &mut processed_fields, &is_pk)?;
 
         // Then write the non-primary key fields
         write_scalar_fields(writer, self, context, &mut processed_fields, &is_not_pk)?;
-        write_foreign_key_reference(writer, context, parent, self, &is_not_pk)?;
+        write_foreign_key_reference(
+            writer,
+            context,
+            parent,
+            self,
+            &mut processed_fields,
+            &is_not_pk,
+        )?;
 
         // Finally write the references
         write_references(writer, context, &mut processed_fields, &self.name)?;


### PR DESCRIPTION
If a schema has multiple foreign key relations with another table (with the same columns in each relation), we had been creating an identical field for each one of those. This fixes by keeping track of fields created so far.