### PR TITLE
breaking: introduce `EXO_ENV` to set the deploy mode

### DIFF
--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use clap::{Arg, ArgMatches, Command};
 use colored::Colorize;
 use common::env_const::{
-    _EXO_DEPLOYMENT_MODE, EXO_CORS_DOMAINS, EXO_INTROSPECTION, EXO_INTROSPECTION_LIVE_UPDATE,
+    EXO_CORS_DOMAINS, EXO_ENV, EXO_INTROSPECTION, EXO_INTROSPECTION_LIVE_UPDATE,
 };
 use exo_env::{MapEnvironment, SystemEnvironment};
 use exo_sql::DatabaseClient;
@@ -80,7 +80,7 @@ impl CommandDefinition for DevCommandDefinition {
         setup_trusted_documents_enforcement(matches, &mut env_vars);
         env_vars.set(EXO_INTROSPECTION, "true");
         env_vars.set(EXO_INTROSPECTION_LIVE_UPDATE, "true");
-        env_vars.set(_EXO_DEPLOYMENT_MODE, "dev");
+        env_vars.set(EXO_ENV, "dev");
         env_vars.set(EXO_CORS_DOMAINS, "*");
 
         const MIGRATE: &str = "Attempt migration";

--- a/crates/cli/src/commands/playground.rs
+++ b/crates/cli/src/commands/playground.rs
@@ -8,8 +8,8 @@ use clap::{Arg, ArgMatches, Command};
 
 use anyhow::Result;
 use common::env_const::{
-    _EXO_DEPLOYMENT_MODE, _EXO_UPSTREAM_ENDPOINT_URL, EXO_CHECK_CONNECTION_ON_STARTUP,
-    EXO_CORS_DOMAINS, EXO_INTROSPECTION, EXO_POSTGRES_URL,
+    _EXO_UPSTREAM_ENDPOINT_URL, EXO_CHECK_CONNECTION_ON_STARTUP, EXO_CORS_DOMAINS, EXO_ENV,
+    EXO_INTROSPECTION, EXO_POSTGRES_URL,
 };
 use exo_env::{MapEnvironment, SystemEnvironment};
 
@@ -58,7 +58,7 @@ impl CommandDefinition for PlaygroundCommandDefinition {
         env_vars.set(EXO_POSTGRES_URL, "postgres://__placeholder");
         env_vars.set(EXO_CHECK_CONNECTION_ON_STARTUP, "false");
         env_vars.set(EXO_CORS_DOMAINS, "*");
-        env_vars.set(_EXO_DEPLOYMENT_MODE, "playground");
+        env_vars.set(EXO_ENV, "playground");
         env_vars.set(_EXO_UPSTREAM_ENDPOINT_URL, &endpoint_url);
 
         let mut server = watcher::build_and_start_server(port, &Config::default(), None, &|| {

--- a/crates/cli/src/commands/templates/Dockerfile.railway.external_db
+++ b/crates/cli/src/commands/templates/Dockerfile.railway.external_db
@@ -26,6 +26,7 @@ COPY --from=builder /app/target/index.exo_ir ./target/index.exo_ir
 
 # The following defers checking for connection to the database until the first request is received.
 ENV EXO_CHECK_CONNECTION_ON_STARTUP=false
+ENV EXO_ENV=production
 ENV EXO_POSTGRES_URL=${DATABASE_URL} 
 
 CMD ["sh", "-c", "EXO_SERVER_PORT=${PORT} exo-server"]

--- a/crates/cli/src/commands/templates/Dockerfile.railway.railway_db
+++ b/crates/cli/src/commands/templates/Dockerfile.railway.railway_db
@@ -24,6 +24,7 @@ COPY --from=builder /app/target/index.exo_ir ./target/index.exo_ir
 
 # Update the following environment variables to match your needs. See the documentation for more information.
 ENV EXO_POSTGRES_URL=${DATABASE_PRIVATE_URL}?sslmode=disable
+ENV EXO_ENV=production
 
 # The following defers checking for connection to the database until the first request is received.
 # This accommodates Railway's delay in setting up private networking (which takes about 100ms after the app is ready).

--- a/crates/cli/src/commands/templates/fly.toml
+++ b/crates/cli/src/commands/templates/fly.toml
@@ -11,6 +11,7 @@ dockerfile = "Dockerfile.fly"
 release_command = "exo schema migrate --use-ir --apply-to-database"
 
 [env]
+EXO_ENV = "production"
 <<<ENV_VARS>>>
 
 [experimental]

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -13,6 +13,7 @@ use super::command::{CommandDefinition, get, get_required};
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use clap::{Arg, ArgMatches, Command};
+use common::env_const::EXO_ENV;
 use exo_sql::testing::db::EXO_SQL_EPHEMERAL_DATABASE_LAUNCH_PREFERENCE;
 
 use crate::config::Config;
@@ -65,6 +66,11 @@ impl CommandDefinition for TestCommandDefinition {
                     std::env::remove_var(key);
                 }
             }
+        }
+
+        // SAFETY: std::env::set_var is unsafe if called from multiple threads. This is a start of the process and still in the main thread.
+        unsafe {
+            std::env::set_var(EXO_ENV, "test");
         }
 
         testing::run(&dir, &pattern, run_introspection_tests)

--- a/crates/cli/src/commands/yolo.rs
+++ b/crates/cli/src/commands/yolo.rs
@@ -13,7 +13,7 @@ use async_trait::async_trait;
 use clap::{ArgMatches, Command};
 use colored::Colorize;
 use common::env_const::{
-    _EXO_DEPLOYMENT_MODE, EXO_CORS_DOMAINS, EXO_INTROSPECTION, EXO_INTROSPECTION_LIVE_UPDATE,
+    EXO_CORS_DOMAINS, EXO_ENV, EXO_INTROSPECTION, EXO_INTROSPECTION_LIVE_UPDATE,
 };
 use exo_env::{MapEnvironment, SystemEnvironment};
 use exo_sql::schema::migration::Migration;
@@ -97,7 +97,7 @@ impl CommandDefinition for YoloCommandDefinition {
         env_vars.set(EXO_POSTGRES_URL, &db.url());
         env_vars.set(EXO_INTROSPECTION, "true");
         env_vars.set(EXO_INTROSPECTION_LIVE_UPDATE, "true");
-        env_vars.set(_EXO_DEPLOYMENT_MODE, "yolo");
+        env_vars.set(EXO_ENV, "yolo");
 
         match &jwt_secret {
             JWTSecret::EnvSecret(s) => env_vars.set(EXO_JWT_SECRET, s),

--- a/crates/server-actix/src/lib.rs
+++ b/crates/server-actix/src/lib.rs
@@ -43,7 +43,9 @@ pub fn configure_router(
     env: Arc<dyn Environment>,
 ) -> impl FnOnce(&mut ServiceConfig) {
     let endpoint_url = match get_deployment_mode(env.as_ref()) {
-        Ok(Some(DeploymentMode::Playground(url))) => Some(Url::parse(&url).unwrap()),
+        Ok(Some(DeploymentMode::Playground(url))) => {
+            Some(Url::parse(&url).expect("Failed to parse upstream endpoint URL"))
+        }
         _ => None,
     };
 

--- a/crates/server-actix/src/lib.rs
+++ b/crates/server-actix/src/lib.rs
@@ -43,7 +43,7 @@ pub fn configure_router(
     env: Arc<dyn Environment>,
 ) -> impl FnOnce(&mut ServiceConfig) {
     let endpoint_url = match get_deployment_mode(env.as_ref()) {
-        Ok(DeploymentMode::Playground(url)) => Some(Url::parse(&url).unwrap()),
+        Ok(Some(DeploymentMode::Playground(url))) => Some(Url::parse(&url).unwrap()),
         _ => None,
     };
 

--- a/crates/server-actix/src/main.rs
+++ b/crates/server-actix/src/main.rs
@@ -86,10 +86,14 @@ async fn main() -> Result<(), ServerError> {
     let deployment_mode = match get_deployment_mode(env.as_ref())? {
         Some(mode) => mode,
         None => {
-            return Err(ServerError::ConfigError(
-                "Cannot determine deployment mode. Must set EXO_ENV to one of 'yolo', 'dev', 'test', 'playground', or 'production'"
-                    .to_string(),
-            ));
+            let env_value = env
+                .as_ref()
+                .get("EXO_ENV")
+                .unwrap_or_else(|| "<unset>".to_string());
+            return Err(ServerError::ConfigError(format!(
+                "Cannot determine deployment mode. Must set EXO_ENV to one of 'yolo', 'dev', 'test', 'playground', or 'production', got: {}",
+                env_value
+            )));
         }
     };
 

--- a/docs/docs/application-tutorial/local-server.md
+++ b/docs/docs/application-tutorial/local-server.md
@@ -72,7 +72,7 @@ Now, you can start the server in production mode.
 
 ```shell-session
 # shell-command-next-line
-exo-server
+EXO_ENV=production exo-server
 ```
 
 Compared to the development mode:

--- a/docs/docs/cli-reference/production/exo-server.md
+++ b/docs/docs/cli-reference/production/exo-server.md
@@ -15,11 +15,11 @@ You build the exo_ir using the `exo build` command. See [`exo build`](/cli-refer
 
 ## Serving the exo_ir
 
-You serve the exo_ir using the `exo-server` command. The command expects `target/index_exo_ir` as the location of the exo_ir file (which is the file created by the `exo build` command).
+You serve the exo_ir using the `exo-server` command. The command expects `target/index_exo_ir` as the location of the exo_ir file (which is the file created by the `exo build` command). The command also requires the `EXO_ENV` environment variable to be set (typically to `production`).
 
 ```shell-session
 # shell-command-next-line
-exo-server
+EXO_ENV=production exo-server
 ```
 
 It will print the information necessary to connect to the server:
@@ -32,11 +32,11 @@ Started server on 0.0.0.0:9876 in 5.47 ms
 
 You can now send GraphQL queries to the endpoint using a GraphQL client such as [Apollo Client](https://www.apollographql.com/docs/react/) or [urql](https://formidable.com/open-source/urql/).
 
+By default, the `exo-server` command will have its introspection and playground disabled. While you can enable it by setting the `EXO_INTROSPECTION` environment variable to `true`, it is not a [good idea to do so in production](/production/introspection.md).
+
 ## Playground
 
-What if you want to use the GraphQL playground with the production deployment with all the goodies, such as autocomplete, schema documentation, query history, and [integrated authentication](/authentication/overview.md)?
-
-By default, the `exo-server` command will have its introspection and playground disabled. While you can enable it by setting the `EXO_INTROSPECTION` environment variable to `true`, it is not a [good idea to do so in production](/production/introspection.md). Instead, you can use the `exo playground` command that fetches the schema from your local model and executes GraphQL operations against the specified endpoint.
+What if you want to use the GraphQL playground with the production deployment with all the goodies, such as autocomplete, schema documentation, query history, and [integrated authentication](/authentication/overview.md)? Exograph provides `exo playground` that fetches the schema from your local model and executes GraphQL operations against the specified endpoint.
 
 ```shell-session
 # shell-command-next-line


### PR DESCRIPTION
Replace the internal `_EXO_DEPLOYMENT_MODE` env with `EXO_ENV` and do no use any fallback (earlier we used `production` as the fallback). This is a breaking change, since now running exo-server in production requires explicit setting of `EXO_ENV`.