### PR TITLE
refactor: simplify Fly.io deployment template files

### DIFF
--- a/crates/cli/src/commands/templates/Dockerfile.fly
+++ b/crates/cli/src/commands/templates/Dockerfile.fly
@@ -12,12 +12,4 @@ WORKDIR /app
 
 COPY --from=builder /app/target/index.exo_ir ./target/index.exo_ir
 
-# Update the following environment variables to match your needs. See the documentation for more information.
-
-# The following defers checking for connection to the database until the first request is received.
-ENV EXO_CHECK_CONNECTION_ON_STARTUP=false
-
-EXPOSE 8080
-
-CMD ["sh", "-c", "EXO_SERVER_PORT=8080 EXO_POSTGRES_URL=$DATABASE_URL exo-server"]
-
+CMD ["exo-server"]

--- a/crates/cli/src/commands/templates/fly.toml
+++ b/crates/cli/src/commands/templates/fly.toml
@@ -12,6 +12,7 @@ release_command = "exo schema migrate --use-ir --apply-to-database"
 
 [env]
 EXO_ENV = "production"
+EXO_POSTGRES_READ_WRITE = "false" # Change this to "true" to allow write operations with Postgres
 <<<ENV_VARS>>>
 
 [experimental]
@@ -20,7 +21,7 @@ auto_rollback = true
 
 [[services]]
 http_checks = []
-internal_port = 8080
+internal_port = 9876
 processes = ["app"]
 protocol = "tcp"
 script_checks = []


### PR DESCRIPTION
- Remove all env processing from Dockerfile (let fly.toml be the only source)
- Remove the `sh` wrapper for starting `exo-server`.
- Add `EXO_POSTGRES_READ_WRITE` to fly.toml with the default value (developers will likely want to change this)
- Set service's `internal_port` to default `9876` (thus avoiding the need to set `EXO_SERVER_PORT`)