### PR TITLE
test: restore Deno redirect integration coverage

### DIFF
--- a/integration-tests/services/import-with-redirect/src/sha.ts
+++ b/integration-tests/services/import-with-redirect/src/sha.ts
@@ -1,16 +1,10 @@
-import { sha512 } from 'https://denopkg.com/chiefbiiko/sha512/mod.ts';
-// import { sha512 } from 'https://raw.githubusercontent.com/chiefbiiko/sha512/master/mod.ts';
-
-import { encode as hexify } from "https://deno.land/std@0.192.0/encoding/hex.ts";
+// Importing directly from raw.githubusercontent.com would not test redirect handling.
+import { encode as hexify } from "https://github.com/denoland/std/raw/0.192.0/encoding/hex.ts";
 
 const decode = (d: Uint8Array) => new TextDecoder().decode(d);
 
-export function computeSha512(value: string): string {
-	const sha = sha512(value);
-	if (typeof sha === 'string') {
-		return sha;
-	} else {
-		return decode(hexify(sha));
-	}
+export async function computeSha512(value: string): Promise<string> {
+	const sha = await crypto.subtle.digest("SHA-512", new TextEncoder().encode(value));
+	return decode(hexify(new Uint8Array(sha)));
 }
 


### PR DESCRIPTION
Use redirected Deno imports against a stable, versioned source and unblock the integration test suite.