### PR TITLE
test: use cleaner test names relative to the supplied directory

### DIFF
--- a/crates/testing/src/loader/integration_test.rs
+++ b/crates/testing/src/loader/integration_test.rs
@@ -114,7 +114,12 @@ impl IntegrationTest {
 
         if extension == "gql" {
             // For init files, we don't care about the name, so we use the parent directory as root and project
-            let parent = init_file_path.parent().unwrap();
+            let parent = init_file_path.parent().with_context(|| {
+                format!(
+                    "Could not get parent directory for init file: {}",
+                    init_file_path.display()
+                )
+            })?;
             Self::load(init_file_path, vec![], parent, parent).map(|test| {
                 let IntegrationTest {
                     test_operations, ..
@@ -169,7 +174,7 @@ impl IntegrationTest {
     Error as a single stage test: {}
     Error as a multistage test: {}
     "#,
-                testfile_path.to_str().unwrap(),
+                testfile_path.display(),
                 single_stage_error,
                 multi_stage_error
             );
@@ -184,7 +189,7 @@ impl IntegrationTest {
             bail!(
                 "Unknown fields: {:?} defined in {}",
                 extra_keys.iter().collect::<Vec<_>>(),
-                testfile_path.to_str().unwrap()
+                testfile_path.display()
             );
         }
 
@@ -234,14 +239,24 @@ impl IntegrationTest {
         testfile_path: &Path,
         invariants: Vec<TestfileStageInvariant>,
     ) -> Result<Vec<ApiOperationInvariant>> {
-        let testfile_dir = testfile_path.parent().unwrap();
+        let testfile_dir = testfile_path.parent().with_context(|| {
+            format!(
+                "Could not get parent directory for testfile: {}",
+                testfile_path.display()
+            )
+        })?;
 
         let mut invariant_ops: Vec<ApiOperationInvariant> = vec![];
 
         for invariant in invariants {
             let invariant_path = testfile_dir.join(invariant.path.clone());
             // For invariants, we don't care about the name, so we use the parent directory as root and project
-            let parent = invariant_path.parent().unwrap();
+            let parent = invariant_path.parent().with_context(|| {
+                format!(
+                    "Could not get parent directory for invariant file: {}",
+                    invariant_path.display()
+                )
+            })?;
             let integration_test = Self::load(&invariant_path, vec![], parent, parent)?;
 
             for op in integration_test.test_operations {

--- a/crates/testing/src/loader/test_suite.rs
+++ b/crates/testing/src/loader/test_suite.rs
@@ -30,7 +30,13 @@ impl TestSuite {
         exo_project_dirs
             .into_iter()
             .map(|exo_project_dir| {
-                let tests = load_tests_dir(&exo_project_dir, &[], pattern)?;
+                let tests = load_tests_dir(
+                    &exo_project_dir,
+                    &[],
+                    pattern,
+                    root_directory,
+                    &exo_project_dir,
+                )?;
                 Ok(TestSuite {
                     project_dir: exo_project_dir,
                     tests,
@@ -44,6 +50,8 @@ fn load_tests_dir(
     test_directory: &Path, // directory that contains "src/index.exo"
     init_ops: &[InitOperation],
     pattern: &Option<String>,
+    root_dir: &Path,
+    project_dir: &Path, // The exo project directory
 ) -> Result<Vec<IntegrationTest>> {
     // Begin directory traversal
     let mut exotest_files: Vec<PathBuf> = vec![];
@@ -89,14 +97,21 @@ fn load_tests_dir(
     let mut testfiles = vec![];
 
     for testfile_path in exotest_files.iter() {
-        let testfile = IntegrationTest::load(testfile_path, init_ops.clone())?;
+        let testfile =
+            IntegrationTest::load(testfile_path, init_ops.clone(), root_dir, project_dir)?;
         testfiles.push(testfile);
     }
 
     // Recursively parse test files
     for sub_directory in sub_directories.iter() {
         let child_init_ops = init_ops.clone();
-        let child_testfiles = load_tests_dir(sub_directory, &child_init_ops, pattern)?;
+        let child_testfiles = load_tests_dir(
+            sub_directory,
+            &child_init_ops,
+            pattern,
+            root_dir,
+            project_dir,
+        )?;
         testfiles.extend(child_testfiles)
     }
 

--- a/crates/testing/src/model/mod.rs
+++ b/crates/testing/src/model/mod.rs
@@ -22,11 +22,16 @@ pub struct TestSuite {
 
 #[derive(Debug, Clone)]
 pub struct IntegrationTest {
+    /// The root directory from which the test command was run (used to compute the test name to be relative to the root directory)
+    pub root_dir: PathBuf,
+    /// The exo project directory containing src/ and tests/ (used to compute the test name to drop the "tests/" prefix)
+    pub project_dir: PathBuf,
     pub testfile_path: PathBuf,
     pub retries: usize,
     pub init_operations: Vec<InitOperation>,
     pub test_operations: Vec<ApiOperation>,
-    pub extra_envs: HashMap<String, String>, // extra envvars to be set when starting the exo server
+    /// Extra envvars to be set when starting the exo server
+    pub extra_envs: HashMap<String, String>,
 }
 
 #[allow(clippy::large_enum_variant)]


### PR DESCRIPTION
When we run `exo test integration-tests/services`, the test names should be relative to the `integration-tests/services` directory: `set-arg-return-value/basic` and `node-module/basic-query` etc. Previously, they included an additional `services/` prefix (and `basic` was prefixed with `tests`): `services/set-arg-return-value/tests/basic` and `services/node-module/tests/basic-query`.

Similarly, when we run `exo test integration-tests/services/basic`, test names should be relative to the `integration-tests/services/basic` directory: `query-service` and `exceptions` etc. Previously, they included an additional `services/basic/tests/` prefix.

This change creates test names that are:
1. Relative to the directory specified in the `exo test <directory>` command
2. Strip the "tests/" directory component when it's a direct child of an exo project directory

The result is cleaner, shorter, and more intuitive test names.