### PR TITLE
refactor: replace manual memory management in transaction

### DIFF
--- a/crates/common/src/context/request_context.rs
+++ b/crates/common/src/context/request_context.rs
@@ -53,7 +53,7 @@ impl<'a> RequestContext<'a> {
                 env,
                 jwt_authenticator,
                 system_router,
-                transaction_holder: Arc::new(Mutex::new(TransactionHolder::default())),
+                transaction_holder: Arc::new(Mutex::new(TransactionHolder::new())),
             },
         }
     }

--- a/libs/exo-sql/src/asql/database_executor.rs
+++ b/libs/exo-sql/src/asql/database_executor.rs
@@ -7,22 +7,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::{ops::DerefMut, sync::atomic::AtomicBool};
-
 use crate::{
     Database,
     database_error::DatabaseError,
     sql::{
-        connect::{
-            database_client::{DatabaseClient, TransactionWrapper},
-            database_client_manager::DatabaseClientManager,
-        },
-        transaction::{TransactionScript, TransactionStepResult},
+        connect::database_client_manager::DatabaseClientManager, transaction::TransactionStepResult,
     },
     transform::{pg::Postgres, transformer::OperationTransformer},
 };
 
-use super::abstract_operation::AbstractOperation;
+use super::{abstract_operation::AbstractOperation, transaction_holder::TransactionHolder};
 
 pub struct DatabaseExecutor {
     pub database_client: DatabaseClientManager,
@@ -44,139 +38,5 @@ impl DatabaseExecutor {
         tx_holder
             .with_tx(database, &self.database_client, transaction_script)
             .await
-    }
-}
-
-// TransactionHolder holds raw pointers to two objects: `client` and `transaction`.
-// `transaction` holds a reference to `client`, which makes initializing this struct properly difficult.
-// In addition, we must interact with async methods when using either of these objects, further complicating things
-// and preventing us from using libraries like self_cell and ouroboros.
-//
-// To simplify lifetime constraints, these are allocated and dropped manually through Box::leak
-// and a manual Drop impl. By doing so, this grants `transaction` a 'static lifetime that oversteps some lifetime
-// issues we encountered. Of course, we must manually make sure that the objects are tied to the lifetime of TransactionHolder.
-
-#[derive(Default)]
-pub struct TransactionHolder {
-    client: Option<*mut DatabaseClient>,
-    transaction: Option<*mut TransactionWrapper<'static>>,
-    finalized: AtomicBool,
-    needs_transaction: AtomicBool,
-}
-
-/// # Safety
-///
-/// This is needed to mark mut pointers in TransactionHolder as Send
-/// <https://internals.rust-lang.org/t/shouldnt-pointers-be-send-sync-or/8818/4>
-///
-/// As the base types are Send, this should not be a problem.
-unsafe impl Send for TransactionHolder {}
-
-impl Drop for TransactionHolder {
-    fn drop(&mut self) {
-        if let Some(client) = self.client {
-            // SAFETY: this should always be de-referenceable when it is a Some(_)
-            let client = unsafe { Box::from_raw(client) };
-            drop(client)
-        }
-
-        if let Some(transaction) = self.transaction {
-            // SAFETY: this should always be de-referenceable when it is a Some(_)
-            let transaction = unsafe { Box::from_raw(transaction) };
-            drop(transaction)
-        }
-    }
-}
-
-impl TransactionHolder {
-    pub async fn with_tx(
-        &mut self,
-        database: &Database,
-        client_manager: &DatabaseClientManager,
-        work: TransactionScript<'_>,
-    ) -> Result<TransactionStepResult, DatabaseError> {
-        if self.finalized.load(std::sync::atomic::Ordering::SeqCst) {
-            return Err(DatabaseError::Transaction(
-                "Transaction already finalized".into(),
-            ));
-        }
-
-        // SAFETY: this should be safe, we only really handle transaction in this function and it should
-        // always be de-referencable when it is a Some(_)
-        let tx = unsafe {
-            self.transaction
-                .map(|ptr| ptr.as_mut().unwrap().deref_mut())
-        };
-
-        match tx {
-            Some(tx) => work.execute(database, tx).await,
-
-            None => {
-                // first, grab a client if none are available
-                if self.client.is_none() {
-                    let client_owned = unsafe {
-                        let mut client_owned: Option<*mut DatabaseClient> = None;
-                        std::mem::swap(&mut self.client, &mut client_owned);
-                        client_owned.map(|ptr| Box::from_raw(ptr))
-                    };
-
-                    if client_owned.is_none() {
-                        let client = client_manager.get_client().await?;
-                        self.client = Some(Box::leak(Box::new(client)));
-                    };
-                }
-
-                // proceed with grabbing a transaction and execution
-                {
-                    // SAFETY: this should always be de-referenceable when it is a Some(_)
-                    let client = unsafe { self.client.map(|ptr| ptr.as_mut().unwrap()) }.unwrap();
-
-                    if work.needs_transaction()
-                        || self
-                            .needs_transaction
-                            .load(std::sync::atomic::Ordering::SeqCst)
-                    {
-                        let mut tx = Box::new(client.transaction().await?);
-                        let res = work.execute(database, tx.deref_mut().deref_mut()).await;
-
-                        self.transaction = Some(Box::leak(tx));
-
-                        res
-                    } else {
-                        work.execute(database, client.deref_mut()).await
-                    }
-                }
-            }
-        }
-    }
-
-    pub async fn finalize(&mut self, commit: bool) -> Result<(), tokio_postgres::Error> {
-        // SAFETY: this should always be de-referenceable when it is a Some(_)
-        let tx_owned = unsafe {
-            let mut tx_owned: Option<*mut TransactionWrapper> = None;
-            std::mem::swap(&mut self.transaction, &mut tx_owned);
-            tx_owned.map(|ptr| Box::from_raw(ptr))
-        };
-
-        match tx_owned {
-            Some(boxed) => {
-                if commit {
-                    boxed.commit().await
-                } else {
-                    boxed.rollback().await
-                }
-            }
-
-            None => Ok(()),
-        }?;
-
-        self.finalized
-            .store(true, std::sync::atomic::Ordering::SeqCst);
-        Ok(())
-    }
-
-    pub fn ensure_transaction(&self) {
-        self.needs_transaction
-            .store(true, std::sync::atomic::Ordering::SeqCst);
     }
 }

--- a/libs/exo-sql/src/asql/mod.rs
+++ b/libs/exo-sql/src/asql/mod.rs
@@ -17,5 +17,6 @@ pub mod order_by;
 pub mod predicate;
 pub mod select;
 pub mod selection;
+pub mod transaction_holder;
 
 pub mod update;

--- a/libs/exo-sql/src/asql/transaction_holder.rs
+++ b/libs/exo-sql/src/asql/transaction_holder.rs
@@ -1,0 +1,229 @@
+// Copyright Exograph, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file at the root of this repository.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::{
+    ops::DerefMut,
+    sync::{LazyLock, atomic::AtomicBool},
+};
+
+use tokio::sync::Mutex;
+
+use crate::{
+    Database,
+    database_error::DatabaseError,
+    sql::{
+        connect::{
+            database_client::{DatabaseClient, TransactionWrapper},
+            database_client_manager::DatabaseClientManager,
+        },
+        transaction::{TransactionScript, TransactionStepResult},
+    },
+};
+
+/// Manages the state of a transaction.
+///
+/// The implementation complexity comes from the requirement that we must defer the creation of the transaction
+/// until the first database operation is performed and must finalize (commit or rollback) after the last database operation.
+/// For example, we may have a Deno operation that may execute multiple queries/mutations. We need to create a transaction
+/// before the first database operation and finalize only when we are about to return results. Note that we can't
+/// just wrap the work in a transaction because, for example, a Deno operation may not do any database work at all.
+pub struct TransactionHolder {
+    state: LazyLock<Mutex<TransactionState>>,
+    needs_transaction: AtomicBool,
+}
+
+struct TransactionState {
+    client: Option<DatabaseClient>,
+    transaction: Option<TransactionWrapper<'static>>,
+    finalized: bool,
+}
+
+impl Default for TransactionHolder {
+    fn default() -> Self {
+        Self {
+            state: LazyLock::new(|| Mutex::new(TransactionState::new())),
+            needs_transaction: AtomicBool::new(false),
+        }
+    }
+}
+
+impl TransactionHolder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the flag to indicate that a transaction must be used when executing work.
+    ///
+    /// Typically, a caller higher-up in the stack calls this method when it determines that a transaction
+    /// must be used. (For example, when an operation has an interceptor and caller can't know if the interceptor
+    /// will also do some database work).
+    pub fn ensure_transaction(&self) {
+        self.needs_transaction
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    /// Execute work within a transaction context
+    pub(super) async fn with_tx(
+        &mut self,
+        database: &Database,
+        client_manager: &DatabaseClientManager,
+        work: TransactionScript<'_>,
+    ) -> Result<TransactionStepResult, DatabaseError> {
+        let mut state = self.state.lock().await;
+
+        if state.finalized {
+            return Err(DatabaseError::Transaction(
+                "Transaction already finalized".to_string(),
+            ));
+        }
+
+        // Ensure we have a client
+        state.ensure_client(client_manager).await?;
+
+        // Execute the work
+        let needs_tx = self
+            .needs_transaction
+            .load(std::sync::atomic::Ordering::SeqCst);
+        state.execute_work(database, work, needs_tx).await
+    }
+
+    /// Finalize the transaction (commit or rollback based on parameter)
+    pub async fn finalize(&mut self, commit: bool) -> Result<(), tokio_postgres::Error> {
+        let mut state = self.state.lock().await;
+        if commit {
+            state.commit().await.map_err(|e| match e {
+                DatabaseError::Delegate(pg_err) => pg_err,
+                _ => tokio_postgres::Error::__private_api_timeout(),
+            })
+        } else {
+            state.rollback().await.map_err(|e| match e {
+                DatabaseError::Delegate(pg_err) => pg_err,
+                _ => tokio_postgres::Error::__private_api_timeout(),
+            })
+        }
+    }
+}
+
+impl TransactionState {
+    fn new() -> Self {
+        Self {
+            client: None,
+            transaction: None,
+            finalized: false,
+        }
+    }
+
+    async fn ensure_client(
+        &mut self,
+        client_manager: &DatabaseClientManager,
+    ) -> Result<(), DatabaseError> {
+        if self.client.is_none() && !self.finalized {
+            self.client = Some(client_manager.get_client().await?);
+        }
+        Ok(())
+    }
+
+    async fn ensure_transaction(&mut self) -> Result<(), DatabaseError> {
+        if self.transaction.is_none() && !self.finalized {
+            if let Some(ref mut client) = self.client {
+                let tx = client.transaction().await?;
+
+                // SAFETY: This lifetime extension is safe because:
+                // 1. The TransactionWrapper<'_> borrows from the DatabaseClient (see DatabaseClient::transaction)
+                // 2. Both the client and transaction are stored in the same struct (TransactionState)
+                // 3. All fields of TransactionState and TransactionHolder are private, thus their access is only in this module
+                // 4. The transaction is only accessed through methods that ensure the client is still alive
+                // 5. Both are protected by the same Mutex<TransactionState> ensuring exclusive access
+                // 6. The transaction is always dropped before or with the client in commit/rollback
+                // 6. The 'static lifetime here is for the type system, but the actual lifetime
+                //    is managed by the containing struct which ensures memory safety
+                let tx_static: TransactionWrapper<'static> = unsafe { std::mem::transmute(tx) };
+                self.transaction = Some(tx_static);
+            }
+        }
+        Ok(())
+    }
+
+    async fn execute_work(
+        &mut self,
+        database: &Database,
+        work: TransactionScript<'_>,
+        needs_tx: bool,
+    ) -> Result<TransactionStepResult, DatabaseError> {
+        if work.needs_transaction() || needs_tx {
+            self.ensure_transaction().await?;
+            if let Some(ref mut tx) = self.transaction {
+                work.execute(database, tx.deref_mut()).await
+            } else {
+                Err(DatabaseError::Transaction(
+                    "Failed to create transaction".to_string(),
+                ))
+            }
+        } else if let Some(ref mut client) = self.client {
+            work.execute(database, client.deref_mut()).await
+        } else {
+            Err(DatabaseError::Transaction(
+                "No database client available".to_string(),
+            ))
+        }
+    }
+
+    async fn commit(&mut self) -> Result<(), DatabaseError> {
+        if let Some(tx) = self.transaction.take() {
+            tx.commit().await?;
+        }
+        self.finalized = true;
+        Ok(())
+    }
+
+    async fn rollback(&mut self) -> Result<(), DatabaseError> {
+        if let Some(tx) = self.transaction.take() {
+            tx.rollback().await?;
+        }
+        self.finalized = true;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Note: These tests would require a real database connection to be comprehensive
+    // For now, we just test the basic state management
+
+    #[tokio::test]
+    async fn test_transaction_holder_creation() {
+        let holder = TransactionHolder::new();
+        assert!(!holder.state.lock().await.finalized);
+    }
+
+    #[test]
+    fn test_ensure_transaction() {
+        let holder = TransactionHolder::new();
+        holder.ensure_transaction();
+        assert!(
+            holder
+                .needs_transaction
+                .load(std::sync::atomic::Ordering::SeqCst)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_finalized_state_consistency() {
+        let mut holder = TransactionHolder::new();
+
+        // Initially not finalized
+        assert!(!holder.state.lock().await.finalized);
+
+        // After finalize, should be finalized (even without actual DB operations)
+        let _ = holder.finalize(true).await; // We expect this to succeed even without DB
+        assert!(holder.state.lock().await.finalized);
+    }
+}

--- a/libs/exo-sql/src/lib.rs
+++ b/libs/exo-sql/src/lib.rs
@@ -48,13 +48,14 @@ pub mod database_error;
 pub use asql::{
     abstract_operation::AbstractOperation,
     column_path::{ColumnPath, ColumnPathLink, PhysicalColumnPath},
-    database_executor::{DatabaseExecutor, TransactionHolder},
+    database_executor::DatabaseExecutor,
     delete::AbstractDelete,
     insert::{AbstractInsert, ColumnValuePair, InsertionElement, InsertionRow, NestedInsertion},
     order_by::{AbstractOrderBy, AbstractOrderByExpr},
     predicate::AbstractPredicate,
     select::AbstractSelect,
     selection::{AliasedSelectionElement, Selection, SelectionCardinality, SelectionElement},
+    transaction_holder::TransactionHolder,
     update::{
         AbstractUpdate, NestedAbstractDelete, NestedAbstractInsert, NestedAbstractInsertSet,
         NestedAbstractUpdate,

--- a/libs/exo-sql/src/sql/connect/database_client.rs
+++ b/libs/exo-sql/src/sql/connect/database_client.rs
@@ -39,6 +39,7 @@ impl DerefMut for DatabaseClient {
     }
 }
 
+/// Abstracts over the different transaction types that can be returned by the database client.
 pub enum TransactionWrapper<'a> {
     #[cfg(feature = "pool")]
     Pooled(deadpool_postgres::Transaction<'a>),


### PR DESCRIPTION
Replaces raw pointer manipulation with the introduction of `TransactionState` to hold all transaction related information and the use of a `LazyLock<Mutex<TransactionState>>` field in `TransactionHolder` to eliminate most unsafe code. Reduces from ~8 unsafe blocks to 1 and better documents the remaining unsafe block for lifetime extension.

Fixes #594