### PR TITLE
fix(migration): improve column matching for constraints and indices

### DIFF
--- a/libs/exo-sql/src/schema/index_spec.rs
+++ b/libs/exo-sql/src/schema/index_spec.rs
@@ -90,6 +90,12 @@ impl IndexSpec {
         }
     }
 
+    // Does the other index serve the same purpose as this index?
+    // Effectively, match ignoring the index name
+    pub fn effectively_eq(&self, other: &IndexSpec) -> bool {
+        self.columns == other.columns && self.index_kind == other.index_kind
+    }
+
     pub async fn from_live_db(
         client: &DatabaseClient,
         table_name: &SchemaObjectName,


### PR DESCRIPTION
Match with name or column set associated with a constraint or an index. This removes migration's sensitivity to the names we generate vs names that a database may already have.

Without this change, we drop an index/constraint (with the old name) and create a new one with the same set of columns.