### PR TITLE
feat: revamp env file processing

### DIFF
--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -12,11 +12,13 @@ use async_trait::async_trait;
 use builder::RealFileSystem;
 use builder::error::ParserError;
 use clap::{ArgMatches, Command};
+use common::env_processing::EnvProcessing;
 use core_model_builder::plugin::BuildMode;
 use core_plugin_interface::interface::SubsystemBuilder;
 use core_plugin_shared::profile::SchemaProfiles;
 use core_plugin_shared::serializable_system::SerializableSystem;
 use core_plugin_shared::system_serializer::SystemSerializer;
+use exo_env::Environment;
 
 use std::error::Error;
 use std::fmt::Display;
@@ -24,6 +26,7 @@ use std::fs::create_dir_all;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::{fs::File, io::BufWriter};
 
 use crate::commands::command::default_model_file;
@@ -43,8 +46,18 @@ impl CommandDefinition for BuildCommandDefinition {
         Command::new("build").about("Build exograph server binary")
     }
 
+    /// Build command does not process env files.
+    fn env_processing(&self, _env: &dyn Environment) -> EnvProcessing {
+        EnvProcessing::DoNotProcess
+    }
+
     /// Build exograph server binary
-    async fn execute(&self, _matches: &ArgMatches, config: &Config) -> Result<()> {
+    async fn execute(
+        &self,
+        _matches: &ArgMatches,
+        config: &Config,
+        _env: Arc<dyn Environment>,
+    ) -> Result<()> {
         build(true, config).await?;
 
         Ok(())

--- a/crates/cli/src/commands/deploy/aws_lambda.rs
+++ b/crates/cli/src/commands/deploy/aws_lambda.rs
@@ -10,12 +10,14 @@
 use std::{
     fs::{File, create_dir_all},
     path::PathBuf,
+    sync::Arc,
 };
 
 use anyhow::{Ok, Result};
 use async_trait::async_trait;
 use clap::Command;
 use colored::Colorize;
+use exo_env::Environment;
 
 use crate::commands::{build::build, command::CommandDefinition};
 use crate::config::Config;
@@ -43,7 +45,12 @@ impl CommandDefinition for AwsLambdaCommandDefinition {
             .arg(app_name_arg())
     }
 
-    async fn execute(&self, matches: &clap::ArgMatches, config: &Config) -> Result<()> {
+    async fn execute(
+        &self,
+        matches: &clap::ArgMatches,
+        config: &Config,
+        _env: Arc<dyn Environment>,
+    ) -> Result<()> {
         let download_file_name = "exograph-aws-lambda-linux-2023-x86_64.zip";
         let download_url = format!(
             "https://github.com/exograph/exograph/releases/download/v{CURRENT_VERSION}/{download_file_name}"

--- a/crates/cli/src/commands/deploy/cf_worker.rs
+++ b/crates/cli/src/commands/deploy/cf_worker.rs
@@ -2,6 +2,7 @@ use std::{
     collections::HashMap,
     fs::{File, create_dir_all},
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use async_trait::async_trait;
@@ -9,6 +10,7 @@ use async_trait::async_trait;
 use anyhow::Result;
 use clap::Command;
 use colored::Colorize;
+use exo_env::Environment;
 
 use crate::commands::{build::build, command::CommandDefinition};
 use crate::config::Config;
@@ -33,7 +35,12 @@ impl CommandDefinition for CfWorkerCommandDefinition {
             .arg(app_name_arg())
     }
 
-    async fn execute(&self, matches: &clap::ArgMatches, config: &Config) -> Result<()> {
+    async fn execute(
+        &self,
+        matches: &clap::ArgMatches,
+        config: &Config,
+        _env: Arc<dyn Environment>,
+    ) -> Result<()> {
         let app_name: String = app_name_from_args(matches);
 
         build(false, config).await?; // Build the exo_ir file

--- a/crates/cli/src/commands/deploy/fly.rs
+++ b/crates/cli/src/commands/deploy/fly.rs
@@ -12,12 +12,14 @@ use std::{
     fs::File,
     io::{BufRead, Write},
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use clap::{Arg, ArgAction, Command};
 use colored::Colorize;
+use exo_env::Environment;
 
 use crate::commands::{
     build::build,
@@ -65,7 +67,12 @@ impl CommandDefinition for FlyCommandDefinition {
 
     /// Create a fly.toml file, a Dockerfile, and build the docker image. Then provide instructions
     /// on how to deploy the app to Fly.io.
-    async fn execute(&self, matches: &clap::ArgMatches, config: &Config) -> Result<()> {
+    async fn execute(
+        &self,
+        matches: &clap::ArgMatches,
+        config: &Config,
+        _env: Arc<dyn Environment>,
+    ) -> Result<()> {
         let app_name: String = app_name_from_args(matches);
         let envs: Option<Vec<String>> = matches.get_many("env").map(|env| env.cloned().collect());
         let env_file: Option<PathBuf> = get(matches, "env-file");

--- a/crates/cli/src/commands/deploy/railway.rs
+++ b/crates/cli/src/commands/deploy/railway.rs
@@ -8,11 +8,13 @@
 // by the Apache License, Version 2.0.
 
 use std::path::Path;
+use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
 use clap::{Arg, Command};
 use colored::Colorize;
+use exo_env::Environment;
 
 use crate::commands::{command::CommandDefinition, deploy::util::write_template_file};
 use crate::config::Config;
@@ -31,7 +33,12 @@ impl CommandDefinition for RailwayCommandDefinition {
     }
 
     /// Create a Dockerfile. Then provide instructions on how to deploy the app to Railway.app.
-    async fn execute(&self, matches: &clap::ArgMatches, _config: &Config) -> Result<()> {
+    async fn execute(
+        &self,
+        matches: &clap::ArgMatches,
+        _config: &Config,
+        _env: Arc<dyn Environment>,
+    ) -> Result<()> {
         let current_dir = std::env::current_dir()?;
 
         let use_railway_db: bool = match matches.get_one("use-railway-db") {

--- a/crates/cli/src/commands/graphql/schema.rs
+++ b/crates/cli/src/commands/graphql/schema.rs
@@ -10,11 +10,13 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use clap::{Arg, Command, ValueEnum, builder::PossibleValue};
+use exo_env::Environment;
 
 use std::{
     fs::{self, File},
     io::Write,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use crate::commands::{
@@ -46,7 +48,12 @@ impl CommandDefinition for SchemaCommandDefinition {
     }
 
     /// Create a database schema from a exograph model
-    async fn execute(&self, matches: &clap::ArgMatches, _config: &Config) -> Result<()> {
+    async fn execute(
+        &self,
+        matches: &clap::ArgMatches,
+        _config: &Config,
+        _env: Arc<dyn Environment>,
+    ) -> Result<()> {
         let use_ir: bool = matches.get_flag("use-ir");
 
         let model_path: PathBuf = default_model_file();

--- a/crates/cli/src/commands/new.rs
+++ b/crates/cli/src/commands/new.rs
@@ -10,11 +10,13 @@
 use std::fs::{File, create_dir_all};
 use std::io::Write;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use clap::{Arg, ArgMatches, Command};
 use colored::Colorize;
+use exo_env::Environment;
 use exo_sql::TransactionMode;
 
 use super::command::{
@@ -55,7 +57,12 @@ impl CommandDefinition for NewCommandDefinition {
             .arg(mutation_access_arg())
     }
 
-    async fn execute(&self, matches: &ArgMatches, _config: &Config) -> Result<()> {
+    async fn execute(
+        &self,
+        matches: &ArgMatches,
+        _config: &Config,
+        env: Arc<dyn Environment>,
+    ) -> Result<()> {
         let path: PathBuf = get_required(matches, "path")?;
         let from_database: bool = matches.get_flag("from-database");
         let database_url = database_value(matches);
@@ -112,8 +119,12 @@ impl CommandDefinition for NewCommandDefinition {
         if from_database {
             let mut model_file = File::create(src_path.join("index.exo"))?;
 
-            let db_client =
-                open_database(database_url.as_deref(), TransactionMode::ReadOnly).await?;
+            let db_client = open_database(
+                database_url.as_deref(),
+                TransactionMode::ReadOnly,
+                env.as_ref(),
+            )
+            .await?;
             let db_client = db_client.get_client().await?;
 
             let table_names = create_exo_model(

--- a/crates/cli/src/commands/new.rs
+++ b/crates/cli/src/commands/new.rs
@@ -16,6 +16,7 @@ use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use clap::{Arg, ArgMatches, Command};
 use colored::Colorize;
+use common::env_processing::EnvProcessing;
 use exo_env::Environment;
 use exo_sql::TransactionMode;
 
@@ -55,6 +56,10 @@ impl CommandDefinition for NewCommandDefinition {
             .arg(migration_scope_arg())
             .arg(query_access_arg())
             .arg(mutation_access_arg())
+    }
+
+    fn env_processing(&self, _env: &dyn Environment) -> EnvProcessing {
+        EnvProcessing::DoNotProcess
     }
 
     async fn execute(

--- a/crates/cli/src/commands/schema/create.rs
+++ b/crates/cli/src/commands/schema/create.rs
@@ -10,7 +10,9 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use clap::Command;
+use exo_env::Environment;
 use exo_sql::schema::migration::Migration;
+use std::sync::Arc;
 use std::{io::Write, path::PathBuf};
 
 use exo_sql::schema::database_spec::DatabaseSpec;
@@ -41,7 +43,12 @@ impl CommandDefinition for CreateCommandDefinition {
     }
 
     /// Create a database schema from a exograph model
-    async fn execute(&self, matches: &clap::ArgMatches, _config: &Config) -> Result<()> {
+    async fn execute(
+        &self,
+        matches: &clap::ArgMatches,
+        _config: &Config,
+        _env: Arc<dyn Environment>,
+    ) -> Result<()> {
         let use_ir: bool = matches.get_flag("use-ir");
 
         let model: PathBuf = default_model_file();

--- a/crates/cli/src/commands/schema/migrate.rs
+++ b/crates/cli/src/commands/schema/migrate.rs
@@ -7,11 +7,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::Arc;
 use std::{io, path::PathBuf};
 
 use anyhow::anyhow;
 use colored::Colorize;
-use exo_env::SystemEnvironment;
+use exo_env::{Environment, SystemEnvironment};
 use exo_sql::SchemaObjectName;
 use exo_sql::schema::database_spec::DatabaseSpec;
 use exo_sql::schema::migration::{
@@ -80,7 +81,12 @@ impl CommandDefinition for MigrateCommandDefinition {
     }
 
     /// Perform a database migration for a exograph model
-    async fn execute(&self, matches: &clap::ArgMatches, _config: &Config) -> Result<()> {
+    async fn execute(
+        &self,
+        matches: &clap::ArgMatches,
+        _config: &Config,
+        env: Arc<dyn Environment>,
+    ) -> Result<()> {
         let model: PathBuf = default_model_file();
         let database_url = database_value(matches);
         let output: Option<PathBuf> = get(matches, "output");
@@ -114,7 +120,8 @@ impl CommandDefinition for MigrateCommandDefinition {
             }
         };
 
-        let db_client = open_database(database_url.as_deref(), transaction_mode).await?;
+        let db_client =
+            open_database(database_url.as_deref(), transaction_mode, env.as_ref()).await?;
         let mut db_client = db_client.get_client().await?;
 
         let scope = compute_migration_scope(scope);

--- a/crates/cli/src/commands/schema/util.rs
+++ b/crates/cli/src/commands/schema/util.rs
@@ -54,7 +54,7 @@ pub(crate) async fn database_manager_from_env(
         .and_then(|s| s.parse().ok());
     let check_connection = env
         .enabled(EXO_CHECK_CONNECTION_ON_STARTUP, true)
-        .unwrap_or(true);
+        .map_err(|e| DatabaseError::Config(e.to_string()))?;
 
     DatabaseClientManager::from_url(&url, check_connection, pool_size, transaction_mode).await
 }

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -7,13 +7,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 use super::command::{CommandDefinition, get, get_required};
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use clap::{Arg, ArgMatches, Command};
 use common::env_const::EXO_ENV;
+use exo_env::Environment;
 use exo_sql::testing::db::EXO_SQL_EPHEMERAL_DATABASE_LAUNCH_PREFERENCE;
 
 use crate::config::Config;
@@ -43,7 +44,12 @@ impl CommandDefinition for TestCommandDefinition {
             )
     }
 
-    async fn execute(&self, matches: &ArgMatches, _config: &Config) -> Result<()> {
+    async fn execute(
+        &self,
+        matches: &ArgMatches,
+        _config: &Config,
+        _env: Arc<dyn Environment>,
+    ) -> Result<()> {
         let dir: PathBuf = get_required(matches, "dir")?;
         let pattern: Option<String> = get(matches, "pattern"); // glob pattern indicating tests to be executed
 

--- a/crates/cli/src/commands/update.rs
+++ b/crates/cli/src/commands/update.rs
@@ -9,9 +9,12 @@
 
 use async_trait::async_trait;
 use clap::{ArgMatches, Command};
-use std::process::Command as ProcessCommand;
+use exo_env::Environment;
+use std::{process::Command as ProcessCommand, sync::Arc};
 
 use colored::Colorize;
+
+use common::env_processing::EnvProcessing;
 
 use crate::{commands::command::CommandDefinition, config::Config};
 
@@ -23,7 +26,16 @@ impl CommandDefinition for UpdateCommandDefinition {
         Command::new("update").about("Updates the Exograph version")
     }
 
-    async fn execute(&self, _args: &ArgMatches, _config: &Config) -> anyhow::Result<()> {
+    fn env_processing(&self, _env: &dyn Environment) -> EnvProcessing {
+        EnvProcessing::DoNotProcess
+    }
+
+    async fn execute(
+        &self,
+        _args: &ArgMatches,
+        _config: &Config,
+        _env: Arc<dyn Environment>,
+    ) -> anyhow::Result<()> {
         let current_version = env!("CARGO_PKG_VERSION");
         let latest_version = get_latest_version(true).await?;
 
@@ -59,13 +71,8 @@ impl CommandDefinition for UpdateCommandDefinition {
     }
 }
 
-pub(crate) async fn report_update_needed() -> anyhow::Result<()> {
-    let skip_update_check = std::env::var("EXO_SKIP_UPDATE_CHECK")
-        .ok()
-        .unwrap_or("false".to_string())
-        .to_lowercase()
-        .as_str()
-        == "true";
+pub(crate) async fn report_update_needed(env: &dyn Environment) -> anyhow::Result<()> {
+    let skip_update_check = env.enabled("EXO_SKIP_UPDATE_CHECK", false)?;
 
     if skip_update_check {
         return Ok(());

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -9,11 +9,14 @@
 
 use std::{
     env,
-    sync::atomic::{AtomicBool, Ordering},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use anyhow::Result;
-use common::logging_tracing;
+use exo_env::SystemEnvironment;
 use tokio::sync::{
     Mutex,
     broadcast::{Receiver, Sender},
@@ -48,8 +51,6 @@ pub static EXIT_ON_SIGINT: AtomicBool = AtomicBool::new(true);
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    logging_tracing::init().await?;
-
     // register a sigint handler
     ctrlc::set_handler(move || {
         // set SIGINT event when receiving signal
@@ -89,5 +90,7 @@ async fn main() -> Result<()> {
 
     let config = config::load_config()?;
 
-    subcommand_definition.execute(&matches, &config).await
+    subcommand_definition
+        .execute(&matches, &config, Arc::new(SystemEnvironment))
+        .await
 }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [features]
 default = []
 test-context = []
-test-support = ["colored", "wildmatch"]
+test-support = ["wildmatch"]
 opentelemetry = ["opentelemetry_sdk", "opentelemetry-otlp", "tonic"]
 
 [dependencies]
@@ -27,6 +27,7 @@ cookie = "0.18.1"
 elsa = "1.8.1"
 async-graphql-value.workspace = true
 tokio-postgres.workspace = true
+colored.workspace = true
 
 exo-env = { path = "../../libs/exo-env" }
 exo-sql = { path = "../../libs/exo-sql" }
@@ -52,7 +53,6 @@ tonic = { version = "0.12.3", features = ["tls", "tls-roots"], optional = true }
 hyper-util = { version = "0.1.7" }
 tower = { version = "0.5", features = ["util"] }
 
-colored = { workspace = true, optional = true }
 wildmatch = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/common/src/env_processing.rs
+++ b/crates/common/src/env_processing.rs
@@ -1,0 +1,51 @@
+use std::{path::PathBuf, sync::Arc};
+
+use colored::Colorize;
+use exo_env::{CompositeEnvironment, DotEnvironment, Environment, SystemEnvironment};
+
+/// Describe the env processing for a command.
+///
+/// - `Process(Some(env))`: Process env files and use the provided value to pick the env file to use.
+/// - `Process(None)`: Process env-agnostic files (.env and .env.local)
+/// - `DoNotProcess`: Do not process env files at all (for example, with the update/new/build commands)
+pub enum EnvProcessing {
+    Process(Option<String>),
+    DoNotProcess,
+}
+
+impl EnvProcessing {
+    pub fn load_env(&self) -> impl Environment + Send + Sync + 'static {
+        // Files in order of precedence
+        let mut env_files: Vec<PathBuf> = vec![];
+
+        let mut push_env_file = |file: &str| {
+            let file_path = PathBuf::from(file);
+            if file_path.exists() {
+                println!("Loading env file: {}", file.blue());
+                env_files.push(file_path);
+            }
+        };
+
+        if let EnvProcessing::Process(exo_env) = self {
+            if let Some(exo_env) = &exo_env {
+                push_env_file(&format!(".env.{}.local", exo_env));
+            }
+
+            push_env_file(".env.local");
+
+            if let Some(exo_env) = &exo_env {
+                push_env_file(&format!(".env.{}", exo_env));
+            }
+
+            push_env_file(".env");
+        }
+
+        let mut envs: Vec<Arc<dyn Environment>> = vec![Arc::new(SystemEnvironment)];
+
+        for env_file in env_files.iter() {
+            envs.push(Arc::new(DotEnvironment::new(env_file)));
+        }
+
+        CompositeEnvironment::new(envs)
+    }
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod context;
 pub mod cors;
 pub mod env_const;
+pub mod env_processing;
 pub mod http;
 pub mod introspection;
 pub mod operation_payload;

--- a/crates/server-cf-worker/src/init.rs
+++ b/crates/server-cf-worker/src/init.rs
@@ -1,5 +1,6 @@
 use std::{cell::OnceCell, sync::Arc};
 
+use common::env_const::EXO_LOG;
 use exo_env::Environment;
 use system_router::{SystemRouter, create_system_router_from_system};
 use tracing::level_filters::LevelFilter;
@@ -36,7 +37,7 @@ fn setup_tracing(env: &WorkerEnvironment) {
     // Set up simple tracing filter.
     // The proper way would be to call `parse_lossy` on the `EnvFilter` builder, but that adds about
     // 300KB to the wasm binary (and makes the total size exceed the recommended 1MB).
-    let level: LevelFilter = match env.get("EXO_LOG") {
+    let level: LevelFilter = match env.get(EXO_LOG) {
         Some(level) => match level.to_lowercase().as_str() {
             "trace" => LevelFilter::TRACE,
             "debug" => LevelFilter::DEBUG,

--- a/crates/server-common/src/lib.rs
+++ b/crates/server-common/src/lib.rs
@@ -28,7 +28,7 @@ use system_router::{SystemRouter, create_system_router_from_file};
 /// # Exit codes
 /// - 1 - If the exo_ir file doesn't exist or can't be loaded.
 pub async fn init(env: Arc<dyn Environment>) -> Result<SystemRouter, ServerInitError> {
-    logging_tracing::init().await?;
+    logging_tracing::init(env.as_ref()).await?;
 
     let exo_ir_file = get_exo_ir_file_name();
 

--- a/docs/docs/cli-reference/production/exo-server.md
+++ b/docs/docs/cli-reference/production/exo-server.md
@@ -15,7 +15,7 @@ You build the exo_ir using the `exo build` command. See [`exo build`](/cli-refer
 
 ## Serving the exo_ir
 
-You serve the exo_ir using the `exo-server` command. The command expects `target/index_exo_ir` as the location of the exo_ir file (which is the file created by the `exo build` command). The command also requires the `EXO_ENV` environment variable to be set (typically to `production`).
+You serve the exo_ir using the `exo-server` command. The command expects `target/index_exo_ir` as the location of the exo_ir file (which is the file created by the `exo build` command). The command processes [.env* files](/managing-env.md) based on the `EXO_ENV` environment variable to be set (typically to `production`).
 
 ```shell-session
 # shell-command-next-line

--- a/docs/docs/managing-env.md
+++ b/docs/docs/managing-env.md
@@ -37,10 +37,9 @@ DATABASE_URL=postgres://localhost/finance-dev
 EXO_JWT_SECRET=your-dev-secret
 ```
 
-### Shared Files
+### Mode-specific Shared Files
 
-If you want to share the same environment variables across multiple modes, you can create a `.env` or `.env.{mode}` file. You may commit these files to version control for shared configuration. For example, you can create a `.env.dev` file with the following content to use a shared SMTP server for development:
-
+For mode-specific variables you want to share with your team, use a `.env.{mode}` file. You may commit these files to version control. For example, you can create a `.env.dev` file with the following content to use a shared SMTP server during development:
 
 ```properties
 MAIL_HOST=dev.example.com
@@ -50,13 +49,13 @@ MAIL_PASSWORD=your-dev-password
 ```
 
 :::warning
-Avoid committing `.env.production` as it may contain sensitive production secrets. New Exograph projects include a `.gitignore` file that excludes all .env files, with comments guiding you on which files are safe to commit.
+Avoid committing `.env.production` as it may contain sensitive production secrets. Projects created with `exo new` include a `.gitignore` file that excludes all .env files, with comments to guide whichfiles are safe to commit.
 :::
 
-### Mode agnostic files
+### Mode-agnostic Shared File
 
 Create a `.env` file for environment variables common to all modes.
 
 ## Production Secrets
 
-You should never include production secrets in your `.env` files. Instead, use facilities provided by your infrastructure provider. For example, if you're using Fly.io, you can use [Fly.io Secrets](https://fly.io/docs/reference/secrets/) to manage your secrets. See [Deploying Exograph on Fly.io](./deployment/flyio.md#set-the-jwt-secret-or-the-oidc-url) for more details.
+You should never include production secrets in your `.env*` files. Instead, use facilities provided by your infrastructure provider. For example, if you're using Fly.io, you can use [Fly.io Secrets](https://fly.io/docs/reference/secrets/) to manage your secrets. See [Deploying Exograph on Fly.io](./deployment/flyio.md#set-the-jwt-secret-or-the-oidc-url) for more details.

--- a/docs/docs/managing-env.md
+++ b/docs/docs/managing-env.md
@@ -30,7 +30,7 @@ Higher precedence files override variables in lower precedence files. For exampl
 
 ### Local Files (`.local` suffix)
 
-Use these files with specific environment variables for local development. Never commit them to version control. For example, you can create a `.env.dev.local` file with the following content to point to a local database and a JWT secret for development:
+Use `.env.{mode}.local` for mode-specific local variables, and `.env.local` for local variables shared across all modes. Never commit them to version control. For example, you can create a `.env.dev.local` file with the following content to point to a local database and a JWT secret for development:
 
 ```properties
 DATABASE_URL=postgres://localhost/finance-dev

--- a/docs/docs/managing-env.md
+++ b/docs/docs/managing-env.md
@@ -4,17 +4,15 @@ sidebar_position: 75
 
 # Managing Environments
 
-Exograph provides flexible environment variable management through `.env` files and environment modes. You can configure different settings for development, testing, and production environments.
+Exograph provides flexible environment variable management through `.env*` files and environment modes. You can configure different settings for development, testing, and production environments.
 
 ## Environment Modes
 
-The `EXO_ENV` environment variable controls Exograph's environment mode. Valid values for `EXO_ENV` are:
+The `EXO_ENV` environment variable controls loading of `.env*` files. It also controls the [IP address of the server](cli-reference/environment.md#http-paths).
 
-- `yolo`: Quick exploration with temporary database (`exo yolo` sets this automatically)
-- `dev`: Development mode with persistent database (`exo dev` sets this automatically)
-- `test`: Testing environment (`exo test` sets this automatically)
-- `playground`: Playground mode to connect to an existing GraphQL endpoint (`exo playground` sets this automatically)
-- `production`: Production deployment. **You must set this explicitly when running `exo-server`**.
+For `exo yolo`, `exo dev`, `exo test`, and `exo playground`, Exograph automatically sets this variable to the subcommand name. For example, when running `exo yolo`, `EXO_ENV` is set to `yolo`.
+
+You can also set it manually to control the environment mode when running `exo-server` or other `exo` commands such as `exo schema migrate`. For example, when running `EXO_ENV=production exo-server`, Exograph will files with the `production` mode as described [below](#environment-file-loading). Similarly, when running `EXO_ENV=dev exo schema migrate`, Exograph will files with the `dev` mode.
 
 ## Environment File Loading
 
@@ -32,36 +30,17 @@ Higher precedence files override variables in lower precedence files. For exampl
 
 ### Local Files (`.local` suffix)
 
-Use these files for local development. Never commit them to version control:
-
-- `.env.yolo.local`
-- `.env.dev.local` 
-- `.env.test.local`
-- `.env.production.local`
-- `.env.local`
-
-Create a `.env.{mode}.local` file for environment variables specific to your local development environment.
+Use these files with specific environment variables for local development. Never commit them to version control. For example, you can create a `.env.dev.local` file with the following content to point to a local database and a JWT secret for development:
 
 ```properties
 DATABASE_URL=postgres://localhost/finance-dev
 EXO_JWT_SECRET=your-dev-secret
 ```
 
-If you want to share the same environment variables across multiple modes, you can create a `.env.local` file.
-
 ### Shared Files
 
-You can commit these files to version control for shared configuration:
-- `.env.yolo`
-- `.env.dev`
-- `.env.test`
-- `.env` (base configuration)
+If you want to share the same environment variables across multiple modes, you can create a `.env` or `.env.{mode}` file. You may commit these files to version control for shared configuration. For example, you can create a `.env.dev` file with the following content to use a shared SMTP server for development:
 
-**Note**: Avoid committing `.env.production` as it may contain sensitive production secrets.
-
-New Exograph projects include a `.gitignore` file that excludes all .env files, with comments guiding you on which files are safe to commit.
-
-Your team can share `.env.{mode}` files for environment variables common to all developers.
 
 ```properties
 MAIL_HOST=dev.example.com
@@ -70,7 +49,13 @@ MAIL_USERNAME=your-dev-username
 MAIL_PASSWORD=your-dev-password
 ```
 
-Create a `.env` file for environment variables common to all modes, similar to `.env.local`.
+:::warning
+Avoid committing `.env.production` as it may contain sensitive production secrets. New Exograph projects include a `.gitignore` file that excludes all .env files, with comments guiding you on which files are safe to commit.
+:::
+
+### Mode agnostic files
+
+Create a `.env` file for environment variables common to all modes.
 
 ## Production Secrets
 

--- a/docs/docs/production/telemetry.md
+++ b/docs/docs/production/telemetry.md
@@ -17,7 +17,9 @@ Please see the [EnvFilter documentation](https://docs.rs/tracing-subscriber/late
 
 ## OpenTelemetry
 
-OpenTelemetry support is built in to the exograph server and can be enabled simply by setting standard [environment variables](https://opentelemetry.io/docs/concepts/sdk-configuration/otlp-exporter-configuration/). A subset of these are supported, including:
+OpenTelemetry support is built in to the exograph server and can be enabled simply by setting the `EXO_ENABLE_OTEL` environment variable to `true`.
+
+You can also set standard [environment variables](https://opentelemetry.io/docs/concepts/sdk-configuration/otlp-exporter-configuration/) to configure the exporter. A subset of these are supported, including:
 
 - `OTEL_SERVICE_NAME` to set the name of your service.
 - `OTEL_EXPORTER_OTLP_ENDPOINT` to set the endpoint to export trace data to.

--- a/libs/exo-env/src/dot.rs
+++ b/libs/exo-env/src/dot.rs
@@ -25,10 +25,6 @@ impl DotEnvironment {
 
     fn load_vars(&self) -> &HashMap<String, String> {
         self.vars.get_or_init(|| {
-            if !self.file_path.exists() {
-                return HashMap::new();
-            }
-
             let mut vars = HashMap::new();
             if let Ok(iter) = dotenvy::from_filename_iter(&self.file_path) {
                 for (key, value) in iter.flatten() {


### PR DESCRIPTION
This change normalizes and expands env file processing in the following ways:
- Instead of forcing developers to use one of the standard values for `EXO_ENV`, we now allow using any value. For example, it may be set to "cloud-production". As before, we process `.env.{mode}[.local]` files, but in this case `mode` would be "cloud-production"
- Use env file loading for all commands (except where it doesn't make sense: exo new and exo build).
- Load OpenTelemetry envs through .env* files (previously, we loaded them only from system environment). Also introduce `EXO_ENABLE_OTEL` (breaking).