### PR TITLE
fix(postgres): provide a clearer log when casting fails

### DIFF
--- a/crates/postgres-subsystem/postgres-core-resolver/src/access/database_solver.rs
+++ b/crates/postgres-subsystem/postgres-core-resolver/src/access/database_solver.rs
@@ -157,7 +157,11 @@ impl<'a> AccessSolver<'a, DatabaseAccessPrimitiveExpression, AbstractPredicateWr
 
                     Ok(AccessSolution::Solved(column_predicate(
                         cast::literal_column_path(&value, &*physical_column.typ, op.needs_unnest())
-                            .map_err(|_| AccessSolverError::Generic("Invalid literal".into()))?,
+                            .map_err(|e| {
+                                AccessSolverError::Generic(
+                                    format!("Failed to cast literal: '{value:?}': {e}").into(),
+                                )
+                            })?,
                         to_column_path(&column),
                     )))
                 }
@@ -172,7 +176,7 @@ impl<'a> AccessSolver<'a, DatabaseAccessPrimitiveExpression, AbstractPredicateWr
                         cast::literal_column_path(&value, &*physical_column.typ, op.needs_unnest())
                             .map_err(|e| {
                                 AccessSolverError::Generic(
-                                    format!("Invalid literal: {:?}", e).into(),
+                                    format!("Failed to cast literal: '{value:?}': {e}").into(),
                                 )
                             })?;
 

--- a/crates/postgres-subsystem/postgres-core-resolver/src/access/precheck_solver.rs
+++ b/crates/postgres-subsystem/postgres-core-resolver/src/access/precheck_solver.rs
@@ -648,8 +648,9 @@ fn compute_relational_sides(
     let path_column_path = to_column_path(tail_path);
 
     let value_column_path =
-        cast::literal_column_path(value, column_type(tail_path, database), false)
-            .map_err(|_| AccessSolverError::Generic("Invalid literal".into()))?;
+        cast::literal_column_path(value, column_type(tail_path, database), false).map_err(|e| {
+            AccessSolverError::Generic(format!("Failed to cast literal: '{value:?}': {e}").into())
+        })?;
 
     Ok((path_column_path, value_column_path))
 }
@@ -662,7 +663,9 @@ fn compute_literal_column_path(
     value
         .map(|v| cast::literal_column_path(v, column_type(associated_column_path, database), false))
         .transpose()
-        .map_err(|_| AccessSolverError::Generic("Invalid literal".into()))
+        .map_err(|e| {
+            AccessSolverError::Generic(format!("Failed to cast literal: '{value:?}': {e}").into())
+        })
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
When a cast fails during context extraction (for example, casting an invalid string to `Uuid`), we logged a message, but it lacked information to clearly indicate the issue.

We now log the value and the error message.