### PR TITLE
feat(mcp): make the server's version compatible with the client's

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5640,6 +5640,7 @@ dependencies = [
  "introspection-util",
  "serde",
  "serde_json",
+ "thiserror 2.0.12",
  "tracing",
 ]
 

--- a/crates/mcp-router/Cargo.toml
+++ b/crates/mcp-router/Cargo.toml
@@ -13,6 +13,7 @@ bytes.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 async-graphql-parser.workspace = true
+thiserror.workspace = true
 
 common = { path = "../common" }
 exo-env = { path = "../../libs/exo-env" }

--- a/crates/mcp-router/src/error.rs
+++ b/crates/mcp-router/src/error.rs
@@ -1,0 +1,5 @@
+#[derive(thiserror::Error, Debug)]
+pub enum McpRouterError {
+    #[error("Invalid protocol version: {0}")]
+    InvalidProtocolVersion(String),
+}

--- a/crates/mcp-router/src/lib.rs
+++ b/crates/mcp-router/src/lib.rs
@@ -1,9 +1,11 @@
 #![cfg(not(target_family = "wasm"))]
 
+mod error;
 mod execute_query_tool;
 mod executor;
 mod introspection_tool;
 mod mcp_router;
+mod protocol_version;
 mod tool;
 mod tools_creator;
 

--- a/crates/mcp-router/src/protocol_version.rs
+++ b/crates/mcp-router/src/protocol_version.rs
@@ -1,0 +1,32 @@
+use std::fmt::{self, Display};
+
+use crate::error::McpRouterError;
+
+#[derive(Debug)]
+pub enum ProtocolVersion {
+    V2024_11_05,
+    V2025_03_26,
+    V2025_06_18,
+}
+
+impl Display for ProtocolVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::V2024_11_05 => write!(f, "2024-11-05"),
+            Self::V2025_03_26 => write!(f, "2025-03-26"),
+            Self::V2025_06_18 => write!(f, "2025-06-18"),
+        }
+    }
+}
+
+impl TryFrom<&str> for ProtocolVersion {
+    type Error = McpRouterError;
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "2024-11-05" => Ok(Self::V2024_11_05),
+            "2025-03-26" => Ok(Self::V2025_03_26),
+            "2025-06-18" => Ok(Self::V2025_06_18),
+            _ => Err(McpRouterError::InvalidProtocolVersion(s.to_string())),
+        }
+    }
+}


### PR DESCRIPTION
The [spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle#version-negotiation) requires that if we support the client's version, we return that to be the server's version. Since we support every version listed in `ProtocolVersion`, we return the client's version if it is valid.

This makes Exograph's MCP support compatible with the current Claude Desktop (which is still at "2024-11-05"), while supporting newer clients with support for the HTTP protocol.