### PR TITLE
fix: use a simpler structure for the app dir in Dockerfiles

### DIFF
--- a/docker/Dockerfile.cli-server.ci
+++ b/docker/Dockerfile.cli-server.ci
@@ -23,14 +23,15 @@ COPY --from=builder /usr/src/exo-server /usr/local/bin/exo-server
 
 ENV TZ=Etc/UTC
 ENV APP_USER=exo
-ENV HOME_DIR=/home/$APP_USER
-ENV APP_DIR=$HOME_DIR/app
 
 ### Create a non-root user to run either the cli or the server
 RUN groupadd $APP_USER \
-  && useradd -g $APP_USER $APP_USER \
-  && mkdir -p ${APP_DIR}
-RUN chown -R $APP_USER:$APP_USER ${HOME_DIR}
+  && useradd --create-home -g $APP_USER $APP_USER
+
 USER $APP_USER
+
+ENV APP_DIR=$HOME/app
+
+RUN mkdir -p ${APP_DIR}
 
 WORKDIR ${APP_DIR}

--- a/docker/Dockerfile.cli-server.ci
+++ b/docker/Dockerfile.cli-server.ci
@@ -32,6 +32,4 @@ USER $APP_USER
 
 ENV APP_DIR=$HOME/app
 
-RUN mkdir -p ${APP_DIR}
-
 WORKDIR ${APP_DIR}

--- a/docker/Dockerfile.cli-server.ci
+++ b/docker/Dockerfile.cli-server.ci
@@ -23,13 +23,14 @@ COPY --from=builder /usr/src/exo-server /usr/local/bin/exo-server
 
 ENV TZ=Etc/UTC
 ENV APP_USER=exo
-ENV APP_DIR=/usr/src/app
+ENV HOME_DIR=/home/$APP_USER
+ENV APP_DIR=$HOME_DIR/app
 
 ### Create a non-root user to run either the cli or the server
 RUN groupadd $APP_USER \
   && useradd -g $APP_USER $APP_USER \
   && mkdir -p ${APP_DIR}
-RUN chown -R $APP_USER:$APP_USER ${APP_DIR}
+RUN chown -R $APP_USER:$APP_USER ${HOME_DIR}
 USER $APP_USER
 
 WORKDIR ${APP_DIR}

--- a/docker/Dockerfile.cli-server.ci
+++ b/docker/Dockerfile.cli-server.ci
@@ -25,8 +25,7 @@ ENV TZ=Etc/UTC
 ENV APP_USER=exo
 
 ### Create a non-root user to run either the cli or the server
-RUN groupadd $APP_USER \
-  && useradd --create-home -g $APP_USER $APP_USER
+RUN useradd --create-home --user-group $APP_USER
 
 USER $APP_USER
 

--- a/docker/Dockerfile.cli.ci
+++ b/docker/Dockerfile.cli.ci
@@ -22,14 +22,15 @@ COPY --from=builder /usr/src/exo /usr/local/bin/exo
 
 ENV TZ=Etc/UTC
 ENV APP_USER=exo
-ENV HOME_DIR=/home/$APP_USER
-ENV APP_DIR=$HOME_DIR/app
 
 ### Create a non-root user to run the cli
 RUN groupadd $APP_USER \
-  && useradd -g $APP_USER $APP_USER \
-  && mkdir -p ${APP_DIR}
-RUN chown -R $APP_USER:$APP_USER ${HOME_DIR}
+  && useradd --create-home -g $APP_USER $APP_USER
+
 USER $APP_USER
+
+ENV APP_DIR=$HOME/app
+
+RUN mkdir -p ${APP_DIR}
 
 WORKDIR ${APP_DIR}

--- a/docker/Dockerfile.cli.ci
+++ b/docker/Dockerfile.cli.ci
@@ -22,13 +22,14 @@ COPY --from=builder /usr/src/exo /usr/local/bin/exo
 
 ENV TZ=Etc/UTC
 ENV APP_USER=exo
-ENV APP_DIR=/usr/src/app
+ENV HOME_DIR=/home/$APP_USER
+ENV APP_DIR=$HOME_DIR/app
 
 ### Create a non-root user to run the cli
 RUN groupadd $APP_USER \
   && useradd -g $APP_USER $APP_USER \
   && mkdir -p ${APP_DIR}
-RUN chown -R $APP_USER:$APP_USER ${APP_DIR}
+RUN chown -R $APP_USER:$APP_USER ${HOME_DIR}
 USER $APP_USER
 
 WORKDIR ${APP_DIR}

--- a/docker/Dockerfile.cli.ci
+++ b/docker/Dockerfile.cli.ci
@@ -24,8 +24,7 @@ ENV TZ=Etc/UTC
 ENV APP_USER=exo
 
 ### Create a non-root user to run the cli
-RUN groupadd $APP_USER \
-  && useradd --create-home -g $APP_USER $APP_USER
+RUN useradd --create-home --user-group $APP_USER
 
 USER $APP_USER
 

--- a/docker/Dockerfile.cli.ci
+++ b/docker/Dockerfile.cli.ci
@@ -31,6 +31,4 @@ USER $APP_USER
 
 ENV APP_DIR=$HOME/app
 
-RUN mkdir -p ${APP_DIR}
-
 WORKDIR ${APP_DIR}

--- a/docker/Dockerfile.server.ci
+++ b/docker/Dockerfile.server.ci
@@ -31,6 +31,4 @@ USER $APP_USER
 
 ENV APP_DIR=$HOME/app
 
-RUN mkdir -p ${APP_DIR}
-
 WORKDIR ${APP_DIR}

--- a/docker/Dockerfile.server.ci
+++ b/docker/Dockerfile.server.ci
@@ -22,13 +22,13 @@ COPY --from=builder /usr/src/exo-server /usr/local/bin/exo-server
 
 ENV TZ=Etc/UTC
 ENV APP_USER=exo
-ENV APP_DIR=/usr/src/app
-
+ENV HOME_DIR=/home/$APP_USER
+ENV APP_DIR=$HOME_DIR/app
 ### Create a non-root user to run the server
 RUN groupadd $APP_USER \
   && useradd -g $APP_USER $APP_USER \
   && mkdir -p ${APP_DIR}
-RUN chown -R $APP_USER:$APP_USER ${APP_DIR}
+RUN chown -R $APP_USER:$APP_USER ${HOME_DIR}
 USER $APP_USER
 
 WORKDIR ${APP_DIR}

--- a/docker/Dockerfile.server.ci
+++ b/docker/Dockerfile.server.ci
@@ -22,13 +22,15 @@ COPY --from=builder /usr/src/exo-server /usr/local/bin/exo-server
 
 ENV TZ=Etc/UTC
 ENV APP_USER=exo
-ENV HOME_DIR=/home/$APP_USER
-ENV APP_DIR=$HOME_DIR/app
+
 ### Create a non-root user to run the server
 RUN groupadd $APP_USER \
-  && useradd -g $APP_USER $APP_USER \
-  && mkdir -p ${APP_DIR}
-RUN chown -R $APP_USER:$APP_USER ${HOME_DIR}
+  && useradd --create-home -g $APP_USER $APP_USER
+
 USER $APP_USER
+
+ENV APP_DIR=$HOME/app
+
+RUN mkdir -p ${APP_DIR}
 
 WORKDIR ${APP_DIR}

--- a/docker/Dockerfile.server.ci
+++ b/docker/Dockerfile.server.ci
@@ -24,8 +24,7 @@ ENV TZ=Etc/UTC
 ENV APP_USER=exo
 
 ### Create a non-root user to run the server
-RUN groupadd $APP_USER \
-  && useradd --create-home -g $APP_USER $APP_USER
+RUN useradd --create-home --user-group $APP_USER
 
 USER $APP_USER
 


### PR DESCRIPTION
We used `/usr/src/app` as the app directory (and set up permissions on it to be readable by the `exo` user). However, during `exo build`, the Deno cache remains in `/home/exo`, which doesn't have permissions set.

Now we use `/home/exo/app` as the app directory and make `exo` own `/home/exo`.