### PR TITLE
fix(import): Fix import of composite foreign keys

### DIFF
--- a/crates/cli/src/commands/schema/import/database_processor.rs
+++ b/crates/cli/src/commands/schema/import/database_processor.rs
@@ -5,12 +5,11 @@ use heck::ToUpperCamelCase;
 
 use super::{ImportContext, ModelProcessor};
 
-impl ModelProcessor<(), ()> for DatabaseSpec {
+impl ModelProcessor<()> for DatabaseSpec {
     fn process(
         &self,
         _parent: &(),
         context: &ImportContext,
-        _parent_context: &mut (),
         writer: &mut (dyn std::io::Write + Send),
     ) -> Result<()> {
         let mut schemas = context.schemas.iter().collect::<Vec<_>>();
@@ -51,7 +50,7 @@ impl ModelProcessor<(), ()> for DatabaseSpec {
             let table_len = matching_tables.len();
 
             for (i, table) in matching_tables.iter().enumerate() {
-                table.process(self, context, &mut (), writer)?;
+                table.process(self, context, writer)?;
                 if i < table_len - 1 {
                     writeln!(writer)?;
                 }
@@ -68,7 +67,7 @@ impl ModelProcessor<(), ()> for DatabaseSpec {
             }
 
             for (i, enum_) in matching_enums.iter().enumerate() {
-                enum_.process(self, context, &mut (), writer)?;
+                enum_.process(self, context, writer)?;
                 if i < matching_enums.len() - 1 {
                     writeln!(writer)?;
                 }

--- a/crates/cli/src/commands/schema/import/enum_processor.rs
+++ b/crates/cli/src/commands/schema/import/enum_processor.rs
@@ -5,12 +5,11 @@ use super::{ImportContext, ModelProcessor, processor::INDENT};
 
 use heck::ToUpperCamelCase;
 
-impl ModelProcessor<DatabaseSpec, ()> for EnumSpec {
+impl ModelProcessor<DatabaseSpec> for EnumSpec {
     fn process(
         &self,
         _parent: &DatabaseSpec,
         _context: &ImportContext,
-        _parent_context: &mut (),
         writer: &mut (dyn std::io::Write + Send),
     ) -> Result<()> {
         writeln!(

--- a/crates/cli/src/commands/schema/import/mod.rs
+++ b/crates/cli/src/commands/schema/import/mod.rs
@@ -114,7 +114,7 @@ pub(crate) async fn create_exo_model(
         context.add_table(&table.name);
     }
 
-    schema.value.process(&(), &context, &mut (), &mut writer)?;
+    schema.value.process(&(), &context, &mut writer)?;
 
     for issue in &schema.issues {
         eprintln!("{issue}");

--- a/crates/cli/src/commands/schema/import/processor.rs
+++ b/crates/cli/src/commands/schema/import/processor.rs
@@ -7,17 +7,11 @@ pub(super) const INDENT: &str = "  ";
 /// A trait for processing a model.
 ///
 /// `P` is the parent type.
-/// `PC` is the parent context type.
-///
-/// The parent context is used to pass information from the parent to the child.
-/// For example, if the parent is a table, the parent context could be a set of
-/// fields that have already been added to the model.
-pub(super) trait ModelProcessor<P, PC> {
+pub(super) trait ModelProcessor<P> {
     fn process(
         &self,
         parent: &P,
         context: &ImportContext,
-        parent_context: &mut PC,
         writer: &mut (dyn std::io::Write + Send),
     ) -> Result<()>;
 }

--- a/crates/cli/src/commands/schema/import/table_processor.rs
+++ b/crates/cli/src/commands/schema/import/table_processor.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
-use exo_sql::{
-    SchemaObjectName,
-    schema::{column_spec::ColumnSpec, database_spec::DatabaseSpec, table_spec::TableSpec},
+use exo_sql::schema::{
+    column_spec::ColumnSpec, database_spec::DatabaseSpec, table_spec::TableSpec,
 };
 use std::collections::HashSet;
 
@@ -11,12 +10,11 @@ use super::{
 
 use heck::ToLowerCamelCase;
 
-impl ModelProcessor<DatabaseSpec, ()> for TableSpec {
+impl ModelProcessor<DatabaseSpec> for TableSpec {
     fn process(
         &self,
         parent: &DatabaseSpec,
         context: &ImportContext,
-        _parent_context: &mut (),
         writer: &mut (dyn std::io::Write + Send),
     ) -> Result<()> {
         if !context.generate_fragments {
@@ -51,29 +49,22 @@ impl ModelProcessor<DatabaseSpec, ()> for TableSpec {
 
         writeln!(writer, "{INDENT}{keyword} {type_name} {{")?;
 
-        // Fields that have already been added to the model
-        let mut processed_fields: HashSet<String> = HashSet::new();
-
         let is_pk = |column_spec: &ColumnSpec| column_spec.is_pk;
         let is_not_pk = |column_spec: &ColumnSpec| !column_spec.is_pk;
 
-        // First write the primary key fields
-        write_scalar_fields(writer, self, context, &mut processed_fields, &is_pk)?;
-        write_foreign_key_reference(writer, context, parent, self, &mut processed_fields, &is_pk)?;
+        // Categorize columns to determine which should be written as scalars vs consumed by FK references
+        let column_categories = categorize_columns(self, context);
 
-        // Then write the non-primary key fields
-        write_scalar_fields(writer, self, context, &mut processed_fields, &is_not_pk)?;
-        write_foreign_key_reference(
-            writer,
-            context,
-            parent,
-            self,
-            &mut processed_fields,
-            &is_not_pk,
-        )?;
+        // First write the primary key fields (scalars first, then FKs)
+        write_scalar_fields(writer, self, context, &column_categories, &is_pk)?;
+        write_foreign_key_reference(writer, context, parent, self, &is_pk)?;
 
-        // Finally write the references
-        write_references(writer, context, &mut processed_fields, &self.name)?;
+        // Then write the non-primary key fields (scalars first, then FKs)
+        write_scalar_fields(writer, self, context, &column_categories, &is_not_pk)?;
+        write_foreign_key_reference(writer, context, parent, self, &is_not_pk)?;
+
+        // Finally write back-references (such as Set<User>, User?, etc.) for which this table is the target
+        write_back_references(writer, context, &column_categories)?;
 
         writeln!(writer, "{INDENT}}}")?;
 
@@ -81,32 +72,61 @@ impl ModelProcessor<DatabaseSpec, ()> for TableSpec {
     }
 }
 
-fn write_scalar_fields(
-    writer: &mut (dyn std::io::Write + Send),
-    table_spec: &TableSpec,
+struct ColumnCategories<'a> {
+    /// Columns that should be written as scalar fields
+    scalar_columns: HashSet<&'a str>,
+    /// Columns that are consumed by FK references (won't be written as scalars)
+    #[allow(dead_code)]
+    fk_consumed_columns: HashSet<&'a str>,
+    /// Back-reference fields with complete information (deduplicated)
+    back_reference_fields: Vec<(String, String, bool, bool)>, // (field_name, model_name, is_many, is_nullable)
+}
+
+fn categorize_columns<'a>(
+    table_spec: &'a TableSpec,
     context: &ImportContext,
-    processed_fields: &mut HashSet<String>,
-    filter: &dyn Fn(&ColumnSpec) -> bool,
-) -> Result<()> {
-    for column in &table_spec.columns {
-        if filter(column) {
-            column.process(table_spec, context, processed_fields, writer)?;
+) -> ColumnCategories<'a> {
+    let pk_columns: HashSet<&str> = table_spec
+        .columns
+        .iter()
+        .filter(|c| c.is_pk)
+        .map(|c| c.name.as_str())
+        .collect();
+
+    let fk_references = table_spec.foreign_key_references();
+
+    // Columns that are consumed by FK references (won't be written as scalars)
+    let mut fk_consumed_columns = HashSet::new();
+
+    // Process each FK to determine which columns it consumes
+    for (_, references) in &fk_references {
+        if references.len() == 1 && pk_columns.contains(references[0].0.name.as_str()) {
+            // Single-column FK on a PK column - this column is consumed by the FK
+            fk_consumed_columns.insert(references[0].0.name.as_str());
+        } else {
+            // Composite FK or non-PK FK - non-PK columns are consumed
+            for (col, _) in references {
+                if !col.is_pk {
+                    fk_consumed_columns.insert(col.name.as_str());
+                }
+            }
         }
     }
 
-    Ok(())
-}
+    // All columns that aren't consumed by FKs should be written as scalars
+    let scalar_columns: HashSet<&str> = table_spec
+        .columns
+        .iter()
+        .filter(|c| !fk_consumed_columns.contains(c.name.as_str()))
+        .map(|c| c.name.as_str())
+        .collect();
 
-fn write_references(
-    writer: &mut (dyn std::io::Write + Send),
-    context: &ImportContext,
-    processed_fields: &mut HashSet<String>,
-    table_name: &SchemaObjectName,
-) -> Result<()> {
-    for (table_name, column, _) in context.referenced_columns(table_name) {
-        let model_name = context.model_name(&table_name);
+    // Compute back-reference fields with complete information (deduplicated)
+    let mut seen_back_ref_names = HashSet::new();
+    let mut back_reference_fields = Vec::new();
 
-        if let Some(model_name) = model_name {
+    for (ref_table_name, column, _) in context.referenced_columns(&table_spec.name) {
+        if let Some(model_name) = context.model_name(&ref_table_name) {
             let is_many = column.unique_constraints.is_empty();
             let field_name = if is_many {
                 pluralizer::pluralize(model_name, 2, false)
@@ -115,27 +135,70 @@ fn write_references(
             }
             .to_lower_camel_case();
 
-            if !processed_fields.insert(field_name.clone()) {
-                // Skip fields that have already been added to the model
-                continue;
+            if seen_back_ref_names.insert(field_name.clone()) {
+                let is_nullable = column.is_nullable || !is_many;
+                back_reference_fields.push((
+                    field_name,
+                    model_name.to_string(),
+                    is_many,
+                    is_nullable,
+                ));
             }
-
-            write!(writer, "{INDENT}{INDENT}{field_name}: ")?;
-
-            if is_many {
-                write!(writer, "Set<")?;
-            }
-            write!(writer, "{}", model_name)?;
-            if is_many {
-                write!(writer, ">")?;
-            }
-
-            if column.is_nullable || !is_many {
-                write!(writer, "?")?;
-            }
-
-            writeln!(writer)?;
         }
+    }
+
+    ColumnCategories {
+        scalar_columns,
+        fk_consumed_columns,
+        back_reference_fields,
+    }
+}
+
+fn write_scalar_fields(
+    writer: &mut (dyn std::io::Write + Send),
+    table_spec: &TableSpec,
+    context: &ImportContext,
+    column_categories: &ColumnCategories,
+    filter: &dyn Fn(&ColumnSpec) -> bool,
+) -> Result<()> {
+    for column in &table_spec.columns {
+        // Write this column as a scalar field if:
+        // 1. It's in the scalar_columns set (not consumed by FK)
+        // 2. It matches the filter (PK or non-PK)
+        if column_categories
+            .scalar_columns
+            .contains(column.name.as_str())
+            && filter(column)
+        {
+            column.process(table_spec, context, writer)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn write_back_references(
+    writer: &mut (dyn std::io::Write + Send),
+    _context: &ImportContext,
+    column_categories: &ColumnCategories,
+) -> Result<()> {
+    // Write back-references using pre-computed deduplicated information
+    for (field_name, model_name, is_many, is_nullable) in &column_categories.back_reference_fields {
+        write!(writer, "{INDENT}{INDENT}{field_name}: ")?;
+
+        if *is_many {
+            write!(writer, "Set<")?;
+        }
+        write!(writer, "{}", model_name)?;
+        if *is_many {
+            write!(writer, ">")?;
+        }
+
+        if *is_nullable {
+            write!(writer, "?")?;
+        }
+
+        writeln!(writer)?;
     }
 
     Ok(())

--- a/crates/cli/src/commands/schema/import/test-data/composite-fk/index.expected.exo
+++ b/crates/cli/src/commands/schema/import/test-data/composite-fk/index.expected.exo
@@ -1,0 +1,18 @@
+@postgres
+module Database {
+  @access(query=true, mutation=false)
+  type Event {
+    @pk tenantId: String
+    @pk eventId: String
+    name: String
+    @column(mapping={sourceId: "source_id", tenantId: "tenant_id"}) source: Source
+  }
+
+  @access(query=true, mutation=false)
+  type Source {
+    @pk tenantId: String
+    @pk sourceId: String
+    name: String?
+    events: Set<Event>
+  }
+}

--- a/crates/cli/src/commands/schema/import/test-data/composite-fk/schema.sql
+++ b/crates/cli/src/commands/schema/import/test-data/composite-fk/schema.sql
@@ -1,0 +1,19 @@
+-- events.tenant_id is a shared column between sources and events, but should be written as a scalar field since there is not "tenant" model
+-- events.(tenant_id, source_id) should be writen as a relation
+
+CREATE TABLE IF NOT EXISTS sources (
+  tenant_id text NOT NULL,
+  source_id TEXT NOT NULL,
+  name TEXT,
+
+  CONSTRAINT sources_pkey PRIMARY KEY (tenant_id, source_id)
+);
+
+CREATE TABLE IF NOT EXISTS events (
+    tenant_id text NOT NULL,
+    event_id text NOT NULL,
+    source_id text NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT events_pkey PRIMARY KEY (tenant_id, event_id),
+    CONSTRAINT fk_events_sources FOREIGN KEY (tenant_id, source_id) REFERENCES sources (tenant_id, source_id)
+);


### PR DESCRIPTION
Refactor column categorization to pre-compute scalars, foreign key columns, and back references. This eliminates error-prone runtime field tracking and fixes importing schemas with composite foreign keys (see the added test).