### PR TITLE
ci(pg): use Postgres@17 for MacOS

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -54,7 +54,9 @@ jobs:
         # For these target platforms
         include:
           - os: macos-14
-            deps-script: brew install protobuf postgresql@17 pgvector
+            deps-script: |
+              brew install protobuf postgresql@17 pgvector
+              echo "/opt/homebrew/opt/postgresql@17/bin" >> $GITHUB_PATH
             target: aarch64-apple-darwin
             bin_extension: ""
           - os: ubuntu-22.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,9 @@ jobs:
               sudo apt-get install -y protobuf-compiler postgresql-14-pgvector
             target: x86_64-unknown-linux-gnu
           - os: macos-14
-            deps-script: brew install protobuf postgresql@17 pgvector
+            deps-script: |
+              brew install protobuf postgresql@17 pgvector
+              echo "/opt/homebrew/opt/postgresql@17/bin" >> $GITHUB_PATH
             target: aarch64-apple-darwin
           - os: windows-2022
             deps-script: choco install protoc


### PR DESCRIPTION
brew formula for pgvector no longer supports Postgres@14 (https://github.com/Homebrew/homebrew-core/commit/9de2dd923d297f53b03179be840b3c0bd6a74f82). We test Postgres@14 version for other platforms, anyway. So switch to Postgres@17 for MacOS.