### PR TITLE
fix: accept omitted nullable arguments and variables per GraphQL spec

### DIFF
--- a/crates/core-subsystem/core-resolver/src/validation/arguments_validator.rs
+++ b/crates/core-subsystem/core-resolver/src/validation/arguments_validator.rs
@@ -131,13 +131,9 @@ impl<'a> ArgumentValidator<'a> {
                 Value::Variable(name) => {
                     let resolved_variable = self.variables.get(name);
                     match resolved_variable {
-                        Some(resolved_variable) => self.validate_argument(
-                            argument_definition,
-                            Some(&Positioned::new(
-                                resolved_variable.clone().into_value(),
-                                value.pos,
-                            )),
-                        ),
+                        Some(resolved_variable) => {
+                            self.validate_const(argument_definition, resolved_variable, value.pos)
+                        }
                         // Absent nullable variables are filtered out upstream
                         // and missing non-nullable variables are already
                         // rejected, so treat a miss here as an omitted
@@ -166,17 +162,34 @@ impl<'a> ArgumentValidator<'a> {
                     Some(self.validate_object_argument(argument_definition, object, value.pos))
                 }
             },
-            None => {
-                if argument_definition.ty.node.nullable {
-                    None
-                } else {
-                    Some(Err(ValidationError::RequiredArgumentNotFound(
-                        argument_definition.name.node.to_string(),
-                        self.field.pos,
-                    )))
+            // Per GraphQL spec 6.4.1: if no value is provided, use the
+            // argument's default value (if any); otherwise treat it as absent
+            // (nullable) or reject (non-nullable).
+            None => match &argument_definition.default_value {
+                Some(default_value) => {
+                    self.validate_const(argument_definition, &default_value.node, default_value.pos)
                 }
-            }
+                None if argument_definition.ty.node.nullable => None,
+                None => Some(Err(ValidationError::RequiredArgumentNotFound(
+                    argument_definition.name.node.to_string(),
+                    self.field.pos,
+                ))),
+            },
         }
+    }
+
+    /// Re-enter argument validation with a pre-resolved `ConstValue` (from a
+    /// variable binding or a default value).
+    fn validate_const(
+        &self,
+        argument_definition: &InputValueDefinition,
+        value: &ConstValue,
+        pos: Pos,
+    ) -> Option<Result<Val, ValidationError>> {
+        self.validate_argument(
+            argument_definition,
+            Some(&Positioned::new(value.clone().into_value(), pos)),
+        )
     }
 
     fn validate_null_argument(

--- a/crates/core-subsystem/core-resolver/src/validation/arguments_validator.rs
+++ b/crates/core-subsystem/core-resolver/src/validation/arguments_validator.rs
@@ -138,10 +138,11 @@ impl<'a> ArgumentValidator<'a> {
                                 value.pos,
                             )),
                         ),
-                        None => Some(Err(ValidationError::VariableNotFound(
-                            name.to_string(),
-                            self.field.pos,
-                        ))),
+                        // Absent nullable variables are filtered out upstream
+                        // and missing non-nullable variables are already
+                        // rejected, so treat a miss here as an omitted
+                        // argument (spec 6.4.1).
+                        None => self.validate_argument(argument_definition, None),
                     }
                 }
                 Value::Null => Some(self.validate_null_argument(argument_definition, value.pos)),

--- a/crates/core-subsystem/core-resolver/src/validation/operation_validator.rs
+++ b/crates/core-subsystem/core-resolver/src/validation/operation_validator.rs
@@ -157,25 +157,48 @@ impl<'a> OperationValidator<'a> {
     ) -> Result<HashMap<Name, ConstValue>, ValidationError> {
         variable_definitions
             .into_iter()
-            .map(|variable_definition| {
-                let variable_name = variable_definition.node.name;
-                let variable_value = self.var_value(&variable_name)?;
-                Ok((variable_name.node, variable_value))
+            .filter_map(|vd| {
+                self.var_value(&vd.node)
+                    .map(|value| value.map(|v| (vd.node.name.node, v)))
+                    .transpose()
             })
             .collect()
     }
 
-    fn var_value(&self, name: &Positioned<Name>) -> Result<ConstValue, ValidationError> {
-        let resolved = self
+    /// Resolve a variable to its value.
+    ///
+    /// Per the GraphQL spec (October 2021, section 5.8.5), a nullable variable
+    /// that is not provided is treated as absent rather than as a validation
+    /// error. Returning `Ok(None)` here lets callers (such as the arguments
+    /// validator) apply the same "absent nullable" behavior as for omitted
+    /// arguments.
+    fn var_value(
+        &self,
+        variable_definition: &VariableDefinition,
+    ) -> Result<Option<ConstValue>, ValidationError> {
+        let name = &variable_definition.name;
+        let name_str = name.node.as_str();
+
+        let provided = self
             .variables
             .as_ref()
-            .and_then(|variables| variables.get(name.node.as_str()))
-            .ok_or_else(|| {
-                ValidationError::VariableNotFound(name.node.as_str().to_string(), name.pos)
-            })?;
+            .and_then(|variables| variables.get(name_str));
 
-        ConstValue::from_json(resolved.to_owned()).map_err(|e| {
-            ValidationError::MalformedVariable(name.node.as_str().to_string(), name.pos, e)
-        })
+        match provided {
+            Some(value) => ConstValue::from_json(value.to_owned())
+                .map(Some)
+                .map_err(|e| ValidationError::MalformedVariable(name_str.to_string(), name.pos, e)),
+            None => match (
+                &variable_definition.default_value,
+                variable_definition.var_type.node.nullable,
+            ) {
+                (Some(default_value), _) => Ok(Some(default_value.node.clone())),
+                (None, true) => Ok(None),
+                (None, false) => Err(ValidationError::VariableNotFound(
+                    name_str.to_string(),
+                    name.pos,
+                )),
+            },
+        }
     }
 }

--- a/crates/deno-subsystem/deno-graphql-resolver/src/deno_operation.rs
+++ b/crates/deno-subsystem/deno-graphql-resolver/src/deno_operation.rs
@@ -195,7 +195,15 @@ pub async fn construct_arg_sequence<'a>(
                 // regular argument
                 Ok(Arg::Serde(val.clone()))
             } else {
-                Err(DenoExecutionError::InvalidArgument(arg.name.clone()))
+                // Per GraphQL spec 6.4.1 (Coercing Field Arguments), if a
+                // nullable argument with no provided value and no default is
+                // simply absent from the coerced argument values, it is not
+                // a field error. The argument validator already rejects
+                // missing non-nullable args, so anything missing here is
+                // optional. Since the Deno resolver is invoked with
+                // positional arguments, pass `null` to keep the argument
+                // positions aligned with the function signature.
+                Ok(Arg::Serde(serde_json::Value::Null))
             }
         })
         .collect::<Vec<Result<_, _>>>()

--- a/integration-tests/services/basic/schema-tests/introspection.expected.graphql
+++ b/integration-tests/services/basic/schema-tests/introspection.expected.graphql
@@ -107,6 +107,7 @@ type Query {
   foosAgg(where: FooFilter): FooAgg!
   getEnv(key: String!): String
   greet(name: String): String!
+  greetFormal(title: String, name: String!, suffix: String): String!
   shimQuery: Int!
   todo(id: Int!): Todo!
   todos: Todos!

--- a/integration-tests/services/basic/schema-tests/introspection.expected.graphql
+++ b/integration-tests/services/basic/schema-tests/introspection.expected.graphql
@@ -106,6 +106,7 @@ type Query {
   """
   foosAgg(where: FooFilter): FooAgg!
   getEnv(key: String!): String
+  greet(name: String): String!
   shimQuery: Int!
   todo(id: Int!): Todo!
   todos: Todos!

--- a/integration-tests/services/basic/src/greet.ts
+++ b/integration-tests/services/basic/src/greet.ts
@@ -4,3 +4,15 @@ export function greet(name: string | undefined | null): string {
 	}
 	return `Hello, ${name}!`;
 }
+
+export function greetFormal(
+	title: string | undefined | null,
+	name: string,
+	suffix: string | undefined | null,
+): string {
+	const parts: string[] = [];
+	if (title !== undefined && title !== null) parts.push(title);
+	parts.push(name);
+	if (suffix !== undefined && suffix !== null) parts.push(suffix);
+	return `Hello, ${parts.join(" ")}!`;
+}

--- a/integration-tests/services/basic/src/greet.ts
+++ b/integration-tests/services/basic/src/greet.ts
@@ -1,0 +1,6 @@
+export function greet(name: string | undefined | null): string {
+	if (name === undefined || name === null) {
+		return "Hello, stranger!";
+	}
+	return `Hello, ${name}!`;
+}

--- a/integration-tests/services/basic/src/index.exo
+++ b/integration-tests/services/basic/src/index.exo
@@ -65,4 +65,5 @@ module EnvModule {
 @deno("greet.ts")
 module GreetModule {
     @access(true) query greet(name: String?): String
+    @access(true) query greetFormal(title: String?, name: String, suffix: String?): String
 }

--- a/integration-tests/services/basic/src/index.exo
+++ b/integration-tests/services/basic/src/index.exo
@@ -53,11 +53,16 @@ module TodoModule {
     @access(true) export query todo(id: Int): Todo
     @access(true) export query todos(): Todos
 
-    // An example of using a type from a Postgrs module
+    // An example of using a type from a Postgres module
     @access(true) export mutation publishFoo(): FooDatabase.Foo
 }
 
 @deno("env.ts")
 module EnvModule {
     @access(true) query getEnv(key: String): String?
+}
+
+@deno("greet.ts")
+module GreetModule {
+    @access(true) query greet(name: String?): String
 }

--- a/integration-tests/services/basic/tests/graphql/nullable-args.exotest
+++ b/integration-tests/services/basic/tests/graphql/nullable-args.exotest
@@ -64,3 +64,119 @@ stages:
                 "greet": "Hello, stranger!"
             }
         }
+
+    # Positional alignment: all args provided
+    - operation: |
+        query {
+            greetFormal(title: "Dr.", name: "Alice", suffix: "PhD")
+        }
+      response: |
+        {
+            "data": {
+                "greetFormal": "Hello, Dr. Alice PhD!"
+            }
+        }
+
+    # Positional alignment: leading nullable omitted — `name` must still land in position 2
+    - operation: |
+        query {
+            greetFormal(name: "Alice", suffix: "PhD")
+        }
+      response: |
+        {
+            "data": {
+                "greetFormal": "Hello, Alice PhD!"
+            }
+        }
+
+    # Positional alignment: trailing nullable omitted
+    - operation: |
+        query {
+            greetFormal(title: "Dr.", name: "Alice")
+        }
+      response: |
+        {
+            "data": {
+                "greetFormal": "Hello, Dr. Alice!"
+            }
+        }
+
+    # Positional alignment: both nullables omitted
+    - operation: |
+        query {
+            greetFormal(name: "Alice")
+        }
+      response: |
+        {
+            "data": {
+                "greetFormal": "Hello, Alice!"
+            }
+        }
+
+    # Positional alignment via variables: all args provided
+    - operation: |
+        query ($title: String, $name: String!, $suffix: String) {
+            greetFormal(title: $title, name: $name, suffix: $suffix)
+        }
+      variable: |
+        {
+            "title": "Dr.",
+            "name": "Alice",
+            "suffix": "PhD"
+        }
+      response: |
+        {
+            "data": {
+                "greetFormal": "Hello, Dr. Alice PhD!"
+            }
+        }
+
+    # Positional alignment via variables: leading nullable omitted
+    - operation: |
+        query ($title: String, $name: String!, $suffix: String) {
+            greetFormal(title: $title, name: $name, suffix: $suffix)
+        }
+      variable: |
+        {
+            "name": "Alice",
+            "suffix": "PhD"
+        }
+      response: |
+        {
+            "data": {
+                "greetFormal": "Hello, Alice PhD!"
+            }
+        }
+
+    # Positional alignment via variables: trailing nullable omitted
+    - operation: |
+        query ($title: String, $name: String!, $suffix: String) {
+            greetFormal(title: $title, name: $name, suffix: $suffix)
+        }
+      variable: |
+        {
+            "title": "Dr.",
+            "name": "Alice"
+        }
+      response: |
+        {
+            "data": {
+                "greetFormal": "Hello, Dr. Alice!"
+            }
+        }
+
+    # Positional alignment via variables: both nullables omitted
+    - operation: |
+        query ($title: String, $name: String!, $suffix: String) {
+            greetFormal(title: $title, name: $name, suffix: $suffix)
+        }
+      variable: |
+        {
+            "name": "Alice"
+        }
+      response: |
+        {
+            "data": {
+                "greetFormal": "Hello, Alice!"
+            }
+        }

--- a/integration-tests/services/basic/tests/graphql/nullable-args.exotest
+++ b/integration-tests/services/basic/tests/graphql/nullable-args.exotest
@@ -1,0 +1,66 @@
+stages:
+    # Query: nullable argument provided
+    - operation: |
+        query {
+            greet(name: "Alice")
+        }
+      response: |
+        {
+            "data": {
+                "greet": "Hello, Alice!"
+            }
+        }
+
+    # Query: nullable argument provided via variable
+    - operation: |
+        query ($name: String) {
+            greet(name: $name)
+        }
+      variable: |
+        {
+            "name": "Alice"
+        }
+      response: |
+        {
+            "data": {
+                "greet": "Hello, Alice!"
+            }
+        }
+
+    # Query: nullable argument omitted (per GraphQL spec 6.4.1)
+    - operation: |
+        query {
+            greet
+        }
+      response: |
+        {
+            "data": {
+                "greet": "Hello, stranger!"
+            }
+        }
+
+    # Query: nullable argument explicitly null
+    - operation: |
+        query {
+            greet(name: null)
+        }
+      response: |
+        {
+            "data": {
+                "greet": "Hello, stranger!"
+            }
+        }
+
+    # Query: nullable argument omitted via variable
+    - operation: |
+        query ($name: String) {
+            greet(name: $name)
+        }
+      variable: |
+        {}
+      response: |
+        {
+            "data": {
+                "greet": "Hello, stranger!"
+            }
+        }


### PR DESCRIPTION
Previously, omitting a nullable argument or variable from a Deno modules query/mutation produced an error. Following GraphQL spec 6.4.1 and 5.8.5, we now pass omitted nullable arguments (as `null` for Deno, so positional args stay aligned), and nullable variable that aren't provided fall back to their default value or treated as absent.

Fixes #2100