### PR TITLE
fix(builder): Improve  shared columns processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6853,6 +6853,7 @@ dependencies = [
  "deno-builder",
  "exo-sql",
  "heck 0.5.0",
+ "indexmap 2.9.0",
  "insta",
  "multiplatform_test",
  "pluralizer",

--- a/crates/postgres-subsystem/postgres-core-builder/Cargo.toml
+++ b/crates/postgres-subsystem/postgres-core-builder/Cargo.toml
@@ -11,6 +11,7 @@ serde_json.workspace = true
 codemap-diagnostic.workspace = true
 codemap.workspace = true
 pluralizer.workspace = true
+indexmap.workspace = true
 
 core-model = { path = "../../core-subsystem/core-model" }
 core-model-builder = { path = "../../core-subsystem/core-model-builder" }

--- a/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/database_builder.rs
@@ -432,9 +432,11 @@ fn create_columns(
                                 if !matches!(field.typ, FieldType::Optional(_)) {
                                     column.is_nullable = false;
                                 }
-                                column
-                                    .unique_constraints
-                                    .extend(unique_constraint_name.clone());
+                                // Use HashSet to avoid duplicates when extending unique constraints
+                                let mut unique_set: HashSet<String> =
+                                    column.unique_constraints.drain(..).collect();
+                                unique_set.extend(unique_constraint_name.clone());
+                                column.unique_constraints = unique_set.into_iter().collect();
                             }
                             None => {
                                 created_columns.insert(


### PR DESCRIPTION
Earlier we set properties of an already created shared column when setting up the relationships. This was error-prone, sincecreating column and setting up properties isn't collocated in this arrangement.

Now we do it as we create columns. Also ensure that we set up unique constraints for shared columns.