### PR TITLE
feat: support .env* files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3744,6 +3744,7 @@ dependencies = [
 name = "exo-env"
 version = "0.22.0"
 dependencies = [
+ "dotenvy",
  "thiserror 2.0.12",
 ]
 
@@ -8395,6 +8396,7 @@ version = "0.22.0"
 dependencies = [
  "actix-web",
  "common",
+ "dotenvy",
  "exo-env",
  "http 1.1.0",
  "reqwest",

--- a/crates/cli/src/commands/templates/exo-new/gitignore
+++ b/crates/cli/src/commands/templates/exo-new/gitignore
@@ -5,3 +5,17 @@ generated/
 node_modules/
 .wrangler/
 .dev.vars
+
+# Env files (unlikely to be added to git)
+.env.yolo.local
+.env.dev.local
+.env.test.local
+.env.production.local
+.env.production
+.env.local
+
+# Env file (might be okay to add to git)
+.env.yolo
+.env.dev
+.env.test
+.env

--- a/crates/server-aws-lambda/src/main.rs
+++ b/crates/server-aws-lambda/src/main.rs
@@ -21,7 +21,8 @@ async fn main() -> Result<(), Error> {
 
     use std::sync::Arc;
 
-    let system_router = Arc::new(server_common::init().await?);
+    let system_router =
+        Arc::new(server_common::init(Arc::new(exo_env::system::SystemEnvironment)).await?);
 
     let module = lambda_runtime::service_fn(|event: LambdaEvent<Value>| async {
         resolve(event, system_router.clone()).await

--- a/crates/server-aws-lambda/src/main.rs
+++ b/crates/server-aws-lambda/src/main.rs
@@ -21,8 +21,7 @@ async fn main() -> Result<(), Error> {
 
     use std::sync::Arc;
 
-    let system_router =
-        Arc::new(server_common::init(Arc::new(exo_env::system::SystemEnvironment)).await?);
+    let system_router = Arc::new(server_common::init(Arc::new(exo_env::SystemEnvironment)).await?);
 
     let module = lambda_runtime::service_fn(|event: LambdaEvent<Value>| async {
         resolve(event, system_router.clone()).await

--- a/crates/server-common/src/lib.rs
+++ b/crates/server-common/src/lib.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use exo_env::Environment;
 use std::{env, process::exit, sync::Arc};
 use thiserror::Error;
 
@@ -14,7 +15,6 @@ use common::logging_tracing::{self, OtelError};
 use core_plugin_interface::interface::SubsystemLoader;
 
 use core_router::SystemLoadingError;
-use exo_env::SystemEnvironment;
 use system_router::{SystemRouter, create_system_router_from_file};
 
 /// Initialize the server by:
@@ -27,17 +27,12 @@ use system_router::{SystemRouter, create_system_router_from_file};
 ///
 /// # Exit codes
 /// - 1 - If the exo_ir file doesn't exist or can't be loaded.
-pub async fn init() -> Result<SystemRouter, ServerInitError> {
+pub async fn init(env: Arc<dyn Environment>) -> Result<SystemRouter, ServerInitError> {
     logging_tracing::init().await?;
 
     let exo_ir_file = get_exo_ir_file_name();
 
-    Ok(create_system_router_from_file(
-        &exo_ir_file,
-        create_static_loaders(),
-        Arc::new(SystemEnvironment),
-    )
-    .await?)
+    Ok(create_system_router_from_file(&exo_ir_file, create_static_loaders(), env).await?)
 }
 
 pub fn create_static_loaders() -> Vec<Box<dyn SubsystemLoader>> {

--- a/docs/docs/managing-env.md
+++ b/docs/docs/managing-env.md
@@ -1,4 +1,8 @@
-# Managing Environment Variables
+---
+sidebar_position: 75
+---
+
+# Managing Environments
 
 Exograph provides flexible environment variable management through `.env` files and environment modes. You can configure different settings for development, testing, and production environments.
 

--- a/docs/docs/managing-env.md
+++ b/docs/docs/managing-env.md
@@ -1,0 +1,73 @@
+# Managing Environment Variables
+
+Exograph provides flexible environment variable management through `.env` files and environment modes. You can configure different settings for development, testing, and production environments.
+
+## Environment Modes
+
+The `EXO_ENV` environment variable controls Exograph's environment mode. Valid values for `EXO_ENV` are:
+
+- `yolo`: Quick exploration with temporary database (`exo yolo` sets this automatically)
+- `dev`: Development mode with persistent database (`exo dev` sets this automatically)
+- `test`: Testing environment (`exo test` sets this automatically)
+- `playground`: Playground mode to connect to an existing GraphQL endpoint (`exo playground` sets this automatically)
+- `production`: Production deployment. **You must set this explicitly when running `exo-server`**.
+
+## Environment File Loading
+
+Exograph loads environment variables from `.env` files based on the environment mode. The loading order follows this precedence (highest to lowest):
+
+1. System environment variables
+2. `.env.{mode}.local` (e.g., `.env.dev.local`)
+3. `.env.local`
+4. `.env.{mode}` (e.g., `.env.dev`)
+5. `.env`
+
+Higher precedence files override variables in lower precedence files. For example, if `.env.dev.local` contains `EXO_INTROSPECTION=true` and `.env.dev` contains `EXO_INTROSPECTION=false`, Exograph will use `EXO_INTROSPECTION=true` from the `.env.dev.local` file.
+
+## Environment File Types
+
+### Local Files (`.local` suffix)
+
+Use these files for local development. Never commit them to version control:
+
+- `.env.yolo.local`
+- `.env.dev.local` 
+- `.env.test.local`
+- `.env.production.local`
+- `.env.local`
+
+Create a `.env.{mode}.local` file for environment variables specific to your local development environment.
+
+```properties
+DATABASE_URL=postgres://localhost/finance-dev
+EXO_JWT_SECRET=your-dev-secret
+```
+
+If you want to share the same environment variables across multiple modes, you can create a `.env.local` file.
+
+### Shared Files
+
+You can commit these files to version control for shared configuration:
+- `.env.yolo`
+- `.env.dev`
+- `.env.test`
+- `.env` (base configuration)
+
+**Note**: Avoid committing `.env.production` as it may contain sensitive production secrets.
+
+New Exograph projects include a `.gitignore` file that excludes all .env files, with comments guiding you on which files are safe to commit.
+
+Your team can share `.env.{mode}` files for environment variables common to all developers.
+
+```properties
+MAIL_HOST=dev.example.com
+MAIL_PORT=587
+MAIL_USERNAME=your-dev-username
+MAIL_PASSWORD=your-dev-password
+```
+
+Create a `.env` file for environment variables common to all modes, similar to `.env.local`.
+
+## Production Secrets
+
+You should never include production secrets in your `.env` files. Instead, use facilities provided by your infrastructure provider. For example, if you're using Fly.io, you can use [Fly.io Secrets](https://fly.io/docs/reference/secrets/) to manage your secrets. See [Deploying Exograph on Fly.io](./deployment/flyio.md#set-the-jwt-secret-or-the-oidc-url) for more details.

--- a/libs/exo-env/Cargo.toml
+++ b/libs/exo-env/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 thiserror.workspace = true
+dotenvy = "0.15"
 
 [lib]
 doctest = false

--- a/libs/exo-env/src/composite.rs
+++ b/libs/exo-env/src/composite.rs
@@ -1,0 +1,28 @@
+// Copyright Exograph, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file at the root of this repository.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::Environment;
+use std::sync::Arc;
+
+pub struct CompositeEnvironment {
+    // Underlying environments in order of precedence (first is highest precedence)
+    envs: Vec<Arc<dyn Environment>>,
+}
+
+impl Environment for CompositeEnvironment {
+    fn get(&self, key: &str) -> Option<String> {
+        self.envs.iter().find_map(|e| e.get(key))
+    }
+}
+
+impl CompositeEnvironment {
+    pub fn new(envs: Vec<Arc<dyn Environment>>) -> Self {
+        Self { envs }
+    }
+}

--- a/libs/exo-env/src/dot.rs
+++ b/libs/exo-env/src/dot.rs
@@ -1,0 +1,48 @@
+// Copyright Exograph, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file at the root of this repository.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::Environment;
+use std::collections::HashMap;
+
+pub struct DotEnvironment {
+    file_path: std::path::PathBuf,
+    vars: std::sync::OnceLock<HashMap<String, String>>,
+}
+
+impl DotEnvironment {
+    pub fn new<P: AsRef<std::path::Path>>(file_path: P) -> Self {
+        Self {
+            file_path: file_path.as_ref().to_path_buf(),
+            vars: std::sync::OnceLock::new(),
+        }
+    }
+
+    fn load_vars(&self) -> &HashMap<String, String> {
+        self.vars.get_or_init(|| {
+            if !self.file_path.exists() {
+                return HashMap::new();
+            }
+
+            let mut vars = HashMap::new();
+            if let Ok(iter) = dotenvy::from_filename_iter(&self.file_path) {
+                for (key, value) in iter.flatten() {
+                    vars.insert(key, value);
+                }
+            }
+            vars
+        })
+    }
+}
+
+impl Environment for DotEnvironment {
+    fn get(&self, key: &str) -> Option<String> {
+        let vars = self.load_vars();
+        vars.get(key).cloned()
+    }
+}

--- a/libs/exo-env/src/lib.rs
+++ b/libs/exo-env/src/lib.rs
@@ -7,8 +7,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
-use std::sync::Arc;
+mod composite;
+mod dot;
+mod map;
+mod system;
+
+pub use composite::CompositeEnvironment;
+pub use dot::DotEnvironment;
+pub use map::MapEnvironment;
+pub use system::SystemEnvironment;
 
 pub trait Environment: Send + Sync {
     fn get(&self, key: &str) -> Option<String>;
@@ -51,73 +58,4 @@ pub enum EnvError {
         env_value: String,
         message: String,
     },
-}
-
-pub struct SystemEnvironment;
-
-impl Environment for SystemEnvironment {
-    fn get(&self, key: &str) -> Option<String> {
-        std::env::var(key).ok()
-    }
-}
-
-#[derive(Clone, Default)]
-pub struct MapEnvironment {
-    values: HashMap<String, String>,
-    fallback: Option<Arc<dyn Environment>>,
-}
-
-impl Environment for MapEnvironment {
-    fn get(&self, key: &str) -> Option<String> {
-        self.values
-            .get(key)
-            .cloned()
-            .or_else(|| self.fallback.as_ref().and_then(|fb| fb.get(key)))
-    }
-}
-
-impl From<HashMap<String, String>> for MapEnvironment {
-    fn from(values: HashMap<String, String>) -> Self {
-        Self {
-            values,
-            fallback: None,
-        }
-    }
-}
-
-impl<const N: usize> From<[(&str, &str); N]> for MapEnvironment {
-    fn from(values: [(&str, &str); N]) -> Self {
-        Self {
-            values: HashMap::from_iter(
-                values
-                    .into_iter()
-                    .map(|(k, v)| (k.to_string(), v.to_string())),
-            ),
-            fallback: None,
-        }
-    }
-}
-
-impl MapEnvironment {
-    pub fn new() -> Self {
-        Self {
-            values: HashMap::new(),
-            fallback: None,
-        }
-    }
-
-    pub fn new_with_fallback(fallback: Arc<dyn Environment>) -> Self {
-        Self {
-            values: HashMap::new(),
-            fallback: Some(fallback),
-        }
-    }
-
-    pub fn set(&mut self, key: &str, value: &str) {
-        self.values.insert(key.to_string(), value.to_string());
-    }
-
-    pub fn vars(&self) -> impl Iterator<Item = (&str, &str)> + '_ {
-        self.values.iter().map(|(k, v)| (k.as_str(), v.as_str()))
-    }
 }

--- a/libs/exo-env/src/map.rs
+++ b/libs/exo-env/src/map.rs
@@ -1,0 +1,73 @@
+// Copyright Exograph, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file at the root of this repository.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::Environment;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[derive(Clone, Default)]
+pub struct MapEnvironment {
+    values: HashMap<String, String>,
+    fallback: Option<Arc<dyn Environment>>,
+}
+
+impl Environment for MapEnvironment {
+    fn get(&self, key: &str) -> Option<String> {
+        self.values
+            .get(key)
+            .cloned()
+            .or_else(|| self.fallback.as_ref().and_then(|fb| fb.get(key)))
+    }
+}
+
+impl From<HashMap<String, String>> for MapEnvironment {
+    fn from(values: HashMap<String, String>) -> Self {
+        Self {
+            values,
+            fallback: None,
+        }
+    }
+}
+
+impl<const N: usize> From<[(&str, &str); N]> for MapEnvironment {
+    fn from(values: [(&str, &str); N]) -> Self {
+        Self {
+            values: HashMap::from_iter(
+                values
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string())),
+            ),
+            fallback: None,
+        }
+    }
+}
+
+impl MapEnvironment {
+    pub fn new() -> Self {
+        Self {
+            values: HashMap::new(),
+            fallback: None,
+        }
+    }
+
+    pub fn new_with_fallback(fallback: Arc<dyn Environment>) -> Self {
+        Self {
+            values: HashMap::new(),
+            fallback: Some(fallback),
+        }
+    }
+
+    pub fn set(&mut self, key: &str, value: &str) {
+        self.values.insert(key.to_string(), value.to_string());
+    }
+
+    pub fn vars(&self) -> impl Iterator<Item = (&str, &str)> + '_ {
+        self.values.iter().map(|(k, v)| (k.as_str(), v.as_str()))
+    }
+}

--- a/libs/exo-env/src/system.rs
+++ b/libs/exo-env/src/system.rs
@@ -1,0 +1,18 @@
+// Copyright Exograph, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file at the root of this repository.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::Environment;
+
+pub struct SystemEnvironment;
+
+impl Environment for SystemEnvironment {
+    fn get(&self, key: &str) -> Option<String> {
+        std::env::var(key).ok()
+    }
+}


### PR DESCRIPTION
So far, we expected developers to set environment variable using an external mechanism (shell script, etc.).

With this change, Exograph loads environment variables from `.env` files based on the environment mode. The loading order follows this precedence (highest to lowest):

1. System environment variables
2. `.env.{mode}.local` (e.g., `.env.dev.local`)
3. `.env.local`
4. `.env.{mode}` (e.g., `.env.dev`)
5. `.env`