### PR TITLE
feat(import): sort imported elements

### DIFF
--- a/crates/cli/src/commands/schema/import/column_processor.rs
+++ b/crates/cli/src/commands/schema/import/column_processor.rs
@@ -17,7 +17,7 @@ use super::{
 pub struct FieldImport {
     pub name: String,
     pub data_type: String,
-    pub field_type: FieldImportType,
+    pub field_kind: FieldImportKind,
     pub is_unique: bool,
     pub is_nullable: bool,
     pub annotations: Vec<String>,
@@ -25,17 +25,17 @@ pub struct FieldImport {
 }
 
 #[derive(Debug)]
-pub enum FieldImportType {
+pub enum FieldImportKind {
     Scalar { is_pk: bool },
     Reference { is_pk: bool },
     BackReference { is_many: bool },
 }
 
-impl FieldImportType {
+impl FieldImportKind {
     pub fn is_pk(&self) -> bool {
         matches!(
             self,
-            FieldImportType::Scalar { is_pk: true } | FieldImportType::Reference { is_pk: true }
+            FieldImportKind::Scalar { is_pk: true } | FieldImportKind::Reference { is_pk: true }
         )
     }
 }
@@ -72,7 +72,7 @@ impl ModelImporter<TableSpec, FieldImport> for ColumnSpec {
         Ok(FieldImport {
             name: standard_field_name,
             data_type,
-            field_type: FieldImportType::Scalar { is_pk: self.is_pk },
+            field_kind: FieldImportKind::Scalar { is_pk: self.is_pk },
             is_unique: !self.unique_constraints.is_empty(),
             is_nullable: self.is_nullable,
             annotations: all_annotations,
@@ -139,7 +139,7 @@ impl ImportWriter for FieldImport {
         // [@pk] [type-annotations] [name]: [data-type] = [default-value]
 
         // Write annotations
-        if self.field_type.is_pk() {
+        if self.field_kind.is_pk() {
             write!(writer, "@pk ")?;
         }
 

--- a/crates/cli/src/commands/schema/import/enum_processor.rs
+++ b/crates/cli/src/commands/schema/import/enum_processor.rs
@@ -27,7 +27,7 @@ impl ModelImporter<DatabaseSpec, EnumImport> for EnumSpec {
 }
 
 impl ImportWriter for EnumImport {
-    fn write_to(&self, writer: &mut (dyn Write + Send)) -> Result<()> {
+    fn write_to(self, writer: &mut (dyn Write + Send)) -> Result<()> {
         writeln!(writer, "{INDENT}enum {} {{", self.name)?;
 
         for variant in &self.variants {

--- a/crates/cli/src/commands/schema/import/table_processor.rs
+++ b/crates/cli/src/commands/schema/import/table_processor.rs
@@ -2,9 +2,11 @@ use anyhow::Result;
 use exo_sql::schema::{
     column_spec::ColumnSpec, database_spec::DatabaseSpec, table_spec::TableSpec,
 };
+use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
 
+use super::column_processor::FieldImportType;
 use super::{
     ImportContext,
     column_processor::FieldImport,
@@ -75,23 +77,16 @@ impl ModelImporter<DatabaseSpec, TableImport> for TableSpec {
             raw_name.to_string()
         };
 
-        let is_pk = |column_spec: &ColumnSpec| column_spec.is_pk;
-        let is_not_pk = |column_spec: &ColumnSpec| !column_spec.is_pk;
-
         // Categorize columns to determine which should be written as scalars vs consumed by FK references
         let column_categories = self.categorize_columns(context);
 
         let mut fields = Vec::new();
 
-        // First add the primary key fields (scalars first, then FKs)
-        self.add_scalar_fields(&mut fields, context, &column_categories, &is_pk)?;
-        self.add_foreign_key_references(&mut fields, context, parent, &is_pk)?;
+        // Add scalar fields and foreign key references (these columns exist in this table)
+        self.add_scalar_fields(&mut fields, context, &column_categories)?;
+        self.add_foreign_key_references(&mut fields, context, parent)?;
 
-        // Then add the non-primary key fields (scalars first, then FKs)
-        self.add_scalar_fields(&mut fields, context, &column_categories, &is_not_pk)?;
-        self.add_foreign_key_references(&mut fields, context, parent, &is_not_pk)?;
-
-        // Finally add back-references (such as Set<User>, User?, etc.) for which this table is the target
+        // Add back-references (such as Set<User>, User?, etc.) for which this table is the target
         add_back_references(&mut fields, &column_categories)?;
 
         Ok(TableImport {
@@ -105,7 +100,7 @@ impl ModelImporter<DatabaseSpec, TableImport> for TableSpec {
 }
 
 impl ImportWriter for TableImport {
-    fn write_to(&self, writer: &mut (dyn Write + Send)) -> Result<()> {
+    fn write_to(self, writer: &mut (dyn Write + Send)) -> Result<()> {
         // Write access annotation
         if let Some(access) = &self.access_annotation {
             writeln!(
@@ -125,7 +120,72 @@ impl ImportWriter for TableImport {
         writeln!(writer, "{INDENT}{keyword} {} {{", self.name)?;
 
         // Write fields
-        for field in &self.fields {
+        let mut fields = self.fields;
+
+        // Sort fields (within each category, ordered by name):
+        // - PK fields
+        //   - Scalars
+        //   - References
+        // - Non-PK fields
+        //   - Scalars
+        //   - References
+        //   - Back-references
+        //     - One
+        //     - Many
+        fields.sort_by(|a, b| {
+            let a_is_pk = a.field_type.is_pk();
+            let b_is_pk = b.field_type.is_pk();
+
+            match (a_is_pk, b_is_pk) {
+                (true, false) => return Ordering::Less,
+                (false, true) => return Ordering::Greater,
+                (true, true) => return a.name.cmp(&b.name),
+                (false, false) => {}
+            }
+
+            let a_is_scalar = matches!(a.field_type, FieldImportType::Scalar { is_pk: false });
+            let b_is_scalar = matches!(b.field_type, FieldImportType::Scalar { is_pk: false });
+
+            match (a_is_scalar, b_is_scalar) {
+                (true, false) => return Ordering::Less,
+                (false, true) => return Ordering::Greater,
+                (true, true) => return a.name.cmp(&b.name),
+                (false, false) => {}
+            }
+
+            let a_is_one_to_one = matches!(
+                a.field_type,
+                FieldImportType::BackReference { is_many: false }
+            );
+            let b_is_one_to_one = matches!(
+                b.field_type,
+                FieldImportType::BackReference { is_many: false }
+            );
+
+            match (a_is_one_to_one, b_is_one_to_one) {
+                (true, false) => return Ordering::Less,
+                (false, true) => return Ordering::Greater,
+                (true, true) => return a.name.cmp(&b.name),
+                (false, false) => {}
+            }
+
+            let a_is_one_to_many = matches!(
+                a.field_type,
+                FieldImportType::BackReference { is_many: true }
+            );
+            let b_is_one_to_many = matches!(
+                b.field_type,
+                FieldImportType::BackReference { is_many: true }
+            );
+
+            match (a_is_one_to_many, b_is_one_to_many) {
+                (true, false) => Ordering::Less,
+                (false, true) => Ordering::Greater,
+                _ => a.name.cmp(&b.name),
+            }
+        });
+
+        for field in fields {
             field.write_to(writer)?;
         }
 
@@ -146,7 +206,6 @@ trait TableSpecImportNaming {
         fields: &mut Vec<FieldImport>,
         context: &ImportContext,
         column_categories: &ColumnCategories,
-        filter: &dyn Fn(&ColumnSpec) -> bool,
     ) -> Result<()>;
 
     /// Add foreign key reference fields to the field list
@@ -155,7 +214,6 @@ trait TableSpecImportNaming {
         fields: &mut Vec<FieldImport>,
         context: &ImportContext,
         database_spec: &DatabaseSpec,
-        filter: &dyn Fn(&ColumnSpec) -> bool,
     ) -> Result<()>;
 }
 
@@ -287,7 +345,6 @@ impl TableSpecImportNaming for TableSpec {
         fields: &mut Vec<FieldImport>,
         context: &ImportContext,
         column_categories: &ColumnCategories,
-        filter: &dyn Fn(&ColumnSpec) -> bool,
     ) -> Result<()> {
         for column in &self.columns {
             // Add this column as a scalar field if:
@@ -296,7 +353,6 @@ impl TableSpecImportNaming for TableSpec {
             if column_categories
                 .scalar_columns
                 .contains(column.name.as_str())
-                && filter(column)
             {
                 fields.push(column.to_import(self, context)?);
             }
@@ -310,23 +366,17 @@ impl TableSpecImportNaming for TableSpec {
         fields: &mut Vec<FieldImport>,
         context: &ImportContext,
         database_spec: &DatabaseSpec,
-        filter: &dyn Fn(&ColumnSpec) -> bool,
     ) -> Result<()> {
         // Group foreign keys by target table
         let mut fks_by_target: HashMap<String, Vec<_>> = HashMap::new();
 
         for (_, references) in self.foreign_key_references() {
-            let (first_column, first_reference) = match &references[..] {
+            let (_, first_reference) = match &references[..] {
                 [] => {
                     continue;
                 }
                 [reference, ..] => reference,
             };
-
-            // Only process this foreign key if the first column matches the filter
-            if !filter(first_column) {
-                continue;
-            }
 
             let foreign_table_name = &first_reference.foreign_table_name;
             fks_by_target
@@ -414,7 +464,7 @@ impl TableSpecImportNaming for TableSpec {
                 fields.push(FieldImport {
                     name: field_name,
                     data_type,
-                    is_pk,
+                    field_type: FieldImportType::Reference { is_pk },
                     is_unique,
                     is_nullable,
                     annotations,
@@ -566,10 +616,14 @@ fn add_back_references(
             annotations.push(format!("@relation(\"{}\")", rel_name));
         }
 
+        let field_type = FieldImportType::BackReference {
+            is_many: back_ref.is_many,
+        };
+
         fields.push(FieldImport {
             name: back_ref.field_name.clone(),
             data_type,
-            is_pk: false,
+            field_type,
             is_unique: false,
             is_nullable: back_ref.is_nullable,
             annotations,

--- a/crates/cli/src/commands/schema/import/test-data/basic/index.expected.exo
+++ b/crates/cli/src/commands/schema/import/test-data/basic/index.expected.exo
@@ -3,9 +3,9 @@ module Database {
   @access(query=true, mutation=false)
   type Todo {
     @pk id: Int = autoIncrement()
-    title: String
     completed: Boolean
     priority: Int = 0
+    title: String
     user: User
   }
 

--- a/crates/cli/src/commands/schema/import/test-data/columns-with-numbers/index.expected.exo
+++ b/crates/cli/src/commands/schema/import/test-data/columns-with-numbers/index.expected.exo
@@ -3,8 +3,8 @@ module Database {
   @access(query=true, mutation=false)
   type Metric {
     @pk id: Int = autoIncrement()
-    name: String
-    @singlePrecision @column("min_30d_price") min30dPrice: Float
     @singlePrecision max30dPrice: Float
+    @singlePrecision @column("min_30d_price") min30dPrice: Float
+    name: String
   }
 }

--- a/crates/cli/src/commands/schema/import/test-data/composite-fk/index.expected.exo
+++ b/crates/cli/src/commands/schema/import/test-data/composite-fk/index.expected.exo
@@ -2,16 +2,16 @@
 module Database {
   @access(query=true, mutation=false)
   type Event {
-    @pk tenantId: String
     @pk eventId: String
+    @pk tenantId: String
     name: String
     @column(mapping={sourceId: "source_id", tenantId: "tenant_id"}) source: Source
   }
 
   @access(query=true, mutation=false)
   type Source {
-    @pk tenantId: String
     @pk sourceId: String
+    @pk tenantId: String
     name: String?
     events: Set<Event>
   }

--- a/crates/cli/src/commands/schema/import/test-data/composite-pk-custom-columns/index.expected.exo
+++ b/crates/cli/src/commands/schema/import/test-data/composite-pk-custom-columns/index.expected.exo
@@ -2,9 +2,9 @@
 module Database {
   @access(query=true, mutation=false)
   type Address {
-    @pk street: String
     @pk city: String
     @pk state: String
+    @pk street: String
     @pk zip: Int
     info: String?
     people: Set<Person>

--- a/crates/cli/src/commands/schema/import/test-data/composite-pk-custom-columns/index.expected.exo
+++ b/crates/cli/src/commands/schema/import/test-data/composite-pk-custom-columns/index.expected.exo
@@ -2,10 +2,10 @@
 module Database {
   @access(query=true, mutation=false)
   type Address {
+    @pk zip: Int
     @pk city: String
     @pk state: String
     @pk street: String
-    @pk zip: Int
     info: String?
     people: Set<Person>
   }

--- a/crates/cli/src/commands/schema/import/test-data/composite-pk/index.expected.exo
+++ b/crates/cli/src/commands/schema/import/test-data/composite-pk/index.expected.exo
@@ -2,9 +2,9 @@
 module Database {
   @access(query=true, mutation=false)
   type Address {
-    @pk street: String
     @pk city: String
     @pk state: String
+    @pk street: String
     @pk zip: Int
     people: Set<Person>
   }

--- a/crates/cli/src/commands/schema/import/test-data/composite-pk/index.expected.exo
+++ b/crates/cli/src/commands/schema/import/test-data/composite-pk/index.expected.exo
@@ -2,10 +2,10 @@
 module Database {
   @access(query=true, mutation=false)
   type Address {
+    @pk zip: Int
     @pk city: String
     @pk state: String
     @pk street: String
-    @pk zip: Int
     people: Set<Person>
   }
 

--- a/crates/cli/src/commands/schema/import/test-data/custom-seq/index.expected.exo
+++ b/crates/cli/src/commands/schema/import/test-data/custom-seq/index.expected.exo
@@ -3,8 +3,8 @@ module Database {
   @access(query=true, mutation=false)
   type Todo {
     @pk id: Int = autoIncrement("public.my_sequence")
-    title: String
     completed: Boolean
+    title: String
     user: User
   }
 

--- a/crates/cli/src/commands/schema/import/test-data/default-values/index.expected.exo
+++ b/crates/cli/src/commands/schema/import/test-data/default-values/index.expected.exo
@@ -3,18 +3,18 @@ module Database {
   @access(query=true, mutation=false)
   type Issue {
     @pk id: Uuid = generate_uuid()
-    name: String
-    description: String = "No description"
-    @maxLength(50) status: String = "pending"
-    @precision(10) @scale(2) price: Decimal = "10.00"
     createdAt: LocalDateTime = now()
-    updatedAt: LocalDateTime = now()
+    description: String = "No description"
     dueDate: LocalDate = now()
-    isActive: Boolean = true
     fixedDate: LocalDateTime = "2025-01-01T12:00:00"
+    @doublePrecision fixedFloat: Float = 100.00
+    fixedInt: Int = 100
     fixedTime: LocalTime = "12:00:00"
     fixedTimestamp: LocalDateTime = "2025-01-01T12:00:00"
-    fixedInt: Int = 100
-    @doublePrecision fixedFloat: Float = 100.00
+    isActive: Boolean = true
+    name: String
+    @precision(10) @scale(2) price: Decimal = "10.00"
+    @maxLength(50) status: String = "pending"
+    updatedAt: LocalDateTime = now()
   }
 }

--- a/crates/cli/src/commands/schema/import/test-data/default-values/index.expected.exo
+++ b/crates/cli/src/commands/schema/import/test-data/default-values/index.expected.exo
@@ -3,18 +3,18 @@ module Database {
   @access(query=true, mutation=false)
   type Issue {
     @pk id: Uuid = generate_uuid()
-    createdAt: LocalDateTime = now()
-    description: String = "No description"
-    dueDate: LocalDate = now()
-    fixedDate: LocalDateTime = "2025-01-01T12:00:00"
+    isActive: Boolean = true
+    @precision(10) @scale(2) price: Decimal = "10.00"
     @doublePrecision fixedFloat: Float = 100.00
     fixedInt: Int = 100
-    fixedTime: LocalTime = "12:00:00"
+    dueDate: LocalDate = now()
+    createdAt: LocalDateTime = now()
+    fixedDate: LocalDateTime = "2025-01-01T12:00:00"
     fixedTimestamp: LocalDateTime = "2025-01-01T12:00:00"
-    isActive: Boolean = true
-    name: String
-    @precision(10) @scale(2) price: Decimal = "10.00"
-    @maxLength(50) status: String = "pending"
     updatedAt: LocalDateTime = now()
+    fixedTime: LocalTime = "12:00:00"
+    description: String = "No description"
+    name: String
+    @maxLength(50) status: String = "pending"
   }
 }

--- a/crates/cli/src/commands/schema/import/test-data/enum-non-public-schema/index.expected.exo
+++ b/crates/cli/src/commands/schema/import/test-data/enum-non-public-schema/index.expected.exo
@@ -3,11 +3,11 @@ module NonPublicDatabase {
   @access(query=true, mutation=false)
   type Todo {
     @pk id: Int = autoIncrement()
-    title: String
     completed: Boolean
-    priorityWithDefault: Priority = MEDIUM
-    priorityNullable: Priority?
     priority: Priority
+    priorityNullable: Priority?
+    priorityWithDefault: Priority = MEDIUM
+    title: String
   }
 
   enum Priority {

--- a/crates/cli/src/commands/schema/import/test-data/enum-non-public-schema/index.expected.exo
+++ b/crates/cli/src/commands/schema/import/test-data/enum-non-public-schema/index.expected.exo
@@ -5,8 +5,8 @@ module NonPublicDatabase {
     @pk id: Int = autoIncrement()
     completed: Boolean
     priority: Priority
-    priorityNullable: Priority?
     priorityWithDefault: Priority = MEDIUM
+    priorityNullable: Priority?
     title: String
   }
 

--- a/crates/cli/src/commands/schema/import/test-data/enum/index.expected.exo
+++ b/crates/cli/src/commands/schema/import/test-data/enum/index.expected.exo
@@ -5,8 +5,8 @@ module Database {
     @pk id: Int = autoIncrement()
     completed: Boolean
     priority: Priority
-    priorityNullable: Priority?
     priorityWithDefault: Priority = MEDIUM
+    priorityNullable: Priority?
     title: String
   }
 

--- a/crates/cli/src/commands/schema/import/test-data/enum/index.expected.exo
+++ b/crates/cli/src/commands/schema/import/test-data/enum/index.expected.exo
@@ -3,11 +3,11 @@ module Database {
   @access(query=true, mutation=false)
   type Todo {
     @pk id: Int = autoIncrement()
-    title: String
     completed: Boolean
-    priorityWithDefault: Priority = MEDIUM
-    priorityNullable: Priority?
     priority: Priority
+    priorityNullable: Priority?
+    priorityWithDefault: Priority = MEDIUM
+    title: String
   }
 
   enum Priority {

--- a/crates/cli/src/commands/schema/import/test-data/multi-relation-irregular-column-names/index.expected.exo
+++ b/crates/cli/src/commands/schema/import/test-data/multi-relation-irregular-column-names/index.expected.exo
@@ -3,10 +3,10 @@ module Database {
   @access(query=true, mutation=false)
   type Account {
     @pk accountId: Uuid = uuidGenerateV4()
-    name: String
     @precision(15) @scale(2) balance: Decimal = "0"
-    @relation("account") transactions: Set<Transaction>
+    name: String
     @relation("counterpartyAccount") counterpartyTransactions: Set<Transaction>
+    @relation("account") transactions: Set<Transaction>
   }
 
   @access(query=true, mutation=false)

--- a/crates/cli/src/commands/schema/import/test-data/multi-relation-regular-column-names/index.expected.exo
+++ b/crates/cli/src/commands/schema/import/test-data/multi-relation-regular-column-names/index.expected.exo
@@ -3,10 +3,10 @@ module Database {
   @access(query=true, mutation=false)
   type Account {
     @pk id: Uuid = uuidGenerateV4()
-    name: String
     @precision(15) @scale(2) balance: Decimal = "0"
-    @relation("account") transactions: Set<Transaction>
+    name: String
     @relation("counterpartyAccount") counterpartyTransactions: Set<Transaction>
+    @relation("account") transactions: Set<Transaction>
   }
 
   @access(query=true, mutation=false)

--- a/crates/cli/src/commands/schema/import/test-data/non-public-schema/index.expected.exo
+++ b/crates/cli/src/commands/schema/import/test-data/non-public-schema/index.expected.exo
@@ -3,9 +3,9 @@ module TDatabase {
   @access(query=true, mutation=false)
   type Todo {
     @pk id: Int = autoIncrement()
-    title: String
     completed: Boolean
     priority: Int = 0
+    title: String
     user: User
   }
 }

--- a/crates/cli/src/commands/schema/import/test-data/timestamp/index.expected.exo
+++ b/crates/cli/src/commands/schema/import/test-data/timestamp/index.expected.exo
@@ -3,9 +3,9 @@ module Database {
   @access(query=true, mutation=false)
   type Issue {
     @pk id: Int = autoIncrement()
-    @maxLength(200) name: String
-    dueDate: LocalDate = now()
     createdAt: Instant? = now()
+    dueDate: LocalDate = now()
+    @maxLength(200) name: String
     updatedAt: Instant? = now()
   }
 }

--- a/crates/cli/src/commands/schema/import/test-data/timestamp/index.expected.exo
+++ b/crates/cli/src/commands/schema/import/test-data/timestamp/index.expected.exo
@@ -4,8 +4,8 @@ module Database {
   type Issue {
     @pk id: Int = autoIncrement()
     createdAt: Instant? = now()
+    updatedAt: Instant? = now()
     dueDate: LocalDate = now()
     @maxLength(200) name: String
-    updatedAt: Instant? = now()
   }
 }

--- a/crates/cli/src/commands/schema/import/traits.rs
+++ b/crates/cli/src/commands/schema/import/traits.rs
@@ -18,5 +18,5 @@ pub(super) trait ModelImporter<P, O> {
 
 /// A trait for writing import structures to output
 pub(super) trait ImportWriter {
-    fn write_to(&self, writer: &mut (dyn Write + Send)) -> Result<()>;
+    fn write_to(self, writer: &mut (dyn Write + Send)) -> Result<()>;
 }


### PR DESCRIPTION
This produces a stable and predictable imported file.

For tables, sort by name. For fields: first pks, then scalars, then references, and finally back-references. Within each field group sort by name.