### PR TITLE
feat(mcp): enable MCP by defautl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,9 +1599,9 @@ version = "0.20.0"
 name = "core-router"
 version = "0.20.0"
 dependencies = [
- "common",
  "core-plugin-interface",
  "core-plugin-shared",
+ "exo-env",
  "thiserror 2.0.12",
 ]
 
@@ -3743,6 +3743,9 @@ dependencies = [
 [[package]]
 name = "exo-env"
 version = "0.20.0"
+dependencies = [
+ "thiserror 2.0.12",
+]
 
 [[package]]
 name = "exo-sql"

--- a/crates/common/src/env_const.rs
+++ b/crates/common/src/env_const.rs
@@ -1,6 +1,4 @@
-use exo_env::Environment;
-
-use super::EnvError;
+use exo_env::{EnvError, Environment};
 
 pub const EXO_INTROSPECTION: &str = "EXO_INTROSPECTION";
 pub const EXO_INTROSPECTION_LIVE_UPDATE: &str = "EXO_INTROSPECTION_LIVE_UPDATE";
@@ -34,7 +32,7 @@ pub const EXO_GRAPHQL_ALLOW_MUTATIONS: &str = "EXO_GRAPHQL_ALLOW_MUTATIONS";
 
 pub const EXO_UNSTABLE_ENABLE_REST_API: &str = "EXO_UNSTABLE_ENABLE_REST_API";
 pub const EXO_UNSTABLE_ENABLE_RPC_API: &str = "EXO_UNSTABLE_ENABLE_RPC_API";
-pub const EXO_ENABLE_MCP_API: &str = "EXO_ENABLE_MCP_API";
+pub const EXO_ENABLE_MCP: &str = "EXO_ENABLE_MCP";
 
 pub const EXO_WWW_AUTHENTICATE_HEADER: &str = "EXO_WWW_AUTHENTICATE_HEADER";
 

--- a/crates/common/src/introspection.rs
+++ b/crates/common/src/introspection.rs
@@ -1,6 +1,6 @@
-use exo_env::Environment;
+use exo_env::{EnvError, Environment};
 
-use crate::{EnvError, env_const::EXO_INTROSPECTION};
+use crate::env_const::EXO_INTROSPECTION;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum IntrospectionMode {

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -7,8 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use thiserror::Error;
-
 pub mod context;
 pub mod cors;
 pub mod env_const;
@@ -18,16 +16,6 @@ pub mod operation_payload;
 pub mod router;
 pub mod test_support;
 pub mod value;
-
-#[derive(Error, Debug)]
-pub enum EnvError {
-    #[error("Invalid env value {env_value} for {env_key}: {message}")]
-    InvalidEnum {
-        env_key: &'static str,
-        env_value: String,
-        message: String,
-    },
-}
 
 #[cfg(feature = "opentelemetry")]
 pub mod logging_tracing;

--- a/crates/core-subsystem/core-router/Cargo.toml
+++ b/crates/core-subsystem/core-router/Cargo.toml
@@ -11,7 +11,7 @@ test-context = []
 [dependencies]
 thiserror.workspace = true
 
-common = { path = "../../common" }
+exo-env = { path = "../../../libs/exo-env" }
 
 core-plugin-shared = { path = "../core-plugin-shared" }
 core-plugin-interface = { path = "../core-plugin-interface" }

--- a/crates/core-subsystem/core-router/src/system_loading_error.rs
+++ b/crates/core-subsystem/core-router/src/system_loading_error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use common::EnvError;
+use exo_env::EnvError;
 
 use core_plugin_interface::interface::{LibraryLoadingError, SubsystemLoadingError};
 use core_plugin_shared::error::ModelSerializationError;

--- a/crates/playground-router/src/graphiql.rs
+++ b/crates/playground-router/src/graphiql.rs
@@ -75,7 +75,9 @@ struct PlaygroundConfig {
 }
 
 fn exo_playground_config(env: &dyn Environment) -> PlaygroundConfig {
-    let enable_schema_live_update = env.enabled(EXO_INTROSPECTION_LIVE_UPDATE, false);
+    let enable_schema_live_update = env
+        .enabled(EXO_INTROSPECTION_LIVE_UPDATE, false)
+        .unwrap_or(false);
     // Normalize the OIDC URL to remove the trailing slash, if any
     let oidc_url = env
         .get("EXO_OIDC_URL")

--- a/crates/system-router/src/system_router.rs
+++ b/crates/system-router/src/system_router.rs
@@ -9,7 +9,7 @@
 
 use std::{fs::File, io::BufReader, path::Path, sync::Arc};
 
-use common::env_const::{EXO_ENABLE_MCP_API, EXO_UNSTABLE_ENABLE_RPC_API};
+use common::env_const::{EXO_ENABLE_MCP, EXO_UNSTABLE_ENABLE_RPC_API};
 use common::introspection::{IntrospectionMode, introspection_mode};
 use common::router::PlainRequestPayload;
 use core_plugin_shared::profile::{SchemaProfile, SchemaProfiles};
@@ -113,7 +113,7 @@ pub async fn create_system_router_from_system(
     }
 
     let graphql_router = {
-        let allow_mutations = env.enabled(EXO_GRAPHQL_ALLOW_MUTATIONS, true);
+        let allow_mutations = env.enabled(EXO_GRAPHQL_ALLOW_MUTATIONS, true)?;
 
         let profile = if allow_mutations {
             SchemaProfile::all()
@@ -315,17 +315,17 @@ async fn create_system_router(
     let mut routers: Vec<Box<dyn for<'a> Router<RequestContext<'a>> + Send + Sync>> =
         vec![Box::new(graphql_router)];
 
-    if env.enabled(EXO_UNSTABLE_ENABLE_REST_API, false) {
+    if env.enabled(EXO_UNSTABLE_ENABLE_REST_API, false)? {
         routers.push(Box::new(rest_router));
     }
 
-    if env.enabled(EXO_UNSTABLE_ENABLE_RPC_API, false) {
+    if env.enabled(EXO_UNSTABLE_ENABLE_RPC_API, false)? {
         routers.push(Box::new(rpc_router));
     }
 
     #[cfg(not(target_family = "wasm"))]
     {
-        if env.enabled(EXO_ENABLE_MCP_API, false) {
+        if env.enabled(EXO_ENABLE_MCP, true)? {
             routers.push(Box::new(mcp_router));
         }
     }

--- a/libs/exo-env/Cargo.toml
+++ b/libs/exo-env/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
+thiserror.workspace = true
 
 [lib]
 doctest = false


### PR DESCRIPTION
Developers can set `EXO_ENABLE_MCP` env to a falsy value to disable it.

Also, clean up the processing of boolean env to expand accepted truthy and falsy values as well as rejecting invalid values (instead of using the default).