### PR TITLE
fix: produce a precise error for column mapping errors

### DIFF
--- a/crates/postgres-subsystem/postgres-core-builder/src/resolved_builder.rs
+++ b/crates/postgres-subsystem/postgres-core-builder/src/resolved_builder.rs
@@ -654,17 +654,74 @@ fn compute_column_info(
 
     let user_supplied_column_mapping = column_annotation_mapping(field);
 
+    // Validate column mapping once to avoid duplicate errors
+    if let Some(ColumnMapping::Map(mapping)) = &user_supplied_column_mapping {
+        let field_base_type = match &field.typ {
+            AstFieldType::Optional(inner_typ) => inner_typ.as_ref(),
+            _ => &field.typ,
+        };
+        let field_type = field_base_type.to_typ(types).deref(types);
+
+        if let Type::Composite(ct) = field_type {
+            // Collect all primary key field names from the target type
+            let pk_field_names: Vec<&String> = ct
+                .fields
+                .iter()
+                .filter(|f| f.annotations.contains("pk"))
+                .map(|f| &f.name)
+                .collect();
+
+            // Check if all mapping keys correspond to actual fields in the target type
+            for (mapping_key, _) in mapping.iter() {
+                if !ct.fields.iter().any(|f| &f.name == mapping_key) {
+                    return Err(Diagnostic {
+                        level: Level::Error,
+                        message: format!(
+                            "Field '{}' specified in column mapping does not exist in type '{}'",
+                            mapping_key, ct.name
+                        ),
+                        code: Some("C000".to_string()),
+                        spans: vec![SpanLabel {
+                            span: field.span,
+                            style: SpanStyle::Primary,
+                            label: None,
+                        }],
+                    });
+                }
+            }
+
+            // Check if all primary key fields are included in the mapping
+            for pk_field_name in &pk_field_names {
+                if !mapping.contains_key(*pk_field_name) {
+                    return Err(Diagnostic {
+                        level: Level::Error,
+                        message: format!(
+                            "Primary key field '{}' from type '{}' is missing in the column mapping",
+                            pk_field_name, ct.name
+                        ),
+                        code: Some("C000".to_string()),
+                        spans: vec![SpanLabel {
+                            span: field.span,
+                            style: SpanStyle::Primary,
+                            label: None,
+                        }],
+                    });
+                }
+            }
+        }
+    }
+
     let compute_column_name = |field_name: &str| match &user_supplied_column_mapping {
         Some(ColumnMapping::Single(name)) => name.clone(),
         _ => field_name.to_snake_case(),
     };
 
-    let id_column_names = |field: &AstField<Typed>| {
+    let id_column_names = |field: &AstField<Typed>| -> Result<Vec<String>, Diagnostic> {
         let user_supplied_column_mapping = column_annotation_mapping(field);
 
         // Handle simple column name for non-composite types
         if let Some(ColumnMapping::Single(name)) = user_supplied_column_mapping {
-            return vec![name];
+            return Ok(vec![name]);
         }
 
         let field_base_type = match &field.typ {
@@ -676,7 +733,10 @@ fn compute_column_info(
         let base_name = field.name.to_snake_case();
 
         if let Type::Composite(ct) = field_type {
-            ct.fields
+            // Validation is already done upfront, no need to repeat it here
+
+            Ok(ct
+                .fields
                 .iter()
                 .filter_map(|f| {
                     if f.annotations.contains("pk") {
@@ -694,9 +754,9 @@ fn compute_column_info(
                         None
                     }
                 })
-                .collect::<Vec<_>>()
+                .collect::<Vec<_>>())
         } else {
-            vec![]
+            Ok(vec![])
         }
     };
 
@@ -801,7 +861,7 @@ fn compute_column_info(
                                                 })
                                     } else {
                                         Ok(ColumnInfo {
-                                            names: id_column_names(matching_field?),
+                                            names: id_column_names(matching_field?)?,
                                             self_column: false,
                                             unique_constraints,
                                             indices,
@@ -810,7 +870,7 @@ fn compute_column_info(
                                     }
                                 }
                                 Cardinality::Unbounded => Ok(ColumnInfo {
-                                    names: id_column_names(field),
+                                    names: id_column_names(field)?,
                                     self_column: true,
                                     unique_constraints,
                                     indices,
@@ -833,7 +893,7 @@ fn compute_column_info(
                                 };
 
                             Ok(ColumnInfo {
-                                names: id_column_names(field),
+                                names: id_column_names(field)?,
                                 self_column: true,
                                 unique_constraints,
                                 indices,
@@ -887,7 +947,7 @@ fn compute_column_info(
                             });
                         } else {
                             Ok(ColumnInfo {
-                                names: id_column_names(matching_field),
+                                names: id_column_names(matching_field)?,
                                 self_column: false,
                                 unique_constraints,
                                 indices,
@@ -1662,6 +1722,70 @@ mod tests {
         }
         "#,
             "Many-to-many relationships (both side optional) without a linking type should be rejected"
+        );
+    }
+
+    #[multiplatform_test]
+    fn column_mapping_validation() {
+        // Test invalid field in mapping
+        assert_resolved_err!(
+            r#"
+        @postgres
+        module Database {
+            type Member {
+                @pk memberId: String
+                @pk memberTenantId: String
+                memberName: String?
+            }
+
+            type Membership {
+                @pk membershipId: String
+                @column(mapping={invalidField: "membership_member_id", memberTenantId: "membership_tenant_id"}) member: Member
+            }
+        }
+        "#,
+            "Field 'invalidField' specified in column mapping does not exist"
+        );
+
+        // Test missing primary key field in mapping
+        assert_resolved_err!(
+            r#"
+        @postgres
+        module Database {
+            type Member {
+                @pk memberId: String
+                @pk memberTenantId: String
+                memberName: String?
+            }
+
+            type Membership {
+                @pk membershipId: String
+                @column(mapping={memberTenantId: "membership_tenant_id"}) member: Member
+            }
+        }
+        "#,
+            "Primary key field 'memberId' from type 'Member' is missing"
+        );
+
+        // Test valid mapping
+        assert_resolved!(
+            r#"
+        @postgres
+        module Database {
+            type Member {
+                @pk memberId: String
+                @pk memberTenantId: String
+                memberName: String?
+                memberships: Set<Membership>
+            }
+
+            type Membership {
+                @pk membershipId: String
+                @column(mapping={memberId: "membership_member_id", memberTenantId: "membership_tenant_id"}) member: Member
+            }
+        }
+        "#,
+            "column_mapping_validation"
         );
     }
 }

--- a/crates/postgres-subsystem/postgres-core-builder/src/snapshots/column_mapping_validation.snap
+++ b/crates/postgres-subsystem/postgres-core-builder/src/snapshots/column_mapping_validation.snap
@@ -1,0 +1,285 @@
+---
+source: crates/postgres-subsystem/postgres-core-builder/src/resolved_builder.rs
+expression: resolved
+---
+values:
+  - - ~
+    - Primitive:
+        Plain: Boolean
+  - - ~
+    - Primitive:
+        Plain: Int
+  - - ~
+    - Primitive:
+        Plain: Float
+  - - ~
+    - Primitive:
+        Plain: Decimal
+  - - ~
+    - Primitive:
+        Plain: String
+  - - ~
+    - Primitive:
+        Plain: LocalTime
+  - - ~
+    - Primitive:
+        Plain: LocalDateTime
+  - - ~
+    - Primitive:
+        Plain: LocalDate
+  - - ~
+    - Primitive:
+        Plain: Instant
+  - - ~
+    - Primitive:
+        Plain: Json
+  - - ~
+    - Primitive:
+        Plain: Blob
+  - - ~
+    - Primitive:
+        Plain: Uuid
+  - - ~
+    - Primitive:
+        Plain: Vector
+  - - ~
+    - Composite:
+        name: Member
+        plural_name: Members
+        representation: Managed
+        fields:
+          - name: memberId
+            typ:
+              Plain:
+                type_name: String
+                is_primitive: true
+            column_names:
+              - member_id
+            self_column: true
+            is_pk: true
+            access:
+              default:
+                BooleanLiteral:
+                  - true
+              query: ~
+              mutation: ~
+              creation: ~
+              update: ~
+              delete: ~
+            type_hint: ~
+            unique_constraints: []
+            indices: []
+            cardinality: ~
+            default_value: ~
+            update_sync: false
+            readonly: false
+            doc_comments: ~
+          - name: memberTenantId
+            typ:
+              Plain:
+                type_name: String
+                is_primitive: true
+            column_names:
+              - member_tenant_id
+            self_column: true
+            is_pk: true
+            access:
+              default:
+                BooleanLiteral:
+                  - true
+              query: ~
+              mutation: ~
+              creation: ~
+              update: ~
+              delete: ~
+            type_hint: ~
+            unique_constraints: []
+            indices: []
+            cardinality: ~
+            default_value: ~
+            update_sync: false
+            readonly: false
+            doc_comments: ~
+          - name: memberName
+            typ:
+              Optional:
+                Plain:
+                  type_name: String
+                  is_primitive: true
+            column_names:
+              - member_name
+            self_column: true
+            is_pk: false
+            access:
+              default:
+                BooleanLiteral:
+                  - true
+              query: ~
+              mutation: ~
+              creation: ~
+              update: ~
+              delete: ~
+            type_hint: ~
+            unique_constraints: []
+            indices: []
+            cardinality: ~
+            default_value: ~
+            update_sync: false
+            readonly: false
+            doc_comments: ~
+          - name: memberships
+            typ:
+              List:
+                Plain:
+                  type_name: Membership
+                  is_primitive: false
+            column_names:
+              - membership_member_id
+              - membership_tenant_id
+            self_column: false
+            is_pk: false
+            access:
+              default:
+                BooleanLiteral:
+                  - true
+              query: ~
+              mutation: ~
+              creation: ~
+              update: ~
+              delete: ~
+            type_hint: ~
+            unique_constraints: []
+            indices: []
+            cardinality: One
+            default_value: ~
+            update_sync: false
+            readonly: false
+            doc_comments: ~
+        table_name:
+          name: members
+          schema: ~
+        access:
+          default: ~
+          query: ~
+          mutation: ~
+          creation: ~
+          update: ~
+          delete: ~
+        doc_comments: ~
+  - - ~
+    - Composite:
+        name: Membership
+        plural_name: Memberships
+        representation: Managed
+        fields:
+          - name: membershipId
+            typ:
+              Plain:
+                type_name: String
+                is_primitive: true
+            column_names:
+              - membership_id
+            self_column: true
+            is_pk: true
+            access:
+              default:
+                BooleanLiteral:
+                  - true
+              query: ~
+              mutation: ~
+              creation: ~
+              update: ~
+              delete: ~
+            type_hint: ~
+            unique_constraints: []
+            indices: []
+            cardinality: ~
+            default_value: ~
+            update_sync: false
+            readonly: false
+            doc_comments: ~
+          - name: member
+            typ:
+              Plain:
+                type_name: Member
+                is_primitive: false
+            column_names:
+              - membership_member_id
+              - membership_tenant_id
+            self_column: true
+            is_pk: false
+            access:
+              default:
+                BooleanLiteral:
+                  - true
+              query: ~
+              mutation: ~
+              creation: ~
+              update: ~
+              delete: ~
+            type_hint: ~
+            unique_constraints: []
+            indices: []
+            cardinality: Unbounded
+            default_value: ~
+            update_sync: false
+            readonly: false
+            doc_comments: ~
+        table_name:
+          name: memberships
+          schema: ~
+        access:
+          default: ~
+          query: ~
+          mutation: ~
+          creation: ~
+          update: ~
+          delete: ~
+        doc_comments: ~
+  - ~
+map:
+  Blob:
+    index: 10
+    generation: ~
+  Boolean:
+    index: 0
+    generation: ~
+  Decimal:
+    index: 3
+    generation: ~
+  Float:
+    index: 2
+    generation: ~
+  Instant:
+    index: 8
+    generation: ~
+  Int:
+    index: 1
+    generation: ~
+  Json:
+    index: 9
+    generation: ~
+  LocalDate:
+    index: 7
+    generation: ~
+  LocalDateTime:
+    index: 6
+    generation: ~
+  LocalTime:
+    index: 5
+    generation: ~
+  Member:
+    index: 13
+    generation: ~
+  Membership:
+    index: 14
+    generation: ~
+  String:
+    index: 4
+    generation: ~
+  Uuid:
+    index: 11
+    generation: ~
+  Vector:
+    index: 12
+    generation: ~

--- a/error-report-testing/column-mapping/non-existing-field/error.txt
+++ b/error-report-testing/column-mapping/non-existing-field/error.txt
@@ -1,0 +1,8 @@
+error[C000]: Field 'invalid' specified in column mapping does not exist in type 'Member'
+  --> src/index.exo:15:5
+   |
+15 |     @column(mapping={invalid: "membership_member_id", memberTenantId: "membership_tenant_id"}) member: Member?
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Error: Parser error: Could not process input exo files
+

--- a/error-report-testing/column-mapping/non-existing-field/src/index.exo
+++ b/error-report-testing/column-mapping/non-existing-field/src/index.exo
@@ -1,0 +1,24 @@
+@postgres
+module Database {
+  @access(query=true, mutation=true)
+  type Member {
+    @pk memberId: String
+    @pk @column("member_tenant_id") memberTenantId: String
+    memberName: String?
+    memberships: Set<Membership>
+  }
+
+  @access(query=true, mutation=true)
+  type Membership {
+    @pk membershipId: String
+    @pk @column("membership_tenant_id") membershipTenantId: String
+    @column(mapping={invalid: "membership_member_id", memberTenantId: "membership_tenant_id"}) member: Member?
+    membershipName: String?
+  }
+
+  @access(query=true, mutation=true)
+  type Tenant {
+    @pk tenantId: String
+    tenantName: String?
+  }
+}

--- a/error-report-testing/column-mapping/unspecified-pk/error.txt
+++ b/error-report-testing/column-mapping/unspecified-pk/error.txt
@@ -1,0 +1,8 @@
+error[C000]: Primary key field 'memberId' from type 'Member' is missing in the column mapping
+  --> src/index.exo:12:5
+   |
+12 |     @column(mapping={memberTenantId: "membership_tenant_id"}) member: Member
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Error: Parser error: Could not process input exo files
+

--- a/error-report-testing/column-mapping/unspecified-pk/src/index.exo
+++ b/error-report-testing/column-mapping/unspecified-pk/src/index.exo
@@ -1,0 +1,14 @@
+@postgres
+module Database {
+  type Member {
+    @pk memberId: String
+    @pk memberTenantId: String
+    memberName: String?
+  }
+
+  type Membership {
+    @pk membershipId: String
+    // The mapping is missing the memberId field, which is a primary key field in the Member type
+    @column(mapping={memberTenantId: "membership_tenant_id"}) member: Member
+  }
+}


### PR DESCRIPTION
Earlier, we produced a vague error that didn't help user with the real issue. Now we produce two kind of specific validations (and point to a specific line) for `@column(mapping...)`.

1. Use of non-existing fields
2. Missed primary keys from the target type